### PR TITLE
Do not prefix deposit tx type twice when calculating receipt trie root.

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -471,10 +471,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType:
-		rlp.Encode(w, data)
-	case DepositTxType:
-		w.WriteByte(DepositTxType)
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, DepositTxType:
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for


### PR DESCRIPTION
A fix was added upstream after I started the rebase, so I just cherry-pick it for now and it should disappear at the next rebase.