### PR TITLE
Validate debitGasFees execution in tx pool

### DIFF
--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/contracts/celo/abigen"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -21,6 +22,17 @@ const (
 	// Calculated to estimate 1 balance read, 1 debit, and 4 credit transactions.
 	IntrinsicGasForAlternativeFeeCurrency uint64 = 50 * Thousand
 )
+
+// Returns nil if debit is possible, used in tx pool validation
+func TryDebitFees(tx *types.Transaction, from common.Address, backend *CeloBackend) error {
+	amount := new(big.Int).SetUint64(tx.Gas())
+	amount.Mul(amount, tx.GasFeeCap())
+
+	snapshot := backend.State.Snapshot()
+	err := DebitFees(backend.NewEVM(), tx.FeeCurrency(), from, amount)
+	backend.State.RevertToSnapshot(snapshot)
+	return err
+}
 
 // Debits transaction fees from the transaction sender and stores them in the temporary address
 func DebitFees(evm *vm.EVM, feeCurrency *common.Address, address common.Address, amount *big.Int) error {

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -1,7 +1,6 @@
 package contracts
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -23,6 +22,16 @@ const (
 	IntrinsicGasForAlternativeFeeCurrency uint64 = 50 * Thousand
 )
 
+var feeCurrencyABI *abi.ABI
+
+func init() {
+	var err error
+	feeCurrencyABI, err = abigen.FeeCurrencyMetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+}
+
 // Returns nil if debit is possible, used in tx pool validation
 func TryDebitFees(tx *types.Transaction, from common.Address, backend *CeloBackend) error {
 	amount := new(big.Int).SetUint64(tx.Gas())
@@ -39,27 +48,14 @@ func DebitFees(evm *vm.EVM, feeCurrency *common.Address, address common.Address,
 	if amount.Cmp(big.NewInt(0)) == 0 {
 		return nil
 	}
-	tokenAbi, err := abigen.FeeCurrencyMetaData.GetAbi()
-	if err != nil {
-		return err
-	}
-	// Solidity: function debitGasFees(address from, uint256 value)
-	input, err := tokenAbi.Pack("debitGasFees", address, amount)
-	if err != nil {
-		return fmt.Errorf("pack debitGasFees: %w", err)
-	}
 
-	caller := vm.AccountRef(common.ZeroAddress)
-
-	ret, leftoverGas, err := evm.Call(caller, *feeCurrency, input, maxGasForDebitGasFeesTransactions, big.NewInt(0))
+	leftoverGas, err := evm.CallWithABI(
+		feeCurrencyABI, "debitGasFees", *feeCurrency, maxGasForDebitGasFeesTransactions,
+		// debitGasFees(address from, uint256 value) parameters
+		address, amount,
+	)
 	gasUsed := maxGasForDebitGasFeesTransactions - leftoverGas
 	log.Trace("DebitFees called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
-	if err != nil {
-		revertReason, err2 := abi.UnpackRevert(ret)
-		if err2 == nil {
-			return fmt.Errorf("DebitFees reverted: %s", revertReason)
-		}
-	}
 	return err
 }
 
@@ -82,35 +78,22 @@ func CreditFees(
 		feeTip = new(big.Int).Add(feeTip, l1DataFee)
 	}
 
-	tokenAbi, err := abigen.FeeCurrencyMetaData.GetAbi()
-	if err != nil {
-		return err
-	}
-	// Solidity:
-	// function creditGasFees(
-	// 	address from,
-	// 	address feeRecipient,
-	// 	address, // gatewayFeeRecipient, unused
-	// 	address communityFund,
-	// 	uint256 refund,
-	// 	uint256 tipTxFee,
-	// 	uint256, // gatewayFee, unused
-	// 	uint256 baseTxFee
-	// )
-	input, err := tokenAbi.Pack("creditGasFees", txSender, tipReceiver, common.ZeroAddress, baseFeeReceiver, refund, feeTip, common.Big0, baseFee)
-	if err != nil {
-		return fmt.Errorf("pack creditGasFees: %w", err)
-	}
+	leftoverGas, err := evm.CallWithABI(
+		feeCurrencyABI, "creditGasFees", *feeCurrency, maxGasForCreditGasFeesTransactions,
+		// function creditGasFees(
+		// 	address from,
+		// 	address feeRecipient,
+		// 	address, // gatewayFeeRecipient, unused
+		// 	address communityFund,
+		// 	uint256 refund,
+		// 	uint256 tipTxFee,
+		// 	uint256, // gatewayFee, unused
+		// 	uint256 baseTxFee
+		// )
+		txSender, tipReceiver, common.ZeroAddress, baseFeeReceiver, refund, feeTip, common.Big0, baseFee,
+	)
 
-	caller := vm.AccountRef(common.ZeroAddress)
-	ret, leftoverGas, err := evm.Call(caller, *feeCurrency, input, maxGasForCreditGasFeesTransactions, big.NewInt(0))
 	gasUsed := maxGasForCreditGasFeesTransactions - leftoverGas
 	log.Trace("CreditFees called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
-	if err != nil {
-		revertReason, err2 := abi.UnpackRevert(ret)
-		if err2 == nil {
-			return fmt.Errorf("CreditFees reverted: %s", revertReason)
-		}
-	}
 	return err
 }

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -113,6 +113,7 @@ func celoGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			Code:    feeCurrencyWhitelistBytecode,
 			Balance: big.NewInt(0),
 			Storage: map[common.Hash]common.Hash{
+				common.HexToHash("0x0"):                               DevAddr32,                                   // `_owner` slot
 				common.HexToHash("0x1"):                               common.HexToHash("0x1"),                     // array length 1
 				crypto.Keccak256Hash(common.HexToHash("0x1").Bytes()): common.BytesToHash(FeeCurrencyAddr.Bytes()), // FeeCurrency
 			},

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -685,6 +685,14 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
 		return err
 	}
+	if tx.FeeCurrency() != nil {
+		from, err := pool.signer.Sender(tx) // already validated (and cached), but cleaner to check
+		if err != nil {
+			log.Error("Transaction sender recovery failed", "err", err)
+			return err
+		}
+		return contracts.TryDebitFees(tx, from, pool.celoBackend)
+	}
 	return nil
 }
 

--- a/core/vm/celo_evm.go
+++ b/core/vm/celo_evm.go
@@ -1,0 +1,30 @@
+package vm
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Call function from ABI and check revert message after call.
+// ABIs can be found at contracts/celo/abigen, e.g. abigen.FeeCurrencyMetaData.GetAbi().
+// args are passed through to the EVM function.
+func (evm *EVM) CallWithABI(contractABI *abi.ABI, funcName string, addr common.Address, gas uint64, args ...interface{}) (leftOverGas uint64, err error) {
+	caller := AccountRef(common.ZeroAddress)
+	input, err := contractABI.Pack(funcName, args...)
+	if err != nil {
+		return 0, fmt.Errorf("pack %s: %w", funcName, err)
+	}
+
+	ret, leftOverGas, err := evm.Call(caller, addr, input, gas, big.NewInt(0))
+	if err != nil {
+		revertReason, err2 := abi.UnpackRevert(ret)
+		if err2 == nil {
+			return 0, fmt.Errorf("%s reverted: %s", funcName, revertReason)
+		}
+	}
+
+	return leftOverGas, err
+}


### PR DESCRIPTION
### Description
Txs must not fail during debitGasFees execution during the state transition, so we must remove problematic txs during the tx pool validation. We do this by executing debitGasFees inside the tx pool validation and discarding the resulting state changes. This is not overly efficient, but still better than the alternatives that have been considered so far.

### Other changges
* Added `EVM.CallWithAbi` to make it easier to run state-modifying calls against our contracts.
* Configured an owner for the whitelist in dev mode. Helpful for whitelisting new currencies.

### Testing
Only manually tested against a fee currency that always fails in debit. It fails during tx sending with the fee currencies revert message.