### PR TITLE
Reduce maxGas for debit and credit

### DIFF
--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -57,6 +57,7 @@ func DebitFees(evm *vm.EVM, feeCurrency *common.Address, address common.Address,
 		address, amount,
 	)
 	gasUsed := maxGasForDebitGasFeesTransactions - leftoverGas
+	evm.Context.GasUsedForDebit = gasUsed
 	log.Trace("DebitFees called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
 	return err
 }
@@ -103,6 +104,11 @@ func CreditFees(
 
 	gasUsed := maxGasForCreditGasFeesTransactions - leftoverGas
 	log.Trace("CreditFees called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
+
+	gasUsedForDebitAndCredit := evm.Context.GasUsedForDebit + gasUsed
+	if gasUsedForDebitAndCredit > IntrinsicGasForAlternativeFeeCurrency {
+		log.Info("Gas usage for debit+credit exceeds intrinsic gas!", "gasUsed", gasUsedForDebitAndCredit, "intrinsicGas", IntrinsicGasForAlternativeFeeCurrency, "feeCurrency", feeCurrency)
+	}
 	return err
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -93,7 +93,8 @@ type BlockContext struct {
 	Random      *common.Hash   // Provides information for PREVRANDAO
 
 	// Celo specific information
-	ExchangeRates common.ExchangeRates
+	ExchangeRates   common.ExchangeRates
+	GasUsedForDebit uint64
 }
 
 // TxContext provides the EVM with information about a transaction.


### PR DESCRIPTION
Failures in `debitGasFees` won't be paid by the tx sender, so we should not allow more gas usage there then necessary. Three times the `IntrinsicGasForFeeCurrency` is both much lower than the previous value and high enough to be safe.

Also adds logging for the case that the gas usage exceeds `IntrinsicGasForFeeCurrency`.

Closes https://github.com/celo-org/op-geth/issues/70