### PR TITLE
txpool: Check for fee currency and native cost

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -117,7 +117,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 		id:         id,
 		size:       size,
 		nonce:      tx.Nonce(),
-		costCap:    uint256.MustFromBig(tx.Cost()),
+		costCap:    uint256.MustFromBig(tx.NativeCost()),
 		execTipCap: uint256.MustFromBig(tx.GasTipCap()),
 		execFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
 		blobFeeCap: uint256.MustFromBig(tx.BlobGasFeeCap()),
@@ -1114,18 +1114,18 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 			}
 			return have, maxTxsPerAccount - have
 		},
-		ExistingExpenditure: func(addr common.Address) *big.Int {
+		ExistingExpenditure: func(addr common.Address) (*big.Int, *big.Int) {
 			if spent := p.spent[addr]; spent != nil {
-				return spent.ToBig()
+				return new(big.Int), spent.ToBig()
 			}
-			return new(big.Int)
+			return new(big.Int), new(big.Int)
 		},
-		ExistingCost: func(addr common.Address, nonce uint64) *big.Int {
+		ExistingCost: func(addr common.Address, nonce uint64) (*big.Int, *big.Int) {
 			next := p.state.GetNonce(addr)
 			if uint64(len(p.index[addr])) > nonce-next {
-				return p.index[addr][int(tx.Nonce()-next)].costCap.ToBig()
+				return new(big.Int), p.index[addr][int(tx.Nonce()-next)].costCap.ToBig()
 			}
-			return nil
+			return nil, nil
 		},
 		ExistingBalance: func(addr common.Address, feeCurrency *common.Address) *big.Int {
 			return contracts.GetFeeBalance(p.celoBackend, addr, feeCurrency)

--- a/core/txpool/legacypool/celo_list.go
+++ b/core/txpool/legacypool/celo_list.go
@@ -43,6 +43,7 @@ func (l *list) dropInvalidsAfterRemovalAndReheap(removed types.Transactions) typ
 
 func (l *list) FeeCurrencies() []common.Address {
 	currencySet := make(map[common.Address]interface{})
+	currencySet[getCurrencyKey(nil)] = struct{}{} // Always include native token to handle potential value transfers
 	for _, tx := range l.txs.items {
 		// native currency (nil) represented as Zero address
 		currencySet[getCurrencyKey(tx.FeeCurrency())] = struct{}{}

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -62,7 +62,8 @@ func TestListAddVeryExpensive(t *testing.T) {
 		gasprice, _ := new(big.Int).SetString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0)
 		gaslimit := uint64(i)
 		tx, _ := types.SignTx(types.NewTransaction(uint64(i), common.Address{}, value, gaslimit, gasprice, nil), types.HomesteadSigner{}, key)
-		t.Logf("cost: %x bitlen: %d\n", tx.Cost(), tx.Cost().BitLen())
+		costFeeCurrency, costNative := tx.Cost()
+		t.Logf("cost: %x %x\n", costFeeCurrency, costNative)
 		list.Add(tx, DefaultConfig.PriceBump, nil, nil)
 	}
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -217,11 +217,21 @@ type ValidationOptionsWithState struct {
 
 	// ExistingExpenditure is a mandatory callback to retrieve the cumulative
 	// cost of the already pooled transactions to check for overdrafts.
-	ExistingExpenditure func(addr common.Address) *big.Int
+	// Returns (feeCurrencySpent, nativeSpent), where feeCurrencySpent only
+	// includes the spending for txs with the relevant feeCurrency.
+	// The feeCurrency relevant for feeCurrencySpent is fixed for every
+	// instance of ExistingExpenditure and therefore not passed in as a
+	// parameter.
+	ExistingExpenditure func(addr common.Address) (*big.Int, *big.Int)
 
 	// ExistingCost is a mandatory callback to retrieve an already pooled
 	// transaction's cost with the given nonce to check for overdrafts.
-	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+	// Returns (feeCurrencyCost, nativeCost), where feeCurrencyCost only
+	// includes the spending for txs with the relevant feeCurrency.
+	// The feeCurrency relevant for feeCurrencyCost is fixed for every
+	// instance of ExistingCost, and therefore not passed in as a
+	// parameter.
+	ExistingCost func(addr common.Address, nonce uint64) (*big.Int, *big.Int)
 
 	// L1CostFn is an optional extension, to validate L1 rollup costs of a tx
 	L1CostFn L1CostFunc
@@ -255,30 +265,45 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	}
 	// Ensure the transactor has enough funds to cover the transaction costs
 	var (
-		balance = opts.ExistingBalance(from, tx.FeeCurrency())
-		cost    = tx.Cost()
+		feeCurrencyBalance          = opts.ExistingBalance(from, tx.FeeCurrency())
+		nativeBalance               = opts.ExistingBalance(from, &common.ZeroAddress)
+		feeCurrencyCost, nativeCost = tx.Cost()
 	)
 	if opts.L1CostFn != nil {
 		if l1Cost := opts.L1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost
-			cost = cost.Add(cost, l1Cost)
+			nativeCost = nativeCost.Add(nativeCost, l1Cost)
 		}
 	}
-	if balance.Cmp(cost) < 0 {
-		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, cost, new(big.Int).Sub(cost, balance))
+	if feeCurrencyBalance.Cmp(feeCurrencyCost) < 0 {
+		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, feeCurrencyBalance, feeCurrencyCost, new(big.Int).Sub(feeCurrencyCost, feeCurrencyBalance))
+	}
+	if nativeBalance.Cmp(nativeCost) < 0 {
+		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, nativeBalance, nativeCost, new(big.Int).Sub(nativeCost, nativeBalance))
 	}
 	// Ensure the transactor has enough funds to cover for replacements or nonce
 	// expansions without overdrafts
-	spent := opts.ExistingExpenditure(from)
-	if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
-		bump := new(big.Int).Sub(cost, prev)
-		need := new(big.Int).Add(spent, bump)
-		if balance.Cmp(need) < 0 {
-			return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", core.ErrInsufficientFunds, balance, spent, bump, new(big.Int).Sub(need, balance))
+	feeCurrencySpent, nativeSpent := opts.ExistingExpenditure(from)
+	if feeCurrencyPrev, nativePrev := opts.ExistingCost(from, tx.Nonce()); feeCurrencyPrev != nil {
+		// Costs from all transactions refer to the same currency,
+		// which is ensured by ExistingCost and ExistingExpenditure.
+		feeCurrencyBump := new(big.Int).Sub(feeCurrencyCost, feeCurrencyPrev)
+		feeCurrencyNeed := new(big.Int).Add(feeCurrencySpent, feeCurrencyBump)
+		nativeBump := new(big.Int).Sub(nativeCost, nativePrev)
+		nativeNeed := new(big.Int).Add(nativeSpent, nativeBump)
+		if feeCurrencyBalance.Cmp(feeCurrencyNeed) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v, feeCurrency %v", core.ErrInsufficientFunds, feeCurrencyBalance, feeCurrencySpent, feeCurrencyBump, new(big.Int).Sub(feeCurrencyNeed, feeCurrencyBalance), tx.FeeCurrency())
+		}
+		if nativeBalance.Cmp(nativeNeed) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", core.ErrInsufficientFunds, nativeBalance, nativeSpent, nativeBump, new(big.Int).Sub(nativeNeed, nativeBalance))
 		}
 	} else {
-		need := new(big.Int).Add(spent, cost)
-		if balance.Cmp(need) < 0 {
-			return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, spent, cost, new(big.Int).Sub(need, balance))
+		feeCurrencyNeed := new(big.Int).Add(feeCurrencySpent, feeCurrencyCost)
+		nativeNeed := new(big.Int).Add(nativeSpent, nativeCost)
+		if feeCurrencyBalance.Cmp(feeCurrencyNeed) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v, feeCurrency %v", core.ErrInsufficientFunds, feeCurrencyBalance, feeCurrencySpent, feeCurrencyCost, new(big.Int).Sub(feeCurrencyNeed, feeCurrencyBalance), tx.FeeCurrency())
+		}
+		if nativeBalance.Cmp(nativeNeed) < 0 {
+			return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, nativeBalance, nativeSpent, nativeCost, new(big.Int).Sub(nativeNeed, nativeBalance))
 		}
 		// Transaction takes a new nonce value out of the pool. Ensure it doesn't
 		// overflow the number of permitted transactions from a single account

--- a/e2e_test/test_viem_tx.sh
+++ b/e2e_test/test_viem_tx.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 source shared.sh
 prepare_node
 
-cd js-tests && ./node_modules/mocha/bin/mocha.js test_viem_tx.mjs
+cd js-tests && ./node_modules/mocha/bin/mocha.js test_viem_tx.mjs --exit


### PR DESCRIPTION
The previous implementation only checked for the costs in fee currency or in native token, but both can happen at the same time when a fee currency tx is created that also sends native tokens to a contract.

Closes https://github.com/celo-org/op-geth/issues/110