### PR TITLE
Fix base fee sending if Cel2 is disabled

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -694,6 +694,8 @@ func (st *StateTransition) distributeTxFees() error {
 
 		if st.evm.ChainConfig().IsCel2(st.evm.Context.Time) {
 			st.state.AddBalance(feeHandlerAddress, baseTxFee)
+		} else if st.evm.ChainConfig().Optimism != nil {
+			st.state.AddBalance(params.OptimismBaseFeeRecipient, baseTxFee)
 		}
 
 		if l1Cost != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -20,12 +20,11 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	contracts "github.com/ethereum/go-ethereum/contracts/celo"
 )
 
 var (
 	// The base fee portion of the transaction fee accumulates at this predeploy
-	OptimismBaseFeeRecipient = contracts.FeeHandlerAddress
+	OptimismBaseFeeRecipient = common.HexToAddress("0x4200000000000000000000000000000000000019")
 	// The L1 portion of the transaction fee accumulates at this predeploy
 	OptimismL1FeeRecipient = common.HexToAddress("0x420000000000000000000000000000000000001A")
 )


### PR DESCRIPTION
If Cel2 is not enabled, the base fees should be sent to `OptimismBaseFeeRecipient` as if we never changed the code at all. This is our general approach and it allows us to keep a smaller diff, since we can leave tests running unmodified with the old hardfork flags if desired.

Since we explicitly use the FeeHandler as target for the base fees if Cel2 is enabled, we don't have to change the `OptimismBaseFeeRecipient` to the FeeHandler, anymore.