### PR TITLE
forkdiff: add token duality information 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,9 @@ devtools:
 	env GOBIN= go install ./cmd/abigen
 	@type "solc" 2> /dev/null || echo 'Please install solc'
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
+
+forkdiff:
+	docker run \
+		--mount src=$(shell pwd),target=/host-pwd,type=bind \
+		protolambda/forkdiff:latest \
+		-repo /host-pwd/ -fork /host-pwd/fork.yaml -out /host-pwd/forkdiff.html

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length rule:document-start
 title: "CELO <> OP op-geth forkdiff"
 footer: |
   Fork-diff overview of changes made in [Celo's `op-geth`](https://github.com/celo-org/op-geth),
@@ -5,7 +6,7 @@ footer: |
 base:
   name: OP
   url: https://github.com/ethereum-optimism/op-geth
-  hash: 628d30034201ea3ec4585f3c6c22fda581541549 # tracks the last rebased commit
+  hash: 628d30034201ea3ec4585f3c6c22fda581541549  # tracks the last rebased commit
 fork:
   name: CELO
   url: https://github.com/celo-org/op-geth
@@ -25,7 +26,20 @@ def:
         - title: "Celo token duality"
           description: "The Celo token is both the native token and ERC-20 compatible."
           globs:
-            - "common/celo-types/*"
+            - "core/evm.go"
+            - "core/vm/celo_contracts*.go"
+            - "core/vm/contracts*.go"
+            - "core/vm/evm.go"
+        - title: "Celo contracts"
+          description: |
+            Contract bindings are necessary for token duality and gas currencies.
+            The corresponding contracts are included to generate the bindings and test these features.
+          globs:
+            - "contracts/celo/*"
+            - "contracts/celo/*/*"
+            - "contracts/config/registry_ids.go"
+            - "core/celo_backend.go"
+            - "core/celo_genesis.go"
         - title: "Chain config"
           description: ""
           globs:


### PR DESCRIPTION
Split into two sections: general contract additions and the token duality specific part.

Also made the fork.yaml pass [yamllint][1].

Example output: https://sapphire-ettie-96.tiiny.site/ (forkdiff is not built in PRs currently.)

[1]: https://github.com/adrienverge/yamllint