### PR TITLE
Improve state transition logs

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -229,7 +229,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
 func ApplyMessage(evm *vm.EVM, msg *Message, gp *GasPool) (*ExecutionResult, error) {
-	log.Trace("Applying state transition message", "from", msg.From, "nonce", msg.Nonce, "to", msg.To, "gas price", msg.GasPrice, "fee currency", msg.FeeCurrency, "gas", msg.GasLimit, "value", msg.Value, "data", msg.Data)
+	log.Trace("Applying state transition message", "from", msg.From, "nonce", msg.Nonce, "to", msg.To, "gasPrice", msg.GasPrice, "feeCurrency", msg.FeeCurrency, "gas", msg.GasLimit, "value", msg.Value, "data", msg.Data)
 	return NewStateTransition(evm, msg, gp).TransitionDb()
 }
 


### PR DESCRIPTION
Before the spaces in logged field names made the filed names being quouted:
```
  TRACE[04-16|17:51:22.853] Applying state transition message        from=0x71562b71999873DB5b286dF957af199Ec94617F7 nonce=0 to=0x4e59b44847b379578588920cA78FbF26c0B4956C "gas price"=875,000,001 "fee currency"=nil gas=2,054,186  value=0 data="[0 0
```