### PR TITLE
Avoid StateDB copy by wrapping in ReadOnlyStateDB

### DIFF
--- a/core/celo_backend.go
+++ b/core/celo_backend.go
@@ -43,7 +43,8 @@ func (b *CeloBackend) CallContract(ctx context.Context, call ethereum.CallMsg, b
 	txCtx := vm.TxContext{}
 	vmConfig := vm.Config{}
 
-	evm := vm.NewEVM(blockCtx, txCtx, b.state, b.chainConfig, vmConfig)
+	readOnlyStateDB := ReadOnlyStateDB{StateDB: b.state}
+	evm := vm.NewEVM(blockCtx, txCtx, &readOnlyStateDB, b.chainConfig, vmConfig)
 	ret, _, err := evm.StaticCall(vm.AccountRef(evm.Origin), *call.To, call.Data, call.Gas)
 
 	return ret, err

--- a/core/celo_evm.go
+++ b/core/celo_evm.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	contracts "github.com/ethereum/go-ethereum/contracts/celo"
 	"github.com/ethereum/go-ethereum/contracts/celo/abigen"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
@@ -47,13 +46,12 @@ func getExchangeRates(caller *CeloBackend) (map[common.Address]*big.Rat, error) 
 	return exchangeRates, nil
 }
 
-func setCeloFieldsInBlockContext(blockContext *vm.BlockContext, header *types.Header, config *params.ChainConfig, statedb *state.StateDB) {
+func setCeloFieldsInBlockContext(blockContext *vm.BlockContext, header *types.Header, config *params.ChainConfig, statedb vm.StateDB) {
 	if !config.IsCel2(header.Time) {
 		return
 	}
 
-	stateCopy := statedb.Copy()
-	caller := &CeloBackend{config, stateCopy}
+	caller := &CeloBackend{config, statedb}
 
 	// Add fee currency exchange rates
 	var err error

--- a/core/celo_read_only_statedb.go
+++ b/core/celo_read_only_statedb.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// ReadOnlyStateDB wraps a StateDB to prevent modifications. Using it without copying it is safe.
+//
+// Only the following methods will be passed through to the original StateDB:
+//
+//	GetState(common.Address, common.Hash) common.Hash
+//	GetCodeHash(common.Address) common.Hash
+//	GetCode(common.Address) []byte
+//
+// Gas calculations based on ReadOnlyStateDB will be wrong because the accessed storage slots and addresses are not tracked.
+type ReadOnlyStateDB struct {
+	vm.StateDB
+}
+
+func (r *ReadOnlyStateDB) CreateAccount(common.Address) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SubBalance(common.Address, *big.Int) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) AddBalance(_ common.Address, amount *big.Int) {
+	if amount.Cmp(common.Big0) == 0 {
+		// Adding zero is safe, so we can return here
+		return
+	}
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetBalance(common.Address) *big.Int {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetNonce(common.Address) uint64 {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SetNonce(common.Address, uint64) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SetCode(common.Address, []byte) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetCodeSize(common.Address) int {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) AddRefund(uint64) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SubRefund(uint64) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetRefund() uint64 {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetCommittedState(common.Address, common.Hash) common.Hash {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SetState(common.Address, common.Hash, common.Hash) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SetTransientState(addr common.Address, key, value common.Hash) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SelfDestruct(common.Address) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) HasSelfDestructed(common.Address) bool {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) Selfdestruct6780(common.Address) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) Exist(common.Address) bool {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) Empty(common.Address) bool {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) AddressInAccessList(addr common.Address) bool {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	// We don't track access lists
+	return false, false
+}
+
+func (r *ReadOnlyStateDB) AddAddressToAccessList(addr common.Address) {
+}
+
+func (r *ReadOnlyStateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+}
+
+func (r *ReadOnlyStateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) RevertToSnapshot(int) {
+	// No changes can be done, so reverting is a noop.
+}
+
+func (r *ReadOnlyStateDB) Snapshot() int {
+	// We use id 0 for the single state this immutable StateDB can have.
+	return 0
+}
+
+func (r *ReadOnlyStateDB) AddLog(*types.Log) {
+	panic("not implemented")
+}
+
+func (r *ReadOnlyStateDB) AddPreimage(common.Hash, []byte) {
+	panic("not implemented")
+}

--- a/core/evm.go
+++ b/core/evm.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
@@ -39,7 +38,7 @@ type ChainContext interface {
 }
 
 // NewEVMBlockContext creates a new context for use in the EVM.
-func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common.Address, config *params.ChainConfig, statedb *state.StateDB) vm.BlockContext {
+func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common.Address, config *params.ChainConfig, statedb vm.StateDB) vm.BlockContext {
 	var (
 		beneficiary common.Address
 		baseFee     *big.Int


### PR DESCRIPTION
I changed `NewEVMBlockContext` to take the `vm.StateDB` interface instead of only `state.StateDB` structs. This should have been the case from the beginning, but the interface does not provide a way to copy the state db, which is necessary since `StaticCall` does modify the state (touches account address, tracks accesses in access list and reverts on error).

To make the `StaticCall` work, I wrapped the state db in a `ReadOnlyStateDB` wrapper that prevents any state modification. The alternative would be the simpler but more dangerous removal of the legacy state changes in `StaticCall`, see be2803ecc9c043f68e472239c380863b13fdda45.

In effect we gain:
* more flexible NewEVMBlockContext (will help in the optimism repo [where we want to pass a `simState`](https://github.com/celo-org/optimism/blob/5b34a86c1a9912616823677ccf8ed3b726089805/op-chain-ops/squash/sim.go#L188))
* better performance due to not copying the state db