### PR TITLE
Add tests for Celo block receipt

### DIFF
--- a/compat_tests/compat_test.go
+++ b/compat_tests/compat_test.go
@@ -56,13 +56,19 @@ func TestCompatibilityOfChain(t *testing.T) {
 			incrementalLogs = append(incrementalLogs, r.Logs...)
 		}
 		// Get the Celo block receipt. See https://docs.celo.org/developer/migrate/from-ethereum#core-contract-calls
-		res, err = rpcCall(c, dumpOutput, "eth_getTransactionReceipt", blockHash.Hash)
+		res, err = rpcCall(c, dumpOutput, "eth_getBlockReceipt", blockHash.Hash)
 		require.NoError(t, err)
 		if string(res) != "null" {
 			r := types.Receipt{}
 			err = json.Unmarshal(res, &r)
 			require.NoError(t, err)
-			incrementalBlockReceipts = append(incrementalBlockReceipts, &r)
+			if len(r.Logs) > 0 {
+				// eth_getBlockReceipt generates an empty receipt when there
+				// are no logs, we want to avoid adding these here since the
+				// same is not done in eth_gethBlockReceipts, the output of
+				// which we will later compare against.
+				incrementalBlockReceipts = append(incrementalBlockReceipts, &r)
+			}
 			incrementalLogs = append(incrementalLogs, r.Logs...)
 		}
 

--- a/compat_tests/compat_test.go
+++ b/compat_tests/compat_test.go
@@ -35,6 +35,8 @@ func TestCompatibilityOfChain(t *testing.T) {
 	for i := startBlock; i <= startBlock+amount; i++ {
 		res, err := rpcCall(c, dumpOutput, "eth_getBlockByNumber", hexutil.EncodeUint64(i), true)
 		require.NoError(t, err)
+		// Check we got a block
+		require.NotEqual(t, "null", string(res), "block %d should not be null", i)
 		blockHash := blockHash{}
 		err = json.Unmarshal(res, &blockHash)
 		require.NoError(t, err)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -998,7 +998,8 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 		return nil, err
 	}
 	txs := block.Transactions()
-	if len(txs) != len(receipts) {
+	// Legacy Celo blocks sometimes include an extra block receipt. See https://docs.celo.org/developer/migrate/from-ethereum#core-contract-calls
+	if len(txs) != len(receipts) && len(txs)+1 != len(receipts) {
 		return nil, fmt.Errorf("receipts length mismatch: %d vs %d", len(txs), len(receipts))
 	}
 
@@ -1007,9 +1008,12 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 
 	result := make([]map[string]interface{}, len(receipts))
 	for i, receipt := range receipts {
-		result[i] = marshalReceipt(receipt, block.Hash(), block.NumberU64(), signer, txs[i], i, s.b.ChainConfig())
+		if i == len(txs) {
+			result[i] = marshalBlockReceipt(receipt, block.Hash(), block.NumberU64(), signer, i, s.b.ChainConfig())
+		} else {
+			result[i] = marshalReceipt(receipt, block.Hash(), block.NumberU64(), signer, txs[i], i, s.b.ChainConfig())
+		}
 	}
-
 	return result, nil
 }
 
@@ -1989,6 +1993,24 @@ func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
 	if tx == nil || err != nil {
+		block, err := s.b.BlockByHash(ctx, hash)
+		if err != nil {
+			return nil, err
+		}
+		if block != nil {
+			// User is attempting to fetch a celo block receipt. See https://docs.celo.org/developer/migrate/from-ethereum#core-contract-calls
+			receipts, err := s.b.GetReceipts(ctx, hash)
+			if err != nil {
+				return nil, err
+			}
+			if len(receipts) > 0 {
+				i := len(receipts) - 1
+				if len(receipts[i].Logs) > 0 && receipts[i].Logs[0].TxHash == hash {
+					signer := types.MakeSigner(s.b.ChainConfig(), block.Number(), block.Time())
+					return marshalBlockReceipt(receipts[i], hash, block.NumberU64(), signer, i, s.b.ChainConfig()), nil
+				}
+			}
+		}
 		// When the transaction doesn't exist, the RPC method should return JSON null
 		// as per specification.
 		return nil, nil
@@ -2065,6 +2087,34 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 	if receipt.ContractAddress != (common.Address{}) {
 		fields["contractAddress"] = receipt.ContractAddress
 	}
+	return fields
+}
+
+// marshalBlockReceipt marshals a Celo block receipt into a JSON object. See https://docs.celo.org/developer/migrate/from-ethereum#core-contract-calls
+func marshalBlockReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber uint64, signer types.Signer, index int, chainConfig *params.ChainConfig) map[string]interface{} {
+
+	fields := map[string]interface{}{
+		"blockHash":         blockHash,
+		"blockNumber":       hexutil.Uint64(blockNumber),
+		"transactionHash":   blockHash,
+		"transactionIndex":  hexutil.Uint64(index),
+		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
+		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
+		"logs":              receipt.Logs,
+		"logsBloom":         receipt.Bloom,
+		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
+	}
+
+	// Assign receipt status or post state.
+	if len(receipt.PostState) > 0 {
+		fields["root"] = hexutil.Bytes(receipt.PostState)
+	} else {
+		fields["status"] = hexutil.Uint(receipt.Status)
+	}
+	if receipt.Logs == nil {
+		fields["logs"] = []*types.Log{}
+	}
+
 	return fields
 }
 

--- a/internal/ethapi/celo_extensions.go
+++ b/internal/ethapi/celo_extensions.go
@@ -1,0 +1,60 @@
+package ethapi
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// GetBlockReceipt returns "system calls" receipt for the block with the given block hash.
+func (s *BlockChainAPI) GetBlockReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+	block, err := s.b.BlockByHash(ctx, hash)
+	if block == nil || err != nil {
+		// If no header with that hash is found, err gives "header for hash not found".
+		// But we return nil with no error, to match the behavior of eth_getBlockByHash and eth_getTransactionReceipt in these cases.
+		return nil, nil
+	}
+	index := block.Transactions().Len()
+	blockNumber := block.NumberU64()
+	receipts, err := s.b.GetReceipts(ctx, block.Hash())
+	// GetReceipts() doesn't return an error if things go wrong, so we also check len(receipts)
+	if err != nil || len(receipts) < index {
+		return nil, err
+	}
+
+	var receipt *types.Receipt
+	if len(receipts) == int(index) {
+		// The block didn't have any logs from system calls and no receipt was created.
+		// So we create an empty receipt to return, similarly to how system receipts are created.
+		receipt = types.NewReceipt(nil, false, 0)
+		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	} else {
+		receipt = receipts[index]
+	}
+	return marshalBlockReceipt(receipt, hash, blockNumber, index), nil
+}
+
+// marshalBlockReceipt marshals a Celo block receipt into a JSON object. See https://docs.celo.org/developer/migrate/from-ethereum#core-contract-calls
+func marshalBlockReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber uint64, index int) map[string]interface{} {
+	fields := map[string]interface{}{
+		"blockHash":         blockHash,
+		"blockNumber":       hexutil.Uint64(blockNumber),
+		"transactionHash":   blockHash,
+		"transactionIndex":  hexutil.Uint64(index),
+		"from":              common.Address{},
+		"to":                nil,
+		"gasUsed":           hexutil.Uint64(0),
+		"cumulativeGasUsed": hexutil.Uint64(0),
+		"contractAddress":   nil,
+		"logs":              receipt.Logs,
+		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(0),
+		"status":            hexutil.Uint(types.ReceiptStatusSuccessful),
+	}
+	if receipt.Logs == nil {
+		fields["logs"] = []*types.Log{}
+	}
+	return fields
+}


### PR DESCRIPTION
Had to make some changes to the API handlers to make these tests work. These changes actually didn't exist in celo-blockchain which indicates these api methods have never supported fetching the celo block receipt to begin with. Not sure if we'll want to keep all of this but it works! 