### PR TITLE
Work around zero coinbase address in creditGasFees

### DIFF
--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -78,6 +78,12 @@ func CreditFees(
 		feeTip = new(big.Int).Add(feeTip, l1DataFee)
 	}
 
+	// Not all fee currencies can handle a receiver being the zero address.
+	// In that case send the fee to the base fee recipient, which we know is non-zero.
+	if tipReceiver.Cmp(common.ZeroAddress) == 0 {
+		tipReceiver = baseFeeReceiver
+	}
+
 	leftoverGas, err := evm.CallWithABI(
 		feeCurrencyABI, "creditGasFees", *feeCurrency, maxGasForCreditGasFeesTransactions,
 		// function creditGasFees(


### PR DESCRIPTION
Not all fee currencies can accept zero addresses as recipients. To avoid problems, send the tip to the base fee recipient.

As suggested in https://github.com/celo-org/fee-currency-example/issues/4#issuecomment-1906362365