### PR TITLE
Reduce allocations during the ReHeap of the legacypool/priceHeaps

### DIFF
--- a/common/exchange/rates.go
+++ b/common/exchange/rates.go
@@ -120,6 +120,16 @@ func NewRatesAndFees(rates common.ExchangeRates, nativeBaseFee *big.Int) *RatesA
 	}
 }
 
+// HasBaseFee returns if the basefee is set.
+func (rf *RatesAndFees) HasBaseFee() bool {
+	return rf.nativeBaseFee != nil
+}
+
+// GetNativeBaseFee returns the basefee in celo currency.
+func (rf *RatesAndFees) GetNativeBaseFee() *big.Int {
+	return rf.nativeBaseFee
+}
+
 // GetBaseFeeIn returns the basefee expressed in the specified currency. Returns nil
 // if the currency is not whitelisted.
 func (rf *RatesAndFees) GetBaseFeeIn(currency *common.Address) *big.Int {

--- a/common/exchange/rates.go
+++ b/common/exchange/rates.go
@@ -100,3 +100,53 @@ func CompareValue(exchangeRates common.ExchangeRates, val1 *big.Int, feeCurrency
 
 	return leftSide.Cmp(rightSide), nil
 }
+
+// RatesAndFees holds exchange rates and the basefees expressed in the rates currencies.
+type RatesAndFees struct {
+	Rates common.ExchangeRates
+
+	nativeBaseFee    *big.Int
+	currencyBaseFees map[common.Address]*big.Int
+}
+
+// NewRatesAndFees creates a new empty RatesAndFees object.
+func NewRatesAndFees(rates common.ExchangeRates, nativeBaseFee *big.Int) *RatesAndFees {
+	// While it could be made so that currency basefees are calculated on demand,
+	// the low amount of these (usually N < 20)
+	return &RatesAndFees{
+		Rates:            rates,
+		nativeBaseFee:    nativeBaseFee,
+		currencyBaseFees: make(map[common.Address]*big.Int, len(rates)),
+	}
+}
+
+// GetBaseFeeIn returns the basefee expressed in the specified currency. Returns nil
+// if the currency is not whitelisted.
+func (rf *RatesAndFees) GetBaseFeeIn(currency *common.Address) *big.Int {
+	// If native currency is being requested, return it
+	if currency == nil {
+		return rf.nativeBaseFee
+	}
+	// If a non-native currency is being requested, but it is nil,
+	// it means there is no baseFee in this context. Return nil as well.
+	if rf.nativeBaseFee == nil {
+		return nil
+	}
+	// Check the cache
+	baseFee, ok := rf.currencyBaseFees[*currency]
+	if ok {
+		return baseFee
+	}
+	// Not found, calculate
+	calculatedBaseFee, err := ConvertGoldToCurrency(rf.Rates, currency, rf.nativeBaseFee)
+	if err != nil {
+		// Should never happen: error lvl log line
+		log.Error("BaseFee requested for non whitelisted currency",
+			"currency", currency.Hex(),
+			"exchangeRates", rf.Rates,
+			"cause", err)
+		return nil
+	}
+	rf.currencyBaseFees[*currency] = calculatedBaseFee
+	return calculatedBaseFee
+}

--- a/core/txpool/legacypool/celo_list.go
+++ b/core/txpool/legacypool/celo_list.go
@@ -115,3 +115,11 @@ func (c *list) setCapsTo(caps map[common.Address]*big.Int) {
 		}
 	}
 }
+
+// GetNativeBaseFee returns the base fee for this priceHeap
+func (h *priceHeap) GetNativeBaseFee() *big.Int {
+	if h.ratesAndFees == nil {
+		return nil
+	}
+	return h.ratesAndFees.GetNativeBaseFee()
+}

--- a/core/txpool/legacypool/celo_list.go
+++ b/core/txpool/legacypool/celo_list.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/exchange"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -115,44 +114,4 @@ func (c *list) setCapsTo(caps map[common.Address]*big.Int) {
 			c.costCap[curr] = new(big.Int).Set(cap)
 		}
 	}
-}
-
-type TxComparator func(a, b *types.Transaction, baseFee *big.Int) int
-
-func (p *pricedList) compareWithRates(a, b *types.Transaction, goldBaseFee *big.Int) int {
-	if goldBaseFee != nil {
-		tipA := effectiveTip(p.rates, goldBaseFee, a)
-		tipB := effectiveTip(p.rates, goldBaseFee, b)
-		result, _ := exchange.CompareValue(p.rates, tipA, a.FeeCurrency(), tipB, b.FeeCurrency())
-		return result
-	}
-
-	// Compare fee caps if baseFee is not specified or effective tips are equal
-	feeA := a.GasFeeCap()
-	feeB := b.GasFeeCap()
-	c, _ := exchange.CompareValue(p.rates, feeA, a.FeeCurrency(), feeB, b.FeeCurrency())
-	if c != 0 {
-		return c
-	}
-
-	// Compare tips if effective tips and fee caps are equal
-	tipCapA := a.GasTipCap()
-	tipCapB := b.GasTipCap()
-	result, _ := exchange.CompareValue(p.rates, tipCapA, a.FeeCurrency(), tipCapB, b.FeeCurrency())
-	return result
-}
-
-func baseFeeInCurrency(rates common.ExchangeRates, goldBaseFee *big.Int, feeCurrency *common.Address) *big.Int {
-	// can ignore the whitelist error since txs with non whitelisted currencies
-	// are pruned
-	baseFee, _ := exchange.ConvertGoldToCurrency(rates, feeCurrency, goldBaseFee)
-	return baseFee
-}
-
-func effectiveTip(rates common.ExchangeRates, goldBaseFee *big.Int, tx *types.Transaction) *big.Int {
-	if tx.FeeCurrency() == nil {
-		return tx.EffectiveGasTipValue(goldBaseFee)
-	}
-	baseFee := baseFeeInCurrency(rates, goldBaseFee, tx.FeeCurrency())
-	return tx.EffectiveGasTipValue(baseFee)
 }

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -547,7 +547,7 @@ func (pool *LegacyPool) Pending(enforceTips bool) map[common.Address][]*txpool.L
 		// If the miner requests tip enforcement, cap the lists now
 		if enforceTips && !pool.locals.contains(addr) {
 			for i, tx := range txs {
-				if tx.EffectiveGasTipIntCmp(pool.gasTip.Load(), pool.priced.urgent.baseFee) < 0 {
+				if tx.EffectiveGasTipIntCmp(pool.gasTip.Load(), pool.priced.urgent.ratesAndFees.GetNativeBaseFee()) < 0 {
 					txs = txs[:i]
 					break
 				}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -547,7 +547,7 @@ func (pool *LegacyPool) Pending(enforceTips bool) map[common.Address][]*txpool.L
 		// If the miner requests tip enforcement, cap the lists now
 		if enforceTips && !pool.locals.contains(addr) {
 			for i, tx := range txs {
-				if tx.EffectiveGasTipIntCmp(pool.gasTip.Load(), pool.priced.urgent.ratesAndFees.GetNativeBaseFee()) < 0 {
+				if tx.EffectiveGasTipIntCmp(pool.gasTip.Load(), pool.priced.urgent.GetNativeBaseFee()) < 0 {
 					txs = txs[:i]
 					break
 				}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -484,7 +484,8 @@ type priceHeap struct {
 	baseFee *big.Int // heap should always be re-sorted after baseFee is changed
 	list    []*types.Transaction
 
-	txComparator TxComparator
+	// Celo specific
+	ratesAndFees *exchange.RatesAndFees // current exchange rates and basefees
 }
 
 func (h *priceHeap) Len() int      { return len(h.list) }
@@ -502,7 +503,7 @@ func (h *priceHeap) Less(i, j int) bool {
 }
 
 func (h *priceHeap) cmp(a, b *types.Transaction) int {
-	return h.txComparator(a, b, h.baseFee)
+	return types.CompareWithRates(a, b, h.baseFee, h.ratesAndFees)
 }
 
 func (h *priceHeap) Push(x interface{}) {
@@ -537,9 +538,6 @@ type pricedList struct {
 	all              *lookup    // Pointer to the map of all transactions
 	urgent, floating priceHeap  // Heaps of prices of all the stored **remote** transactions
 	reheapMu         sync.Mutex // Mutex asserts that only one routine is reheaping the list
-
-	// Celo specific
-	rates common.ExchangeRates // current exchange rates
 }
 
 const (
@@ -552,8 +550,6 @@ func newPricedList(all *lookup) *pricedList {
 	p := &pricedList{
 		all: all,
 	}
-	p.floating.txComparator = p.compareWithRates
-	p.urgent.txComparator = p.compareWithRates
 	return p
 }
 
@@ -684,7 +680,11 @@ func (l *pricedList) Reheap() {
 // SetBaseFeeAndRates updates the base fee and triggers a re-heap. Note that Removed is not
 // necessary to call right before SetBaseFee when processing a new block.
 func (l *pricedList) SetBaseFeeAndRates(baseFee *big.Int, rates common.ExchangeRates) {
+	ratesAndFees := exchange.NewRatesAndFees(rates, baseFee)
 	l.urgent.baseFee = baseFee
-	l.rates = rates
+	// Since the urgent & floating reheaps and comparisons are not multithreaded, they can share
+	// the ratesAndFees instance.
+	l.urgent.ratesAndFees = ratesAndFees
+	l.floating.ratesAndFees = ratesAndFees
 	l.Reheap()
 }

--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -34,6 +34,6 @@ func CompareWithRates(a, b *Transaction, ratesAndFees *exchange.RatesAndFees) in
 	// Compare tips if effective tips and fee caps are equal
 	tipCapA := a.inner.gasTipCap()
 	tipCapB := b.inner.gasTipCap()
-	c2, _ := exchange.CompareValue(rates, tipCapA, a.inner.feeCurrency(), tipCapB, b.inner.feeCurrency())
-	return c2
+	c, _ = exchange.CompareValue(rates, tipCapA, a.inner.feeCurrency(), tipCapB, b.inner.feeCurrency())
+	return c
 }

--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/exchange"
+)
+
+// CompareWithRates compares the effective gas price of two transactions according to the exchange rates and
+// the base fees in the transactions currencies.
+func CompareWithRates(a, b *Transaction, goldBaseFee *big.Int, ratesAndFees *exchange.RatesAndFees) int {
+	if ratesAndFees == nil {
+		// During node startup the ratesAndFees might not be yet setup, compare nominally
+		feeCapCmp := a.GasFeeCapCmp(b)
+		if feeCapCmp != 0 {
+			return feeCapCmp
+		}
+		return a.GasTipCapCmp(b)
+	}
+	rates := ratesAndFees.Rates
+	if goldBaseFee != nil {
+		tipA := a.EffectiveGasTipValue(ratesAndFees.GetBaseFeeIn(a.inner.feeCurrency()))
+		tipB := b.EffectiveGasTipValue(ratesAndFees.GetBaseFeeIn(b.inner.feeCurrency()))
+		result, _ := exchange.CompareValue(rates, tipA, a.inner.feeCurrency(), tipB, b.inner.feeCurrency())
+		return result
+	}
+
+	// Compare fee caps if baseFee is not specified or effective tips are equal
+	feeA := a.inner.gasFeeCap()
+	feeB := b.inner.gasFeeCap()
+	c, _ := exchange.CompareValue(rates, feeA, a.inner.feeCurrency(), feeB, b.inner.feeCurrency())
+	if c != 0 {
+		return c
+	}
+
+	// Compare tips if effective tips and fee caps are equal
+	tipCapA := a.inner.gasTipCap()
+	tipCapB := b.inner.gasTipCap()
+	result, _ := exchange.CompareValue(rates, tipCapA, a.inner.feeCurrency(), tipCapB, b.inner.feeCurrency())
+	return result
+}

--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -1,14 +1,12 @@
 package types
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common/exchange"
 )
 
 // CompareWithRates compares the effective gas price of two transactions according to the exchange rates and
 // the base fees in the transactions currencies.
-func CompareWithRates(a, b *Transaction, goldBaseFee *big.Int, ratesAndFees *exchange.RatesAndFees) int {
+func CompareWithRates(a, b *Transaction, ratesAndFees *exchange.RatesAndFees) int {
 	if ratesAndFees == nil {
 		// During node startup the ratesAndFees might not be yet setup, compare nominally
 		feeCapCmp := a.GasFeeCapCmp(b)
@@ -18,11 +16,11 @@ func CompareWithRates(a, b *Transaction, goldBaseFee *big.Int, ratesAndFees *exc
 		return a.GasTipCapCmp(b)
 	}
 	rates := ratesAndFees.Rates
-	if goldBaseFee != nil {
+	if ratesAndFees.HasBaseFee() {
 		tipA := a.EffectiveGasTipValue(ratesAndFees.GetBaseFeeIn(a.inner.feeCurrency()))
 		tipB := b.EffectiveGasTipValue(ratesAndFees.GetBaseFeeIn(b.inner.feeCurrency()))
-		result, _ := exchange.CompareValue(rates, tipA, a.inner.feeCurrency(), tipB, b.inner.feeCurrency())
-		return result
+		c, _ := exchange.CompareValue(rates, tipA, a.inner.feeCurrency(), tipB, b.inner.feeCurrency())
+		return c
 	}
 
 	// Compare fee caps if baseFee is not specified or effective tips are equal
@@ -36,6 +34,6 @@ func CompareWithRates(a, b *Transaction, goldBaseFee *big.Int, ratesAndFees *exc
 	// Compare tips if effective tips and fee caps are equal
 	tipCapA := a.inner.gasTipCap()
 	tipCapB := b.inner.gasTipCap()
-	result, _ := exchange.CompareValue(rates, tipCapA, a.inner.feeCurrency(), tipCapB, b.inner.feeCurrency())
-	return result
+	c2, _ := exchange.CompareValue(rates, tipCapA, a.inner.feeCurrency(), tipCapB, b.inner.feeCurrency())
+	return c2
 }


### PR DESCRIPTION
Due to the comparison function being outside of the types package, the inner fields 'tx.inner.gasFeeCap()' weren't available, and the ones used were the such as 'tx.GasFeeCap()' which instantiates a new big int with the same value. Same for 'FeeCurrency()' and others.

This PR moves the comparison function to the same package, while also adding a local cache to the converted baseFees to avoid exchanging the same value more than once.