### PR TITLE
Add forkdiff comparison to op-geth

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,6 +4,7 @@ permissions:
 on:
   push:
     branches:
+      - eelanagaraj/add-forkdiff # TODO remove
       - optimism
 jobs:
   deploy:
@@ -25,9 +26,6 @@ jobs:
           mkdir -p tmp/pages
           mv index.html tmp/pages/index.html
           touch tmp/pages/.nojekyll
-          if [ "$GITHUB_REPOSITORY" == "ethereum-optimism/op-geth" ]; then
-              echo "op-geth.optimism.io" > tmp/pages/CNAME
-          fi;
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,7 +4,7 @@ permissions:
 on:
   push:
     branches:
-      - optimism
+      - celo[0-9]+
 jobs:
   deploy:
     concurrency: ci-${{ github.ref }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,7 +4,6 @@ permissions:
 on:
   push:
     branches:
-      - eelanagaraj/add-forkdiff # TODO remove
       - optimism
 jobs:
   deploy:

--- a/fork.yaml
+++ b/fork.yaml
@@ -5,7 +5,7 @@ footer: |
 base:
   name: OP
   url: https://github.com/ethereum-optimism/op-geth
-  hash: 8f8af46ec728a79137d449891fc1827e1763cd7e # tracks the last rebased commit
+  hash: 628d30034201ea3ec4585f3c6c22fda581541549 # tracks the last rebased commit
 fork:
   name: CELO
   url: https://github.com/celo-org/op-geth

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,198 +1,39 @@
-title: "op-geth - go-ethereum fork diff overview"
+title: "CELO <> OP op-geth forkdiff"
 footer: |
-  Fork-diff overview of [`op-geth`](https://github.com/ethereum-optimism/op-geth), a fork of [`go-ethereum`](https://github.com/ethereum/go-ethereum).
-  and execution-engine of the [OP-stack](https://github.com/ethereum-optimism/optimism).
+  Fork-diff overview of changes made in [Celo's `op-geth`](https://github.com/celo-org/op-geth),
+  a fork of [Optimism's `op-geth`](https://github.com/ethereum-optimism/op-geth).
 base:
-  name: go-ethereum
-  url: https://github.com/ethereum/go-ethereum
-  hash: e501b3b05db8e169f67dc78b7b59bc352b3c638d
-fork:
-  name: op-geth
+  name: OP
   url: https://github.com/ethereum-optimism/op-geth
-  ref: refs/heads/optimism
+  hash: 8f8af46ec728a79137d449891fc1827e1763cd7e # tracks the last rebased commit
+fork:
+  name: CELO
+  url: https://github.com/celo-org/op-geth
+  ref: HEAD
 def:
-  title: "op-geth"
+  title: "Celo's op-geth"
   description: |
-    This is an overview of the changes in [`op-geth`](https://github.com/ethereum-optimism/op-geth),
-    a fork of [`go-ethereum`](https://github.com/ethereum/go-ethereum), part of the OP-stack.
+    This is an overview of the changes in [Celo's `op-geth` implementation](https://github.com/celo-org/op-geth),
+    a fork of [Optimism's `op-geth`](https://github.com/ethereum-optimism/op-geth).
 
-    The OP-stack architecture is modular, following the Consensus/Execution split of post-Merge Ethereum L1:
+    For differences between the base `op-geth` and `go-ethereum`, check out Optimism's
+    [fork-diff overview of changes](https://op-geth.optimism.io/).
 
-      - [`op-node`](https://github.com/ethereum-optimism/optimism/tree/develop/op-node) implements most rollup-specific functionality as Consensus-Layer, similar to a L1 beacon-node. 
-      - [`op-geth`](https://github.com/ethereum-optimism/op-geth) implements the Execution-Layer, with **minimal changes** for a secure Ethereum-equivalent application environment.
-
-    Related [op-stack specifications](https://github.com/ethereum-optimism/optimism/tree/develop/specs):
-
-    - [L2 Execution Engine spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md)
-    - [Deposit Transaction spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md)
   sub:
-    - title: "Core modifications"
+    - title: "Celo-specific features"
       sub:
-        - title: "State-transition modifications"
-          description: ""
-          sub:
-            - title: "Deposit Transaction type"
-              description: |
-                The Bedrock upgrade introduces a `Deposit` transaction-type (`0x7E`) to enable both users and the
-                rollup system itself to change the L2 state based on L1 events and system rules as
-                [specified](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md).
-              globs:
-                - "core/types/deposit_tx.go"
-                - "core/types/transaction_marshalling.go"
-                - "core/types/transaction_signing.go"
-            - title: "Transaction properties"
-              description: |
-                The `Transaction` type now exposes the deposit-transaction and L1-cost properties required for the rollup.
-              globs:
-                - "core/types/transaction.go"
-                - "core/types/tx_access_list.go"
-                - "core/types/tx_dynamic_fee.go"
-                - "core/types/tx_legacy.go"
-            - title: "L1 cost computation"
-              description: |
-                Transactions must pay an additional L1 cost based on the amount of rollup-data-gas they consume,
-                estimated based on gas-price-oracle information and encoded tx size."
-              globs:
-                - "core/vm/evm.go"
-                - "core/types/rollup_l1_cost.go"
-                - "core/state_processor.go"
-                - "core/state_prefetcher.go"
-            - title: Transaction processing
-              description: |
-                Deposit transactions have special processing rules: gas is pre-paid on L1,
-                and deposits with EVM-failure are included with rolled back changes (except mint).
-                For regular transactions, at the end of the transition, the 1559 burn and L1 cost are routed to vaults.
-              globs:
-                - "core/state_transition.go"
-            - title: "Gaslimit"
-              description: |
-                The gaslimit is free to be set by the Engine API caller, instead of enforcing adjustments of the
-                gaslimit in increments of 1/1024 of the previous gaslimit.
-                The gaslimit is changed (and limited) through the `SystemConfig` contract.
-              globs:
-                - "consensus/misc/eip1559.go"
-            - title: "Consensus tweaks"
-              description: |
-                The Engine API is activated at the Merge transition, with a Total Terminal Difficulty (TTD).
-                The rollup starts post-merge, and thus sets the TTD to 0.
-              globs:
-                - "consensus/beacon/consensus.go"
+        - title: "Celo token duality"
+          description: "The Celo token is both the native token and ERC-20 compatible."
+          globs:
+            - "common/celo-types/*"
+            # TODO: this should be updated to reflect the changes in the token duality implementation
+            # TODO EN: ticket for this or comment on Karl's ticket
         - title: "Chain config"
-          description: |
-            The rollup functionality is enabled with the `optimism` field in the chain config.
-            The EIP-1559 parameters are configurable to adjust for faster more frequent and smaller blocks.
-            The parameters can be overriden for testing.
+          description: ""
           globs:
             - "params/config.go"
             - "params/protocol_params.go"
             - "core/genesis.go"
-        - title: "Chain config cleanup"
-          description: |
-            The optimism Goerli testnet used clique-config data to make geth internals accept blocks.
-            Post-bedrock the beacon-consensus (i.e. follow Engine API) is now used, and the clique config is removed.
-          globs:
-            - "core/rawdb/accessors_metadata.go"
-        - title: "Engine API modifications"
-          description: |
-            The Engine API is extended to insert transactions into the block and optionally exclude the tx-pool,
-            to reproduce the exact block of the sequencer from just the inputs, as derived from L1 by the rollup-node.
-            See [L2 execution engine specs](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md).
-          globs:
-            - "beacon/engine/types.go"
-            - "beacon/engine/gen_blockparams.go"
-            - "eth/catalyst/api.go"
-        - title: "Block-building modifications"
-          description: |
-            The block-building code (in the "miner" package because of Proof-Of-Work legacy of ethereum) implements the
-            changes to support the transaction-inclusion, tx-pool toggle and gaslimit parameters of the Engine API.
-          globs:
-            - "miner/*"
-        - title: "Tx-pool tx cost updates"
-          description: |
-            Transaction queueing and inclusion needs to account for the L1 cost component.
-          globs:
-            - "core/txpool/*"
-    - title: "Node modifications"
-      description: Changes to the node configuration and services.
-      sub:
-        - title: "CLI"
-          sub:
-            - title: "Flags"
-              description: |
-                Flag changes:
-                  - Transactions can be forwarded to an RPC for sequencing.
-                  - Historical calls can be forwarded to a legacy node.
-                  - The tx pool propagation can be enabled/disabled.
-                  - The Optimism bedrock fork activation can be changed for testing.
-              globs:
-                - "cmd/utils/flags.go"
-                - "cmd/geth/main.go"
-                - "internal/flags/categories.go"
-                - "cmd/geth/config.go"
-            - title: "Versioning"
-              description: List the op-geth and upstream go-ethereum versions.
-              globs:
-                - "cmd/geth/misccmd.go"
-                - "params/version.go"
-                - "build/ci.go"
-        - title: Node config
-          globs:
-            - "eth/ethconfig/config.go"
-        - title: Tx gossip disable option
-          globs:
-            - "eth/handler.go"
-            - "eth/handler_eth.go"
-    - title: "User API enhancements"
-      description: "Encode the Deposit Tx properties, the L1 costs, and daisy-chain RPC-calls for pre-Bedrock historical data"
-      sub:
-        - title: "Receipts metadata"
-          description: |
-            Pre-Bedrock L1-cost receipt data is loaded from the database if available, and post-Bedrock the L1-cost 
-            metadata is hydrated on-the-fly based on the L1 fee information in the corresponding block.
-          globs:
-            - "core/types/receipt.go"
-            - "core/types/gen_receipt_json.go"
-        - title: "API Backend"
-          description: |
-            Forward transactions to the sequencer if configured.
-          globs:
-            - "eth/api_backend.go"
-            - "eth/backend.go"
-            - "internal/ethapi/backend.go"
-        - title: "Apply L1 cost in API responses"
-          globs:
-            - "eth/state_accessor.go"
-        - title: API frontend
-          description: Format deposit and L1-cost data in transaction responses. Add `debug_chainConfig` API.
-          globs:
-            - "internal/ethapi/api.go"
-            - "rpc/errors.go"
-        - title: Tracer RPC daisy-chain
-          description: Forward pre-bedrock tracing calls to legacy node.
-          globs:
-            - "eth/tracers/api.go"
-        - title: "Light Ethereum Subprotocol (LES) RPC"
-          description: Match the RPC changes in the LES RPC
-          globs:
-            - "les/*"
-        - title: "Daisy Chain tests"
-          globs:
-            - "internal/ethapi/transaction_args_test.go"
-            - "ethclient/ethclient_test.go"
-            - "eth/tracers/api_test.go"
-    - title: "Geth extras"
-      description: Extend the tools available in geth to improve external testing and tooling.
-      sub:
-        - title: Simulated Backend
-          globs:
-            - "accounts/abi/bind/backends/simulated.go"
-        - title: diff-included testing testing
-          description: |
-            Most of the op-geth changes are tested in the Optimism Monorepo and not part of the geth diff,
-            but some testing like the Deposit TX encoding and API interactions are embedded in the op-geth diff instead.
-          globs:
-            - "core/types/transaction_marshalling_test.go"
-            - "internal/ethapi/api_test.go"
 
 # ignored globally, does not count towards line count
 ignore:

--- a/fork.yaml
+++ b/fork.yaml
@@ -26,8 +26,6 @@ def:
           description: "The Celo token is both the native token and ERC-20 compatible."
           globs:
             - "common/celo-types/*"
-            # TODO: this should be updated to reflect the changes in the token duality implementation
-            # TODO EN: ticket for this or comment on Karl's ticket
         - title: "Chain config"
           description: ""
           globs:


### PR DESCRIPTION
# Description
Add forkdiff comparison between celo's & OP's `op-geth` repos. The structure has been left intentionally very simple for now. Ideally, as new Celo features are added, we can also update the forkdiff output to properly visualize these new features.

Take a look at the deployed version: https://celo-org.github.io/op-geth/

Note: this currently points to a slightly older OP commit than we have merged in order to sanity check the diffs, but this will be updated.

Other than the code changes, as part of this PR, the GH pages build (from `gh-pages` branch) & workflows have been activated

# TODOs (after review, any structure changes)
- [x] update hash to point to the latest OP commit hash in our history
- [x] remove trigger for pushes to `eelanagaraj/add-forkdiff`
- [x] add comment to token duality ticket & remove TODOs

# Related issues
#6 