### PR TITLE
Fix S1007: should use raw string in params

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -43,7 +43,7 @@ var gitTag string
 
 // Override the version variables if the gitTag was set at build time.
 var _ = func() (_ string) {
-	semver := regexp.MustCompile("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$")
+	semver := regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$`)
 	version := semver.FindStringSubmatch(gitTag)
 	if version == nil {
 		return


### PR DESCRIPTION
Backport e081fac1450c7eab6cff7c5c30a900a743cc470e from upstream to avoid [CI failure](https://app.circleci.com/pipelines/github/celo-org/op-geth/54/workflows/af634d7a-b404-4f0e-94ac-8117598265ce/jobs/113)
```
params/version.go:46:12: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
```

This commit should vanish after the next rebase to upstream, but I wanted to get CI green now.