### PR TITLE
Validations for celo txs in txpool

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -1036,7 +1036,7 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 		MinTip:    p.gasTip.ToBig(),
 	}
 	var fcv txpool.FeeCurrencyValidator = nil // TODO: create with proper value
-	if err := txpool.CeloValidateTransaction(tx, p.head, p.signer, baseOpts, fcv); err != nil {
+	if err := txpool.CeloValidateTransaction(tx, p.head, p.signer, baseOpts, p.state, fcv); err != nil {
 		return err
 	}
 	// Ensure the transaction adheres to the stateful pool filters (nonce, balance)

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -311,6 +311,9 @@ type BlobPool struct {
 	eventScope event.SubscriptionScope // Event scope to track and mass unsubscribe on termination
 
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
+
+	// Celo
+	feeCurrencyValidator txpool.FeeCurrencyValidator
 }
 
 // New creates a new blob transaction pool to gather, sort and filter inbound
@@ -327,6 +330,8 @@ func New(config Config, chain BlockChain) *BlobPool {
 		lookup: make(map[common.Hash]uint64),
 		index:  make(map[common.Address][]*blobTxMeta),
 		spent:  make(map[common.Address]*uint256.Int),
+
+		feeCurrencyValidator: txpool.NewFeeCurrencyValidator(),
 	}
 }
 
@@ -1024,17 +1029,18 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 func (p *BlobPool) validateTx(tx *types.Transaction) error {
 	// Ensure the transaction adheres to basic pool filters (type, size, tip) and
 	// consensus rules
-	baseOpts := &txpool.ValidationOptions{
-		Config:  p.chain.Config(),
-		Accept:  1 << types.BlobTxType,
-		MaxSize: txMaxSize,
-		MinTip:  p.gasTip.ToBig(),
+	baseOpts := &txpool.CeloValidationOptions{
+		Config:    p.chain.Config(),
+		AcceptMap: txpool.NewAcceptMap(types.BlobTxType),
+		MaxSize:   txMaxSize,
+		MinTip:    p.gasTip.ToBig(),
 	}
-	if err := txpool.ValidateTransaction(tx, p.head, p.signer, baseOpts); err != nil {
+	var fcv txpool.FeeCurrencyValidator = nil // TODO: create with proper value
+	if err := txpool.CeloValidateTransaction(tx, p.head, p.signer, baseOpts, fcv); err != nil {
 		return err
 	}
 	// Ensure the transaction adheres to the stateful pool filters (nonce, balance)
-	stateOpts := &txpool.ValidationOptionsWithState{
+	stateOpts := &txpool.CeloValidationOptionsWithState{
 		State: p.state,
 
 		FirstNonceGap: func(addr common.Address) uint64 {
@@ -1063,6 +1069,7 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 			}
 			return nil
 		},
+		FeeCurrencyValidator: p.feeCurrencyValidator,
 	}
 	if err := txpool.ValidateTransactionWithState(tx, p.signer, stateOpts); err != nil {
 		return err

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -30,7 +30,9 @@ type feeval struct {
 
 func (f *feeval) IsWhitelisted(st *state.StateDB, feeCurrency *common.Address) bool {
 	// TODO: implement proper validation for all currencies
-	return feeCurrency == nil
+	// Hardcoded for the moment
+	return true
+	//return feeCurrency == nil
 }
 
 func (f *feeval) Balance(st *state.StateDB, address common.Address, feeCurrency *common.Address) *big.Int {
@@ -80,7 +82,7 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 	if err := ValidateTransaction(tx, head, signer, opts); err != nil {
 		return err
 	}
-	if FeeCurrencyTx(tx) {
+	if IsFeeCurrencyTx(tx) {
 		if !fcv.IsWhitelisted(st, tx.FeeCurrency()) {
 			return NonWhitelistedFeeCurrencyError
 		}
@@ -88,16 +90,16 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 	return nil
 }
 
-// FeeCurrencyTxType returns true if and only if the transaction type
+// IsFeeCurrencyTxType returns true if and only if the transaction type
 // given can handle custom gas fee currencies.
-func FeeCurrencyTxType(t uint8) bool {
+func IsFeeCurrencyTxType(t uint8) bool {
 	return t == types.CeloDynamicFeeTxType
 }
 
-// FeeCurrencyTx returns true if this transaction specifies a custom
+// IsFeeCurrencyTx returns true if this transaction specifies a custom
 // gas fee currency.
-func FeeCurrencyTx(tx *types.Transaction) bool {
-	return FeeCurrencyTxType(tx.Type()) && tx.FeeCurrency() != nil
+func IsFeeCurrencyTx(tx *types.Transaction) bool {
+	return IsFeeCurrencyTxType(tx.Type()) && tx.FeeCurrency() != nil
 }
 
 // See: txpool.ValidationOptionsWithState

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -66,15 +66,15 @@ func (cvo *CeloValidationOptions) Accepts(txType uint8) bool {
 // This check is public to allow different transaction pools to check the basic
 // rules without duplicating code and running the risk of missed updates.
 func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
-	signer types.Signer, opts *CeloValidationOptions, fcv FeeCurrencyValidator) error {
+	signer types.Signer, opts *CeloValidationOptions, st *state.StateDB, fcv FeeCurrencyValidator) error {
 
 	if err := ValidateTransaction(tx, head, signer, opts); err != nil {
 		return err
 	}
 	if FeeCurrencyTx(tx) {
-		// if !fcv.IsWhitelisted(tx.FeeCurrency(), head.Number) { // TODO: change to celoContext
-		// 	return NonWhitelistedFeeCurrencyError
-		// }
+		if !fcv.IsWhitelisted(st, tx.FeeCurrency()) {
+			return NonWhitelistedFeeCurrencyError
+		}
 	}
 	return nil
 }

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -78,7 +78,6 @@ func (cvo *CeloValidationOptions) Accepts(txType uint8) bool {
 // rules without duplicating code and running the risk of missed updates.
 func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 	signer types.Signer, opts *CeloValidationOptions, st *state.StateDB, fcv FeeCurrencyValidator) error {
-
 	if err := ValidateTransaction(tx, head, signer, opts); err != nil {
 		return err
 	}

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -38,8 +38,8 @@ func (f *feeval) Balance(st *state.StateDB, address common.Address, feeCurrency 
 	return st.GetBalance(address)
 }
 
-// AcceptMap is a set of accepted transaction types for a transaction subpool.
-type AcceptMap = map[uint8]struct{}
+// AcceptSet is a set of accepted transaction types for a transaction subpool.
+type AcceptSet = map[uint8]struct{}
 
 // CeloValidationOptions define certain differences between transaction validation
 // across the different pools without having to duplicate those checks.
@@ -48,14 +48,23 @@ type AcceptMap = map[uint8]struct{}
 type CeloValidationOptions struct {
 	Config *params.ChainConfig // Chain configuration to selectively validate based on current fork rules
 
-	AcceptMap AcceptMap // Map of transaction types that should be accepted for the calling pool
+	AcceptSet AcceptSet // Set of transaction types that should be accepted for the calling pool
 	MaxSize   uint64    // Maximum size of a transaction that the caller can meaningfully handle
 	MinTip    *big.Int  // Minimum gas tip needed to allow a transaction into the caller pool
 }
 
+// NewAcceptSet creates a new AcceptSet with the types provided.
+func NewAcceptSet(types ...uint8) AcceptSet {
+	m := make(AcceptSet, len(types))
+	for _, t := range types {
+		m[t] = struct{}{}
+	}
+	return m
+}
+
 // Accepts returns true iff txType is accepted by this CeloValidationOptions.
 func (cvo *CeloValidationOptions) Accepts(txType uint8) bool {
-	_, ok := cvo.AcceptMap[txType]
+	_, ok := cvo.AcceptSet[txType]
 	return ok
 }
 
@@ -79,15 +88,6 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 	return nil
 }
 
-// NewAcceptMap creates a new AcceptMap with the types provided as keys.
-func NewAcceptMap(types ...uint8) AcceptMap {
-	m := make(AcceptMap, len(types))
-	for _, t := range types {
-		m[t] = struct{}{}
-	}
-	return m
-}
-
 // FeeCurrencyTxType returns true if and only if the transaction type
 // given can handle custom gas fee currencies.
 func FeeCurrencyTxType(t uint8) bool {
@@ -102,31 +102,7 @@ func FeeCurrencyTx(tx *types.Transaction) bool {
 
 // See: txpool.ValidationOptionsWithState
 type CeloValidationOptionsWithState struct {
-	State *state.StateDB // State database to check nonces and balances against
-
-	// FirstNonceGap is an optional callback to retrieve the first nonce gap in
-	// the list of pooled transactions of a specific account. If this method is
-	// set, nonce gaps will be checked and forbidden. If this method is not set,
-	// nonce gaps will be ignored and permitted.
-	FirstNonceGap func(addr common.Address) uint64
-
-	// UsedAndLeftSlots is a mandatory callback to retrieve the number of tx slots
-	// used and the number still permitted for an account. New transactions will
-	// be rejected once the number of remaining slots reaches zero.
-	UsedAndLeftSlots func(addr common.Address) (int, int)
-
-	// ExistingExpenditure is a mandatory callback to retrieve the cummulative
-	// cost of the already pooled transactions to check for overdrafts.
-	ExistingExpenditure func(addr common.Address) *big.Int
-
-	// ExistingCost is a mandatory callback to retrieve an already pooled
-	// transaction's cost with the given nonce to check for overdrafts.
-	ExistingCost func(addr common.Address, nonce uint64) *big.Int
-
-	// L1CostFn is an optional extension, to validate L1 rollup costs of a tx
-	L1CostFn L1CostFunc
-
-	// Celo
+	ValidationOptionsWithState
 
 	// FeeCurrencyValidator allows for balance check of non native fee currencies.
 	FeeCurrencyValidator FeeCurrencyValidator

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -1,0 +1,133 @@
+package txpool
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var NonWhitelistedFeeCurrencyError = errors.New("Fee currency given is not whitelisted at current block")
+
+// FeeCurrencyValidator validates currency whitelisted status at the specified
+// block number.
+type FeeCurrencyValidator interface {
+	IsWhitelisted(st *state.StateDB, feeCurrency *common.Address) bool
+	// Balance returns the feeCurrency balance of the address specified, in the given state.
+	// If feeCurrency is nil, the native currency balance has to be returned.
+	Balance(st *state.StateDB, address common.Address, feeCurrency *common.Address) *big.Int
+}
+
+func NewFeeCurrencyValidator() FeeCurrencyValidator {
+	return &feeval{}
+}
+
+type feeval struct {
+}
+
+func (f *feeval) IsWhitelisted(st *state.StateDB, feeCurrency *common.Address) bool {
+	// TODO: implement proper validation for all currencies
+	return feeCurrency == nil
+}
+
+func (f *feeval) Balance(st *state.StateDB, address common.Address, feeCurrency *common.Address) *big.Int {
+	// TODO: implement proper balance retrieval for fee currencies
+	return st.GetBalance(address)
+}
+
+// AcceptMap is a set of accepted transaction types for a transaction subpool.
+type AcceptMap = map[uint8]struct{}
+
+// CeloValidationOptions define certain differences between transaction validation
+// across the different pools without having to duplicate those checks.
+// In comparison to the standard ValidationOptions, the Accept field has been
+// changed to allow to test for CeloDynamicFeeTx types.
+type CeloValidationOptions struct {
+	Config *params.ChainConfig // Chain configuration to selectively validate based on current fork rules
+
+	AcceptMap AcceptMap // Map of transaction types that should be accepted for the calling pool
+	MaxSize   uint64    // Maximum size of a transaction that the caller can meaningfully handle
+	MinTip    *big.Int  // Minimum gas tip needed to allow a transaction into the caller pool
+}
+
+// Accepts returns true iff txType is accepted by this CeloValidationOptions.
+func (cvo *CeloValidationOptions) Accepts(txType uint8) bool {
+	_, ok := cvo.AcceptMap[txType]
+	return ok
+}
+
+// CeloValidateTransaction is a helper method to check whether a transaction is valid
+// according to the consensus rules, but does not check state-dependent validation
+// (balance, nonce, etc).
+//
+// This check is public to allow different transaction pools to check the basic
+// rules without duplicating code and running the risk of missed updates.
+func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
+	signer types.Signer, opts *CeloValidationOptions, fcv FeeCurrencyValidator) error {
+
+	if err := ValidateTransaction(tx, head, signer, opts); err != nil {
+		return err
+	}
+	if FeeCurrencyTx(tx) {
+		// if !fcv.IsWhitelisted(tx.FeeCurrency(), head.Number) { // TODO: change to celoContext
+		// 	return NonWhitelistedFeeCurrencyError
+		// }
+	}
+	return nil
+}
+
+// NewAcceptMap creates a new AcceptMap with the types provided as keys.
+func NewAcceptMap(types ...uint8) AcceptMap {
+	m := make(AcceptMap, len(types))
+	for _, t := range types {
+		m[t] = struct{}{}
+	}
+	return m
+}
+
+// FeeCurrencyTxType returns true if and only if the transaction type
+// given can handle custom gas fee currencies.
+func FeeCurrencyTxType(t uint8) bool {
+	return t == types.CeloDynamicFeeTxType
+}
+
+// FeeCurrencyTx returns true if this transaction specifies a custom
+// gas fee currency.
+func FeeCurrencyTx(tx *types.Transaction) bool {
+	return FeeCurrencyTxType(tx.Type()) && tx.FeeCurrency() != nil
+}
+
+// See: txpool.ValidationOptionsWithState
+type CeloValidationOptionsWithState struct {
+	State *state.StateDB // State database to check nonces and balances against
+
+	// FirstNonceGap is an optional callback to retrieve the first nonce gap in
+	// the list of pooled transactions of a specific account. If this method is
+	// set, nonce gaps will be checked and forbidden. If this method is not set,
+	// nonce gaps will be ignored and permitted.
+	FirstNonceGap func(addr common.Address) uint64
+
+	// UsedAndLeftSlots is a mandatory callback to retrieve the number of tx slots
+	// used and the number still permitted for an account. New transactions will
+	// be rejected once the number of remaining slots reaches zero.
+	UsedAndLeftSlots func(addr common.Address) (int, int)
+
+	// ExistingExpenditure is a mandatory callback to retrieve the cummulative
+	// cost of the already pooled transactions to check for overdrafts.
+	ExistingExpenditure func(addr common.Address) *big.Int
+
+	// ExistingCost is a mandatory callback to retrieve an already pooled
+	// transaction's cost with the given nonce to check for overdrafts.
+	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+
+	// L1CostFn is an optional extension, to validate L1 rollup costs of a tx
+	L1CostFn L1CostFunc
+
+	// Celo
+
+	// FeeCurrencyValidator allows for balance check of non native fee currencies.
+	FeeCurrencyValidator FeeCurrencyValidator
+}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -622,7 +622,7 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 	if local {
 		opts.MinTip = new(big.Int)
 	}
-	if err := txpool.CeloValidateTransaction(tx, pool.currentHead.Load(), pool.signer, opts, pool.feeCurrencyValidator); err != nil {
+	if err := txpool.CeloValidateTransaction(tx, pool.currentHead.Load(), pool.signer, opts, pool.currentState, pool.feeCurrencyValidator); err != nil {
 		return err
 	}
 	return nil

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -62,7 +62,8 @@ type ValidationOptions struct {
 //
 // This check is public to allow different transaction pools to check the basic
 // rules without duplicating code and running the risk of missed updates.
-func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types.Signer, opts *ValidationOptions) error {
+// ONLY TO BE CALLED FROM "CeloValidateTransaction"
+func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types.Signer, opts *CeloValidationOptions) error {
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
@@ -70,7 +71,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected
-	if opts.Accept&(1<<tx.Type()) == 0 {
+	if opts.Accepts(tx.Type()) {
 		return fmt.Errorf("%w: tx type %v not supported by this pool", core.ErrTxTypeNotSupported, tx.Type())
 	}
 	// Before performing any expensive validations, sanity check that the tx is
@@ -221,7 +222,7 @@ type ValidationOptionsWithState struct {
 //
 // This check is public to allow different transaction pools to check the stateful
 // rules without duplicating code and running the risk of missed updates.
-func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, opts *ValidationOptionsWithState) error {
+func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, opts *CeloValidationOptionsWithState) error {
 	// Ensure the transaction adheres to nonce ordering
 	from, err := signer.Sender(tx) // already validated (and cached), but cleaner to check
 	if err != nil {
@@ -241,7 +242,7 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	}
 	// Ensure the transactor has enough funds to cover the transaction costs
 	var (
-		balance = opts.State.GetBalance(from)
+		balance = opts.FeeCurrencyValidator.Balance(opts.State, from, tx.FeeCurrency())
 		cost    = tx.Cost()
 	)
 	if opts.L1CostFn != nil {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -71,7 +71,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected
-	if opts.Accepts(tx.Type()) {
+	if !opts.Accepts(tx.Type()) {
 		return fmt.Errorf("%w: tx type %v not supported by this pool", core.ErrTxTypeNotSupported, tx.Type())
 	}
 	// Before performing any expensive validations, sanity check that the tx is


### PR DESCRIPTION
Validates and accepts celo transactions in the txpool.

(Extracted from the bigger PR of celo's txpool for clarity)

Missing: actual contract calling code to get fee balance & whitelisted status.