### PR TITLE
Handle fee currency receipts

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -89,6 +89,11 @@ type Receipt struct {
 	L1GasUsed  *big.Int   `json:"l1GasUsed,omitempty"`
 	L1Fee      *big.Int   `json:"l1Fee,omitempty"`
 	FeeScalar  *big.Float `json:"l1FeeScalar,omitempty"`
+
+	// Celo
+	// The BaseFee is stored in fee currency for fee currency txs. We need
+	// this field to calculate the EffectiveGasPrice for fee currency txs.
+	BaseFee *big.Int `json:"baseFee,omitempty"`
 }
 
 type receiptMarshaling struct {
@@ -134,6 +139,15 @@ type depositReceiptRLP struct {
 	DepositReceiptVersion *uint64 `rlp:"optional"`
 }
 
+type celoDynamicReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             Bloom
+	Logs              []*Log
+	// BaseFee was introduced as mandatory in Cel2 ONLY for the CeloDynamicFeeTxs
+	BaseFee *big.Int
+}
+
 // storedReceiptRLP is the storage encoding of a receipt.
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
@@ -146,6 +160,14 @@ type storedReceiptRLP struct {
 	// DepositNonce. Post Canyon, receipts will have a non-empty DepositReceiptVersion indicating
 	// which post-Canyon receipt hash function to invoke.
 	DepositReceiptVersion *uint64 `rlp:"optional"`
+}
+
+type celoDynamicFeeStoredReceiptRLP struct {
+	CeloDynamicReceiptMarker []interface{} // Marker to distinguish this from storedReceiptRLP
+	PostStateOrStatus        []byte
+	CumulativeGasUsed        uint64
+	Logs                     []*Log
+	BaseFee                  *big.Int
 }
 
 // LegacyOptimismStoredReceiptRLP is the pre bedrock storage encoding of a
@@ -250,6 +272,9 @@ func (r *Receipt) EncodeRLP(w io.Writer) error {
 func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
 	w.WriteByte(r.Type)
 	switch r.Type {
+	case CeloDynamicFeeTxType:
+		withBaseFee := &celoDynamicReceiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.BaseFee}
+		return rlp.Encode(w, withBaseFee)
 	case DepositTxType:
 		withNonce := &depositReceiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.DepositNonce, r.DepositReceiptVersion}
 		return rlp.Encode(w, withNonce)
@@ -331,6 +356,15 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		}
 		r.Type = b[0]
 		return r.setFromRLP(data)
+	case CeloDynamicFeeTxType:
+		var data celoDynamicReceiptRLP
+		err := rlp.DecodeBytes(b[1:], &data)
+		if err != nil {
+			return err
+		}
+		r.Type = b[0]
+		r.BaseFee = data.BaseFee
+		return r.setFromRLP(receiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs})
 	case DepositTxType:
 		var data depositReceiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
@@ -395,6 +429,11 @@ type ReceiptForStorage Receipt
 func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 	w := rlp.NewEncoderBuffer(_w)
 	outerList := w.List()
+	if r.Type == CeloDynamicFeeTxType {
+		// Mark receipt as CeloDynamicFee receipt by starting with an empty list
+		listIndex := w.List()
+		w.ListEnd(listIndex)
+	}
 	w.WriteBytes((*Receipt)(r).statusEncoding())
 	w.WriteUint64(r.CumulativeGasUsed)
 	logList := w.List()
@@ -410,8 +449,23 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 			w.WriteUint64(*r.DepositReceiptVersion)
 		}
 	}
+	if r.Type == CeloDynamicFeeTxType {
+		w.WriteBigInt(r.BaseFee)
+	}
 	w.ListEnd(outerList)
 	return w.Flush()
+}
+
+// Detect CeloDynamicFee receipts by looking at the first list element
+// To distinguish these receipts from the very similar normal receipts, an
+// empty list is added as the first element of the RLP-serialized struct.
+func isCeloDynamicFeeReceipt(blob []byte) bool {
+	listHeaderSize := 1 // Length of the list header representing the struct in bytes
+	if blob[0] > 0xf7 {
+		listHeaderSize += int(blob[0]) - 0xf7
+	}
+	firstListElement := blob[listHeaderSize] // First byte of first list element
+	return firstListElement == 0xc0
 }
 
 // DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
@@ -423,6 +477,9 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	// First try to decode the latest receipt database format, try the pre-bedrock Optimism legacy format otherwise.
+	if isCeloDynamicFeeReceipt(blob) {
+		return decodeStoredCeloDynamicFeeReceiptRLP(r, blob)
+	}
 	if err := decodeStoredReceiptRLP(r, blob); err == nil {
 		return nil
 	}
@@ -456,6 +513,21 @@ func decodeLegacyOptimismReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	r.L1GasPrice = stored.L1GasPrice
 	r.L1Fee = stored.L1Fee
 	r.FeeScalar = scalar
+	return nil
+}
+
+func decodeStoredCeloDynamicFeeReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored celoDynamicFeeStoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.Logs = stored.Logs
+	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+	r.BaseFee = stored.BaseFee
 	return nil
 }
 
@@ -498,6 +570,9 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	switch r.Type {
 	case AccessListTxType, DynamicFeeTxType, BlobTxType:
 		rlp.Encode(w, data)
+	case CeloDynamicFeeTxType:
+		celoDynamicData := &celoDynamicReceiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.BaseFee}
+		rlp.Encode(w, celoDynamicData)
 	case DepositTxType:
 		if r.DepositReceiptVersion != nil {
 			// post-canyon receipt hash computation update
@@ -526,7 +601,12 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		// The transaction type and hash can be retrieved from the transaction itself
 		rs[i].Type = txs[i].Type()
 		rs[i].TxHash = txs[i].Hash()
-		rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), baseFee)
+		// The CeloDynamicFeeTxs set the baseFee in the receipt
+		if txs[i].Type() != CeloDynamicFeeTxType {
+			rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), baseFee)
+		} else {
+			rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), rs[i].BaseFee)
+		}
 
 		// EIP-4844 blob transaction fields
 		if txs[i].Type() == BlobTxType {

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -84,6 +84,24 @@ var (
 		},
 		Type: DynamicFeeTxType,
 	}
+	celoDynamicFeeReceipt = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		BaseFee: new(big.Int).SetUint64(1),
+		Type:    CeloDynamicFeeTxType,
+	}
 	depositReceiptNoNonce = &Receipt{
 		Status:            ReceiptStatusFailed,
 		CumulativeGasUsed: 1,
@@ -609,6 +627,24 @@ func TestReceiptMarshalBinary(t *testing.T) {
 	if !bytes.Equal(have, eip1559Want) {
 		t.Errorf("encoded RLP mismatch, got %x want %x", have, eip1559Want)
 	}
+
+	// Celo Dynamic Fee Receipt
+	buf.Reset()
+	celoDynamicFeeReceipt.Bloom = CreateBloom(Receipts{celoDynamicFeeReceipt})
+	have, err = celoDynamicFeeReceipt.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal binary error: %v", err)
+	}
+	celoDynamicFeeReceipts := Receipts{celoDynamicFeeReceipt}
+	celoDynamicFeeReceipts.EncodeIndex(0, buf)
+	haveEncodeIndex = buf.Bytes()
+	if !bytes.Equal(have, haveEncodeIndex) {
+		t.Errorf("BinaryMarshal and EncodeIndex mismatch, got %x want %x", have, haveEncodeIndex)
+	}
+	celoDynamicFeeWant := common.FromHex("7bf901c68001b9010000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000000000000000010000080000000000000000000004000000000000000000000000000040000000000000000000000000000800000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000f8bef85d940000000000000000000000000000000000000011f842a0000000000000000000000000000000000000000000000000000000000000deada0000000000000000000000000000000000000000000000000000000000000beef830100fff85d940000000000000000000000000000000000000111f842a0000000000000000000000000000000000000000000000000000000000000deada0000000000000000000000000000000000000000000000000000000000000beef830100ff01")
+	if !bytes.Equal(have, celoDynamicFeeWant) {
+		t.Errorf("encoded RLP mismatch, got %x want %x", have, celoDynamicFeeWant)
+	}
 }
 
 func TestReceiptUnmarshalBinary(t *testing.T) {
@@ -879,6 +915,7 @@ func TestRoundTripReceipt(t *testing.T) {
 		{name: "Legacy", rcpt: legacyReceipt},
 		{name: "AccessList", rcpt: accessListReceipt},
 		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "CeloDynamicFee", rcpt: celoDynamicFeeReceipt},
 		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
 		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
 		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
@@ -915,6 +952,7 @@ func TestRoundTripReceiptForStorage(t *testing.T) {
 		{name: "Legacy", rcpt: legacyReceipt},
 		{name: "AccessList", rcpt: accessListReceipt},
 		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "CeloDynamicFee", rcpt: celoDynamicFeeReceipt},
 		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
 		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
 		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
@@ -933,6 +971,9 @@ func TestRoundTripReceiptForStorage(t *testing.T) {
 			require.Equal(t, test.rcpt.Logs, d.Logs)
 			require.Equal(t, test.rcpt.DepositNonce, d.DepositNonce)
 			require.Equal(t, test.rcpt.DepositReceiptVersion, d.DepositReceiptVersion)
+			if test.rcpt.Type == CeloDynamicFeeTxType {
+				require.Equal(t, test.rcpt.EffectiveGasPrice, d.EffectiveGasPrice)
+			}
 		})
 	}
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1572,6 +1572,9 @@ type RPCTransaction struct {
 	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
 	// deposit-tx post-Canyon only
 	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+
+	// Celo
+	FeeCurrency *common.Address `json:"feeCurrency,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1593,6 +1596,8 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		V:        (*hexutil.Big)(v),
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
+		// Celo
+		FeeCurrency: tx.FeeCurrency(),
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1648,9 +1648,8 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
 		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
 		// if the transaction has been mined, compute the effective gas price
-		if baseFee != nil && blockHash != (common.Hash{}) {
-			// price = min(gasTipCap + baseFee, gasFeeCap)
-			result.GasPrice = (*hexutil.Big)(effectiveGasPrice(tx, baseFee))
+		if receipt != nil {
+			result.GasPrice = (*hexutil.Big)(receipt.EffectiveGasPrice)
 		} else {
 			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
 		}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1814,28 +1814,34 @@ func TestCeloTransaction_RoundTripRpcJSON(t *testing.T) {
 	)
 	t.Parallel()
 	for i, tt := range tests {
-		var tx2 types.Transaction
 		tx, err := types.SignNewTx(key, signer, tt)
 		if err != nil {
 			t.Fatalf("test %d: signing failed: %v", i, err)
 		}
+
 		// Regular transaction
-		if data, err := json.Marshal(tx); err != nil {
-			t.Fatalf("test %d: marshalling failed; %v", i, err)
-		} else if err = tx2.UnmarshalJSON(data); err != nil {
-			t.Fatalf("test %d: sunmarshal failed: %v", i, err)
-		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
-			t.Fatalf("test %d: stx changed, want %x have %x", i, want, have)
+		{
+			var tx2 types.Transaction
+			if data, err := json.Marshal(tx); err != nil {
+				t.Fatalf("test %d: marshalling failed; %v", i, err)
+			} else if err = tx2.UnmarshalJSON(data); err != nil {
+				t.Fatalf("test %d: sunmarshal failed: %v", i, err)
+			} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+				t.Fatalf("test %d: stx changed, want %x have %x", i, want, have)
+			}
 		}
 
 		//  rpcTransaction
-		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config, nil)
-		if data, err := json.Marshal(rpcTx); err != nil {
-			t.Fatalf("test %d: marshalling failed; %v", i, err)
-		} else if err = tx2.UnmarshalJSON(data); err != nil {
-			t.Fatalf("test %d: unmarshal failed: %v", i, err)
-		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
-			t.Fatalf("test %d: tx changed, want %x have %x", i, want, have)
+		{
+			var tx2 types.Transaction
+			rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil, config, nil)
+			if data, err := json.Marshal(rpcTx); err != nil {
+				t.Fatalf("test %d: marshalling failed; %v", i, err)
+			} else if err = tx2.UnmarshalJSON(data); err != nil {
+				t.Fatalf("test %d: unmarshal failed: %v", i, err)
+			} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+				t.Fatalf("test %d: tx changed, want %x have %x", i, want, have)
+			}
 		}
 	}
 }


### PR DESCRIPTION
* Add fee currency to tx RPC responses
* Use effectiveGasPrice from receipt to get correct values for fee currencies
* Add BaseFee to RLP encoded receipts, so that the effectiveGasPrice can be correctly derived when receipt information is shared with other nodes.

See https://github.com/celo-org/optimism/issues/61

Next step is to check if the usual client libraries will accept the RPC results without breaking.