### PR TITLE
Add celo transaction type

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -214,7 +214,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 	switch tx.Type() {
 	case types.LegacyTxType, types.AccessListTxType:
 		args.GasPrice = (*hexutil.Big)(tx.GasPrice())
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	default:

--- a/core/types/celo_dynamic_fee_tx.go
+++ b/core/types/celo_dynamic_fee_tx.go
@@ -1,0 +1,109 @@
+// TODO: needs copyright header?
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type CeloDynamicFeeTx struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *big.Int
+	GasFeeCap  *big.Int
+	Gas        uint64
+	To         *common.Address `rlp:"nil"` // nil means contract creation
+	Value      *big.Int
+	Data       []byte
+	AccessList AccessList
+
+	FeeCurrency *common.Address `rlp:"nil"` // nil means native currency
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *CeloDynamicFeeTx) copy() TxData {
+	cpy := &CeloDynamicFeeTx{
+		Nonce:       tx.Nonce,
+		To:          copyAddressPtr(tx.To),
+		Data:        common.CopyBytes(tx.Data),
+		Gas:         tx.Gas,
+		FeeCurrency: copyAddressPtr(tx.FeeCurrency),
+		// These are copied below.
+		AccessList: make(AccessList, len(tx.AccessList)),
+		Value:      new(big.Int),
+		ChainID:    new(big.Int),
+		GasTipCap:  new(big.Int),
+		GasFeeCap:  new(big.Int),
+		V:          new(big.Int),
+		R:          new(big.Int),
+		S:          new(big.Int),
+	}
+	copy(cpy.AccessList, tx.AccessList)
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.GasTipCap != nil {
+		cpy.GasTipCap.Set(tx.GasTipCap)
+	}
+	if tx.GasFeeCap != nil {
+		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *CeloDynamicFeeTx) txType() byte              { return CeloDynamicFeeTxType }
+func (tx *CeloDynamicFeeTx) chainID() *big.Int         { return tx.ChainID }
+func (tx *CeloDynamicFeeTx) accessList() AccessList    { return tx.AccessList }
+func (tx *CeloDynamicFeeTx) data() []byte              { return tx.Data }
+func (tx *CeloDynamicFeeTx) gas() uint64               { return tx.Gas }
+func (tx *CeloDynamicFeeTx) gasFeeCap() *big.Int       { return tx.GasFeeCap }
+func (tx *CeloDynamicFeeTx) gasTipCap() *big.Int       { return tx.GasTipCap }
+func (tx *CeloDynamicFeeTx) gasPrice() *big.Int        { return tx.GasFeeCap }
+func (tx *CeloDynamicFeeTx) value() *big.Int           { return tx.Value }
+func (tx *CeloDynamicFeeTx) nonce() uint64             { return tx.Nonce }
+func (tx *CeloDynamicFeeTx) to() *common.Address       { return tx.To }
+func (tx *CeloDynamicFeeTx) blobGas() uint64           { return 0 }
+func (tx *CeloDynamicFeeTx) blobGasFeeCap() *big.Int   { return nil }
+func (tx *CeloDynamicFeeTx) blobHashes() []common.Hash { return nil }
+func (tx *CeloDynamicFeeTx) isSystemTx() bool          { return false }
+
+func (tx *CeloDynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.GasFeeCap)
+	}
+	tip := dst.Sub(tx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.GasTipCap) > 0 {
+		tip.Set(tx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
+func (tx *CeloDynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
+	return tx.V, tx.R, tx.S
+}
+
+func (tx *CeloDynamicFeeTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}
+
+func (tx *CeloDynamicFeeTx) feeCurrency() *common.Address { return tx.FeeCurrency }

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -1,0 +1,94 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// TODO(pl)
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type cel2Signer struct{ cancunSigner }
+
+// NewCel2Signer returns a signer that accepts
+// - CIP-64 celo dynamic fee transaction (v2)
+// - EIP-4844 blob transactions
+// - EIP-1559 dynamic fee transactions
+// - EIP-2930 access list transactions,
+// - EIP-155 replay protected transactions, and
+// - legacy Homestead transactions.
+func NewCel2Signer(chainId *big.Int) Signer {
+	return cel2Signer{cancunSigner{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}}
+}
+
+func (s cel2Signer) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != CeloDynamicFeeTxType {
+		return s.cancunSigner.Sender(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+	// DynamicFee txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, ErrInvalidChainId
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+func (s cel2Signer) Equal(s2 Signer) bool {
+	x, ok := s2.(cel2Signer)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}
+
+func (s cel2Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	txdata, ok := tx.inner.(*CeloDynamicFeeTx)
+	if !ok {
+		return s.cancunSigner.SignatureValues(tx, sig)
+	}
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+		return nil, nil, nil, ErrInvalidChainId
+	}
+	R, S, _ = decodeSignature(sig)
+	V = big.NewInt(int64(sig[64]))
+	return R, S, V, nil
+}
+
+// Hash returns the hash to be signed by the sender.
+// It does not uniquely identify the transaction.
+func (s cel2Signer) Hash(tx *Transaction) common.Hash {
+	if tx.Type() == CeloDynamicFeeTxType {
+		return prefixedRlpHash(
+			tx.Type(),
+			[]interface{}{
+				s.chainId,
+				tx.Nonce(),
+				tx.GasTipCap(),
+				tx.GasFeeCap(),
+				tx.Gas(),
+				tx.To(),
+				tx.Value(),
+				tx.Data(),
+				tx.AccessList(),
+				tx.FeeCurrency(),
+			})
+	}
+	return s.cancunSigner.Hash(tx)
+}

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -94,3 +94,5 @@ func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
 func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	// this is a noop for deposit transactions
 }
+
+func (tx *DepositTx) feeCurrency() *common.Address { return nil }

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -56,6 +56,9 @@ type txJSON struct {
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
+
+	// Celo specific fields
+	FeeCurrency *common.Address `json:"feeCurrency"` // nil means native currency
 }
 
 // MarshalJSON marshals as JSON with a hash.
@@ -98,6 +101,21 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
 		enc.MaxFeePerGas = (*hexutil.Big)(itx.GasFeeCap)
 		enc.MaxPriorityFeePerGas = (*hexutil.Big)(itx.GasTipCap)
+		enc.Value = (*hexutil.Big)(itx.Value)
+		enc.Input = (*hexutil.Bytes)(&itx.Data)
+		enc.AccessList = &itx.AccessList
+		enc.V = (*hexutil.Big)(itx.V)
+		enc.R = (*hexutil.Big)(itx.R)
+		enc.S = (*hexutil.Big)(itx.S)
+
+	case *CeloDynamicFeeTx:
+		enc.ChainID = (*hexutil.Big)(itx.ChainID)
+		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
+		enc.To = tx.To()
+		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
+		enc.MaxFeePerGas = (*hexutil.Big)(itx.GasFeeCap)
+		enc.MaxPriorityFeePerGas = (*hexutil.Big)(itx.GasTipCap)
+		enc.FeeCurrency = tx.FeeCurrency()
 		enc.Value = (*hexutil.Big)(itx.Value)
 		enc.Input = (*hexutil.Bytes)(&itx.Data)
 		enc.AccessList = &itx.AccessList
@@ -273,6 +291,63 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Value == nil {
 			return errors.New("missing required field 'value' in transaction")
 		}
+		itx.Value = (*big.Int)(dec.Value)
+		if dec.Input == nil {
+			return errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Input
+		if dec.V == nil {
+			return errors.New("missing required field 'v' in transaction")
+		}
+		if dec.AccessList != nil {
+			itx.AccessList = *dec.AccessList
+		}
+		itx.V = (*big.Int)(dec.V)
+		if dec.R == nil {
+			return errors.New("missing required field 'r' in transaction")
+		}
+		itx.R = (*big.Int)(dec.R)
+		if dec.S == nil {
+			return errors.New("missing required field 's' in transaction")
+		}
+		itx.S = (*big.Int)(dec.S)
+		withSignature := itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0
+		if withSignature {
+			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
+				return err
+			}
+		}
+
+	case CeloDynamicFeeTxType:
+		var itx CeloDynamicFeeTx
+		inner = &itx
+		if dec.ChainID == nil {
+			return errors.New("missing required field 'chainId' in transaction")
+		}
+		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.Nonce == nil {
+			return errors.New("missing required field 'nonce' in transaction")
+		}
+		itx.Nonce = uint64(*dec.Nonce)
+		if dec.To != nil {
+			itx.To = dec.To
+		}
+		if dec.Gas == nil {
+			return errors.New("missing required field 'gas' for txdata")
+		}
+		itx.Gas = uint64(*dec.Gas)
+		if dec.MaxPriorityFeePerGas == nil {
+			return errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
+		}
+		itx.GasTipCap = (*big.Int)(dec.MaxPriorityFeePerGas)
+		if dec.MaxFeePerGas == nil {
+			return errors.New("missing required field 'maxFeePerGas' for txdata")
+		}
+		itx.GasFeeCap = (*big.Int)(dec.MaxFeePerGas)
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.FeeCurrency = dec.FeeCurrency
 		itx.Value = (*big.Int)(dec.Value)
 		if dec.Input == nil {
 			return errors.New("missing required field 'input' in transaction")

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -65,6 +65,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
+		if config.Cel2Time != nil {
+			return NewCel2Signer(config.ChainID)
+		}
 		if config.CancunTime != nil {
 			return NewCancunSigner(config.ChainID)
 		}
@@ -92,7 +95,7 @@ func LatestSignerForChainID(chainID *big.Int) Signer {
 	if chainID == nil {
 		return HomesteadSigner{}
 	}
-	return NewCancunSigner(chainID)
+	return NewCel2Signer(chainID)
 }
 
 // SignTx signs the transaction using the given signer and private key.

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -121,3 +121,5 @@ func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 func (tx *AccessListTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
 }
+
+func (tx *AccessListTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -131,3 +131,5 @@ func (tx *BlobTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.R.SetFromBig(r)
 	tx.S.SetFromBig(s)
 }
+
+func (tx *BlobTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -117,3 +117,5 @@ func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 func (tx *DynamicFeeTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
 }
+
+func (tx *DynamicFeeTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -118,3 +118,5 @@ func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 func (tx *LegacyTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.V, tx.R, tx.S = v, r, s
 }
+
+func (tx *LegacyTx) feeCurrency() *common.Address { return nil }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1516,7 +1516,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -851,3 +851,77 @@ func TestRPCMarshalBlock(t *testing.T) {
 		}
 	}
 }
+
+func TestCeloTransaction_RoundTripRpcJSON(t *testing.T) {
+	var (
+		config = params.TestChainConfig
+		signer = types.LatestSigner(config)
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		tests  = celoTransactionTypes(common.Address{0xde, 0xad}, config)
+	)
+	t.Parallel()
+	for i, tt := range tests {
+		var tx2 types.Transaction
+		tx, err := types.SignNewTx(key, signer, tt)
+		if err != nil {
+			t.Fatalf("test %d: signing failed: %v", i, err)
+		}
+		// Regular transaction
+		if data, err := json.Marshal(tx); err != nil {
+			t.Fatalf("test %d: marshalling failed; %v", i, err)
+		} else if err = tx2.UnmarshalJSON(data); err != nil {
+			t.Fatalf("test %d: sunmarshal failed: %v", i, err)
+		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+			t.Fatalf("test %d: stx changed, want %x have %x", i, want, have)
+		}
+
+		//  rpcTransaction
+		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config, nil)
+		if data, err := json.Marshal(rpcTx); err != nil {
+			t.Fatalf("test %d: marshalling failed; %v", i, err)
+		} else if err = tx2.UnmarshalJSON(data); err != nil {
+			t.Fatalf("test %d: unmarshal failed: %v", i, err)
+		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+			t.Fatalf("test %d: tx changed, want %x have %x", i, want, have)
+		}
+	}
+}
+func celoTransactionTypes(addr common.Address, config *params.ChainConfig) []types.TxData {
+	return []types.TxData{
+		&types.CeloDynamicFeeTx{
+			ChainID:     config.ChainID,
+			Nonce:       5,
+			GasTipCap:   big.NewInt(6),
+			GasFeeCap:   big.NewInt(9),
+			Gas:         7,
+			FeeCurrency: nil,
+			To:          &addr,
+			Value:       big.NewInt(8),
+			Data:        []byte{0, 1, 2, 3, 4},
+			AccessList: types.AccessList{
+				types.AccessTuple{
+					Address:     common.Address{0x2},
+					StorageKeys: []common.Hash{types.EmptyRootHash},
+				},
+			},
+			V: big.NewInt(32),
+			R: big.NewInt(10),
+			S: big.NewInt(11),
+		},
+		&types.CeloDynamicFeeTx{
+			ChainID:     config.ChainID,
+			Nonce:       5,
+			GasTipCap:   big.NewInt(6),
+			GasFeeCap:   big.NewInt(9),
+			Gas:         7,
+			FeeCurrency: &common.Address{0x42},
+			To:          nil,
+			Value:       big.NewInt(8),
+			Data:        []byte{0, 1, 2, 3, 4},
+			AccessList:  types.AccessList{},
+			V:           big.NewInt(32),
+			R:           big.NewInt(10),
+			S:           big.NewInt(11),
+		},
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/celo-org/optimism/issues/47

Open questions:
- We need to decide how we want to enable those? I think creating a new hardfork (something like `Cel2`) makes most sense, but we could also integrate it in any older hardfork.
  - This is needed both for creating the proper signer, but also for proper rejection of the transaction of this type prior.
  - Was added in #16 
- Should we keep the `V2` in the name, or name it just `CeloDynamicFeeTxType`?
  - I removed the V2 for now, it's easy to add it back later
- Do we need a copyright header for new files. If so, how should that look like?
  - Postponed for clarification


There's also some work left in the tx pools, but this will be done in a new PR to keep this one at manageable size.