### PR TITLE
Simplify CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,125 +1,16 @@
 version: 2.1
 
-orbs:
-  gcp-cli: circleci/gcp-cli@3.0.1
-  slack: circleci/slack@4.10.1
-
-commands:
-  gcp-oidc-authenticate:
-    description: "Authenticate with GCP using a CircleCI OIDC token."
-    parameters:
-      project_id:
-        type: env_var_name
-        default: GCP_PROJECT_ID
-      workload_identity_pool_id:
-        type: env_var_name
-        default: GCP_WIP_ID
-      workload_identity_pool_provider_id:
-        type: env_var_name
-        default: GCP_WIP_PROVIDER_ID
-      service_account_email:
-        type: env_var_name
-        default: GCP_SERVICE_ACCOUNT_EMAIL
-      gcp_cred_config_file_path:
-        type: string
-        default: /home/circleci/gcp_cred_config.json
-      oidc_token_file_path:
-        type: string
-        default: /home/circleci/oidc_token.json
-    steps:
-      - run:
-          name: "Create OIDC credential configuration"
-          command: |
-            # Store OIDC token in temp file
-            echo $CIRCLE_OIDC_TOKEN > << parameters.oidc_token_file_path >>
-            # Create a credential configuration for the generated OIDC ID Token
-            gcloud iam workload-identity-pools create-cred-config \
-                "projects/${<< parameters.project_id >>}/locations/global/workloadIdentityPools/${<< parameters.workload_identity_pool_id >>}/providers/${<< parameters.workload_identity_pool_provider_id >>}"\
-                --output-file="<< parameters.gcp_cred_config_file_path >>" \
-                --service-account="${<< parameters.service_account_email >>}" \
-                --credential-source-file=<< parameters.oidc_token_file_path >>
-      - run:
-          name: "Authenticate with GCP using OIDC"
-          command: |
-            # Configure gcloud to leverage the generated credential configuration
-            gcloud auth login --brief --cred-file "<< parameters.gcp_cred_config_file_path >>"
-            # Configure ADC
-            echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a "$BASH_ENV"
-
 jobs:
-  docker-release:
-    environment:
-      DOCKER_BUILDKIT: 1
-    parameters:
-      docker_name:
-        description: Docker image name
-        type: string
-        default: "op-geth"
-      docker_tags:
-        description: Docker image tags as csv
-        type: string
-      registry:
-        description: Docker registry
-        type: string
-        default: "us-docker.pkg.dev"
-      repo:
-        description: Docker repo
-        type: string
-        default: "oplabs-tools-artifacts/images"
-      push_tags:
-        description: Push release push tags
-        type: boolean
-        default: false
-    machine:
-      image: ubuntu-2204:2022.07.1
-      resource_class: xlarge
-    steps:
-      - gcp-cli/install
-      - gcp-oidc-authenticate
-      - checkout
-      - run:
-          name: Configure Docker
-          command: |
-            gcloud auth configure-docker <<parameters.registry>>
-      - run:
-          name: Build and push
-          command: |
-            RAW_TAGS="<<parameters.docker_tags>>"
-            if [ "$CIRCLE_BRANCH" = "optimism" ]; then
-              RAW_TAGS="$RAW_TAGS,optimism"
-            fi
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_TAGS=$(echo -ne "$RAW_TAGS" | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n.]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
-            docker context create buildx-build
-            docker buildx create --use buildx-build
-            docker buildx build --push \
-              $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
-              --platform=linux/arm64,linux/amd64 \
-              --build-arg VERSION=$CIRCLE_TAG \
-              --build-arg COMMIT=$CIRCLE_SHA \
-              --build-arg BUILDNUM=$CIRCLE_BUILD_NUM \
-              --progress plain \
-              -f Dockerfile .
-      - when:
-          condition:
-            equal: [ true, <<parameters.push_tags>> ]
-          steps:
-            - run:
-                name: Tag
-                command: |
-                  ./.circleci/ci-docker-tag-op-geth-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
-
-
   build-geth:
     docker:
       - image: cimg/go:1.19
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - run:
           command: go run build/ci.go install
   unit-test:
-    resource_class: xlarge
+    resource_class: large
     docker:
       - image: cimg/go:1.19
     steps:
@@ -134,18 +25,6 @@ jobs:
       - checkout
       - run:
           command: go run build/ci.go lint
-  check-releases:
-    docker:
-      - image: cimg/go:1.19
-    steps:
-      - checkout
-      - run:
-          command: .circleci/check-releases.sh
-      - slack/notify:
-          channel: C03N11M0BBN
-          branch_pattern: optimism
-          event: fail
-          template: basic_fail_1
 
 
 workflows:
@@ -157,42 +36,3 @@ workflows:
           name: Run unit tests for geth
       - lint-geth:
           name: Run linter over geth
-      - docker-release:
-          name: Push to Docker
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr
-  release:
-    jobs:
-      - hold:
-          type: approval
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - docker-release:
-          name: Push to Docker (release)
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
-          push_tags: true
-          context:
-            - oplabs-gcr-release
-          requires:
-            - hold
-  scheduled:
-    triggers:
-      - schedule:
-          # run daily
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only: [ "optimism" ]
-    jobs:
-      - check-releases:
-          name: Check for new upstream releases
-          context: slack


### PR DESCRIPTION
Remove all unwanted bits from the CI config.

This only keeps build, linting and running the tests.

Ref: https://github.com/celo-org/op-geth/issues/2