### PR TITLE
Fix "feeCurrency" included in non-Celo marshalled tx JSON

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -65,7 +65,7 @@ type txJSON struct {
 	Hash common.Hash `json:"hash"`
 
 	// Celo specific fields
-	FeeCurrency *common.Address `json:"feeCurrency"` // nil means native currency
+	FeeCurrency *common.Address `json:"feeCurrency,omitempty"` // nil means native currency
 }
 
 // yParityValue returns the YParity value from JSON. For backwards-compatibility reasons,

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1142,7 +1142,6 @@ func TestCall(t *testing.T) {
 }
 
 func TestSignTransaction(t *testing.T) {
-	t.Skip("Currently failing, see https://github.com/celo-org/op-geth/issues/117")
 	t.Parallel()
 	// Initialize test accounts
 	var (


### PR DESCRIPTION
Closes #117  

Originally I thought that changing the FeeCurrency `omitempty` marshalling-behavior depending on the tx-type (Celo / non-celo txs) would be more significant code changes (see https://github.com/celo-org/op-geth/issues/117#issuecomment-2098013535). 

Thanks to struct-embedding this does not seem to be the case.