### PR TITLE
Segregate celo transactions

### DIFF
--- a/core/types/celo_dynamic_fee_tx.go
+++ b/core/types/celo_dynamic_fee_tx.go
@@ -113,5 +113,3 @@ func (tx *CeloDynamicFeeTx) encode(b *bytes.Buffer) error {
 func (tx *CeloDynamicFeeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
-
-func (tx *CeloDynamicFeeTx) feeCurrency() *common.Address { return tx.FeeCurrency }

--- a/core/types/celo_extensions.go
+++ b/core/types/celo_extensions.go
@@ -1,0 +1,6 @@
+package types
+
+const (
+	// CeloDynamicFeeTxType = 0x7c  old Celo tx type with gateway fee
+	CeloDynamicFeeTxType = 0x7b
+)

--- a/core/types/celo_extensions.go
+++ b/core/types/celo_extensions.go
@@ -1,6 +1,20 @@
 package types
 
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
 const (
 	// CeloDynamicFeeTxType = 0x7c  old Celo tx type with gateway fee
 	CeloDynamicFeeTxType = 0x7b
 )
+
+// Returns the fee currency of the transaction if there is one.
+func (tx *Transaction) FeeCurrency() *common.Address {
+	var feeCurrency *common.Address
+	switch t := tx.inner.(type) {
+	case *CeloDynamicFeeTx:
+		feeCurrency = t.FeeCurrency
+	}
+	return feeCurrency
+}

--- a/core/types/celo_transaction_marshalling.go
+++ b/core/types/celo_transaction_marshalling.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+func celoTransactionMarshal(tx *Transaction) ([]byte, bool, error) {
+	var enc txJSON
+	// These are set for all tx types.
+	enc.Hash = tx.Hash()
+	enc.Type = hexutil.Uint64(tx.Type())
+	switch itx := tx.inner.(type) {
+	case *CeloDynamicFeeTx:
+		enc.ChainID = (*hexutil.Big)(itx.ChainID)
+		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
+		enc.To = tx.To()
+		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
+		enc.MaxFeePerGas = (*hexutil.Big)(itx.GasFeeCap)
+		enc.MaxPriorityFeePerGas = (*hexutil.Big)(itx.GasTipCap)
+		enc.FeeCurrency = itx.FeeCurrency
+		enc.Value = (*hexutil.Big)(itx.Value)
+		enc.Input = (*hexutil.Bytes)(&itx.Data)
+		enc.AccessList = &itx.AccessList
+		enc.V = (*hexutil.Big)(itx.V)
+		enc.R = (*hexutil.Big)(itx.R)
+		enc.S = (*hexutil.Big)(itx.S)
+	default:
+		return nil, false, nil
+	}
+	bytes, err := json.Marshal(&enc)
+	return bytes, true, err
+}
+
+func celoTransactionUnmarshal(dec txJSON, inner *TxData) (bool, error) {
+	switch dec.Type {
+	case CeloDynamicFeeTxType:
+		var itx CeloDynamicFeeTx
+		*inner = &itx
+		if dec.ChainID == nil {
+			return true, errors.New("missing required field 'chainId' in transaction")
+		}
+		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.Nonce == nil {
+			return true, errors.New("missing required field 'nonce' in transaction")
+		}
+		itx.Nonce = uint64(*dec.Nonce)
+		if dec.To != nil {
+			itx.To = dec.To
+		}
+		if dec.Gas == nil {
+			return true, errors.New("missing required field 'gas' for txdata")
+		}
+		itx.Gas = uint64(*dec.Gas)
+		if dec.MaxPriorityFeePerGas == nil {
+			return true, errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
+		}
+		itx.GasTipCap = (*big.Int)(dec.MaxPriorityFeePerGas)
+		if dec.MaxFeePerGas == nil {
+			return true, errors.New("missing required field 'maxFeePerGas' for txdata")
+		}
+		itx.GasFeeCap = (*big.Int)(dec.MaxFeePerGas)
+		if dec.Value == nil {
+			return true, errors.New("missing required field 'value' in transaction")
+		}
+		itx.FeeCurrency = dec.FeeCurrency
+		itx.Value = (*big.Int)(dec.Value)
+		if dec.Input == nil {
+			return true, errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Input
+		if dec.V == nil {
+			return true, errors.New("missing required field 'v' in transaction")
+		}
+		if dec.AccessList != nil {
+			itx.AccessList = *dec.AccessList
+		}
+		itx.V = (*big.Int)(dec.V)
+		if dec.R == nil {
+			return true, errors.New("missing required field 'r' in transaction")
+		}
+		itx.R = (*big.Int)(dec.R)
+		if dec.S == nil {
+			return true, errors.New("missing required field 's' in transaction")
+		}
+		itx.S = (*big.Int)(dec.S)
+		withSignature := itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0
+		if withSignature {
+			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
+				return true, err
+			}
+		}
+	default:
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/core/types/celo_transaction_marshalling.go
+++ b/core/types/celo_transaction_marshalling.go
@@ -99,3 +99,15 @@ func celoTransactionUnmarshal(dec txJSON, inner *TxData) (bool, error) {
 
 	return true, nil
 }
+
+func celoDecodeTyped(b []byte) (TxData, bool, error) {
+	var inner TxData
+	switch b[0] {
+	case CeloDynamicFeeTxType:
+		inner = new(CeloDynamicFeeTx)
+	default:
+		return nil, false, nil
+	}
+	err := inner.decode(b[1:])
+	return inner, true, err
+}

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -85,7 +85,7 @@ func (s cel2Signer) Hash(tx *Transaction) common.Hash {
 				tx.Value(),
 				tx.Data(),
 				tx.AccessList(),
-				tx.FeeCurrency(),
+				tx.inner.(*CeloDynamicFeeTx).FeeCurrency,
 			})
 	}
 	return s.londonSigner.Hash(tx)

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -85,7 +85,7 @@ func (s cel2Signer) Hash(tx *Transaction) common.Hash {
 				tx.Value(),
 				tx.Data(),
 				tx.AccessList(),
-				tx.inner.(*CeloDynamicFeeTx).FeeCurrency,
+				tx.FeeCurrency(),
 			})
 	}
 	return s.londonSigner.Hash(tx)

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -101,5 +101,3 @@ func (tx *DepositTx) encode(b *bytes.Buffer) error {
 func (tx *DepositTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
-
-func (tx *DepositTx) feeCurrency() *common.Address { return nil }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -200,14 +200,17 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 	if len(b) <= 1 {
 		return nil, errShortTypedTx
 	}
+
+	if inner, isCelo, err := celoDecodeTyped(b); isCelo {
+		return inner, err
+	}
+
 	var inner TxData
 	switch b[0] {
 	case AccessListTxType:
 		inner = new(AccessListTx)
 	case DynamicFeeTxType:
 		inner = new(DynamicFeeTx)
-	case CeloDynamicFeeTxType:
-		inner = new(CeloDynamicFeeTx)
 	case BlobTxType:
 		inner = new(BlobTx)
 	case DepositTxType:

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -47,8 +47,6 @@ const (
 	AccessListTxType = 0x01
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
-	// CeloDynamicFeeTxType = 0x7c  old Celo tx type with gateway fee
-	CeloDynamicFeeTxType = 0x7b
 )
 
 // Transaction is an Ethereum transaction.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -104,9 +104,6 @@ type TxData interface {
 
 	encode(*bytes.Buffer) error
 	decode([]byte) error
-
-	// Celo specific fields
-	feeCurrency() *common.Address
 }
 
 // EncodeRLP implements rlp.Encoder
@@ -599,11 +596,6 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	cpy := tx.inner.copy()
 	cpy.setSignatureValues(signer.ChainID(), v, r, s)
 	return &Transaction{inner: cpy, time: tx.time}, nil
-}
-
-// FeeCurrency returns the fee currency of the transaction. Nil implies paying in CELO.
-func (tx *Transaction) FeeCurrency() *common.Address {
-	return copyAddressPtr(tx.inner.feeCurrency())
 }
 
 // Transactions implements DerivableList for transactions.

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -84,6 +84,9 @@ func (tx *txJSON) yParityValue() (*big.Int, error) {
 
 // MarshalJSON marshals as JSON with a hash.
 func (tx *Transaction) MarshalJSON() ([]byte, error) {
+	if marshalled, isCelo, err := celoTransactionMarshal(tx); isCelo {
+		return marshalled, err
+	}
 	var enc txJSON
 	// These are set for all tx types.
 	enc.Hash = tx.Hash()
@@ -136,21 +139,6 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		yparity := itx.V.Uint64()
 		enc.YParity = (*hexutil.Uint64)(&yparity)
 
-	case *CeloDynamicFeeTx:
-		enc.ChainID = (*hexutil.Big)(itx.ChainID)
-		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
-		enc.To = tx.To()
-		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
-		enc.MaxFeePerGas = (*hexutil.Big)(itx.GasFeeCap)
-		enc.MaxPriorityFeePerGas = (*hexutil.Big)(itx.GasTipCap)
-		enc.FeeCurrency = tx.FeeCurrency()
-		enc.Value = (*hexutil.Big)(itx.Value)
-		enc.Input = (*hexutil.Bytes)(&itx.Data)
-		enc.AccessList = &itx.AccessList
-		enc.V = (*hexutil.Big)(itx.V)
-		enc.R = (*hexutil.Big)(itx.R)
-		enc.S = (*hexutil.Big)(itx.S)
-
 	case *BlobTx:
 		enc.ChainID = (*hexutil.Big)(itx.ChainID.ToBig())
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
@@ -194,6 +182,12 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 
 	// Decode / verify fields according to transaction type.
 	var inner TxData
+
+	if isCelo, err := celoTransactionUnmarshal(dec, &inner); isCelo {
+		tx.setDecoded(inner, 0)
+		return err
+	}
+
 	switch dec.Type {
 	case LegacyTxType:
 		var itx LegacyTx
@@ -355,63 +349,6 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return err
 		}
 		if itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0 {
-			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
-				return err
-			}
-		}
-
-	case CeloDynamicFeeTxType:
-		var itx CeloDynamicFeeTx
-		inner = &itx
-		if dec.ChainID == nil {
-			return errors.New("missing required field 'chainId' in transaction")
-		}
-		itx.ChainID = (*big.Int)(dec.ChainID)
-		if dec.Nonce == nil {
-			return errors.New("missing required field 'nonce' in transaction")
-		}
-		itx.Nonce = uint64(*dec.Nonce)
-		if dec.To != nil {
-			itx.To = dec.To
-		}
-		if dec.Gas == nil {
-			return errors.New("missing required field 'gas' for txdata")
-		}
-		itx.Gas = uint64(*dec.Gas)
-		if dec.MaxPriorityFeePerGas == nil {
-			return errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
-		}
-		itx.GasTipCap = (*big.Int)(dec.MaxPriorityFeePerGas)
-		if dec.MaxFeePerGas == nil {
-			return errors.New("missing required field 'maxFeePerGas' for txdata")
-		}
-		itx.GasFeeCap = (*big.Int)(dec.MaxFeePerGas)
-		if dec.Value == nil {
-			return errors.New("missing required field 'value' in transaction")
-		}
-		itx.FeeCurrency = dec.FeeCurrency
-		itx.Value = (*big.Int)(dec.Value)
-		if dec.Input == nil {
-			return errors.New("missing required field 'input' in transaction")
-		}
-		itx.Data = *dec.Input
-		if dec.V == nil {
-			return errors.New("missing required field 'v' in transaction")
-		}
-		if dec.AccessList != nil {
-			itx.AccessList = *dec.AccessList
-		}
-		itx.V = (*big.Int)(dec.V)
-		if dec.R == nil {
-			return errors.New("missing required field 'r' in transaction")
-		}
-		itx.R = (*big.Int)(dec.R)
-		if dec.S == nil {
-			return errors.New("missing required field 's' in transaction")
-		}
-		itx.S = (*big.Int)(dec.S)
-		withSignature := itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0
-		if withSignature {
 			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
 				return err
 			}

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -128,5 +128,3 @@ func (tx *AccessListTx) encode(b *bytes.Buffer) error {
 func (tx *AccessListTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
-
-func (tx *AccessListTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -245,5 +245,3 @@ func blobHash(commit *kzg4844.Commitment) common.Hash {
 	vhash[0] = params.BlobTxHashVersion
 	return vhash
 }
-
-func (tx *BlobTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -124,5 +124,3 @@ func (tx *DynamicFeeTx) encode(b *bytes.Buffer) error {
 func (tx *DynamicFeeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
-
-func (tx *DynamicFeeTx) feeCurrency() *common.Address { return nil }

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -124,5 +124,3 @@ func (tx *LegacyTx) encode(*bytes.Buffer) error {
 func (tx *LegacyTx) decode([]byte) error {
 	panic("decode called on LegacyTx)")
 }
-
-func (tx *LegacyTx) feeCurrency() *common.Address { return nil }


### PR DESCRIPTION
This PR attempts to better segregate custom tx celo code from op-geth code.

To make this comparison this PR builds on top of the initial addition of celo tx support to the op-geth codebase, trying to reach a diff that is less intrusive/intertwined.

Going forward having a less intertwined diff should reduce merge conflicts and thereby speed up pulling in upstream changes as well as making it less likely that bugs arise out of the merging process.

It's not intended to be merged, merely to serve as an example of an approach we could take, so please comment with your thoughts.

It's useful to view the diff created by the initial addition of celo transaction support and the diff with these changes incorporated to see how they differ in modifications to op-geth owned files.

[Initial celo transaction support](https://github.com/celo-org/op-geth/compare/14305657f9981b1dca61be00f1291ce575e05b57...celo-org:op-geth:bf630a8b5e57fe84210842d3998234165ffad371)
[celo transaction support more segregated](https://github.com/celo-org/op-geth/compare/14305657f9981b1dca61be00f1291ce575e05b57...celo-org:op-geth:2a6568a238f2b79796d80d6a8b5d424a08272d54)

