### PR TITLE
CIP-64 / CIP-66 compatible `TransactionArgs`

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -215,7 +215,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 	switch tx.Type() {
 	case types.LegacyTxType, types.AccessListTxType:
 		args.GasPrice = (*hexutil.Big)(tx.GasPrice())
-	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType, types.CeloDenominatedTxType:
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	default:

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -154,15 +154,14 @@ func toWordSize(size uint64) uint64 {
 // A Message contains the data derived from a single transaction that is relevant to state
 // processing.
 type Message struct {
-	To        *common.Address
-	From      common.Address
-	Nonce     uint64
-	Value     *big.Int
-	GasLimit  uint64
-	GasPrice  *big.Int
-	GasFeeCap *big.Int
-	GasTipCap *big.Int
-
+	To            *common.Address
+	From          common.Address
+	Nonce         uint64
+	Value         *big.Int
+	GasLimit      uint64
+	GasPrice      *big.Int
+	GasFeeCap     *big.Int
+	GasTipCap     *big.Int
 	Data          []byte
 	AccessList    types.AccessList
 	BlobGasFeeCap *big.Int

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -154,14 +154,15 @@ func toWordSize(size uint64) uint64 {
 // A Message contains the data derived from a single transaction that is relevant to state
 // processing.
 type Message struct {
-	To            *common.Address
-	From          common.Address
-	Nonce         uint64
-	Value         *big.Int
-	GasLimit      uint64
-	GasPrice      *big.Int
-	GasFeeCap     *big.Int
-	GasTipCap     *big.Int
+	To        *common.Address
+	From      common.Address
+	Nonce     uint64
+	Value     *big.Int
+	GasLimit  uint64
+	GasPrice  *big.Int
+	GasFeeCap *big.Int
+	GasTipCap *big.Int
+
 	Data          []byte
 	AccessList    types.AccessList
 	BlobGasFeeCap *big.Int
@@ -182,8 +183,7 @@ type Message struct {
 	// FeeCurrency specifies the currency for gas fees.
 	// `nil` corresponds to Celo Gold (native currency).
 	// All other values should correspond to ERC20 contract addresses.
-	FeeCurrency *common.Address
-
+	FeeCurrency         *common.Address
 	MaxFeeInFeeCurrency *big.Int // MaxFeeInFeeCurrency is the maximum fee that can be charged in the fee currency.
 }
 
@@ -213,7 +213,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {
-		if msg.FeeCurrency != nil {
+		if tx.Type() == types.CeloDynamicFeeTxType {
 			var err error
 			baseFee, err = exchange.ConvertGoldToCurrency(exchangeRates, msg.FeeCurrency, baseFee)
 			if err != nil {

--- a/core/types/celo_denominated_tx.go
+++ b/core/types/celo_denominated_tx.go
@@ -19,7 +19,7 @@ type CeloDenominatedTx struct {
 	Data       []byte
 	AccessList AccessList
 
-	FeeCurrency         *common.Address `rlp:"nil"` // nil means native currency
+	FeeCurrency         *common.Address
 	MaxFeeInFeeCurrency *big.Int
 
 	// Signature values

--- a/core/types/celo_denominated_tx.go
+++ b/core/types/celo_denominated_tx.go
@@ -37,17 +37,18 @@ func (tx *CeloDenominatedTx) copy() TxData {
 		Gas:         tx.Gas,
 		FeeCurrency: copyAddressPtr(tx.FeeCurrency),
 		// These are copied below.
-		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasTipCap:  new(big.Int),
-		GasFeeCap:  new(big.Int),
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
+		MaxFeeInFeeCurrency: new(big.Int),
+		AccessList:          make(AccessList, len(tx.AccessList)),
+		Value:               new(big.Int),
+		ChainID:             new(big.Int),
+		GasTipCap:           new(big.Int),
+		GasFeeCap:           new(big.Int),
+		V:                   new(big.Int),
+		R:                   new(big.Int),
+		S:                   new(big.Int),
 	}
 	if tx.MaxFeeInFeeCurrency != nil {
-		cpy.MaxFeeInFeeCurrency = new(big.Int).Set(tx.MaxFeeInFeeCurrency)
+		cpy.MaxFeeInFeeCurrency.Set(tx.MaxFeeInFeeCurrency)
 	}
 	copy(cpy.AccessList, tx.AccessList)
 	if tx.Value != nil {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -102,4 +102,5 @@ func (tx *DepositTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
-func (tx *DepositTx) feeCurrency() *common.Address { return nil }
+func (tx *DepositTx) feeCurrency() *common.Address  { return nil }
+func (tx *DepositTx) maxFeeInFeeCurrency() *big.Int { return nil }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -634,7 +634,11 @@ func (tx *Transaction) FeeCurrency() *common.Address {
 
 // MaxFeeInFeeCurrency returns the max fee in the fee_currency for celo denominated txs.
 func (tx *Transaction) MaxFeeInFeeCurrency() *big.Int {
-	return new(big.Int).Set(tx.inner.maxFeeInFeeCurrency())
+	mfifc := tx.inner.maxFeeInFeeCurrency()
+	if mfifc == nil {
+		return nil
+	}
+	return new(big.Int).Set(mfifc)
 }
 
 // Transactions implements DerivableList for transactions.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -51,7 +51,8 @@ const (
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
 	// CeloDynamicFeeTxType = 0x7c  old Celo tx type with gateway fee
-	CeloDynamicFeeTxType = 0x7b
+	CeloDynamicFeeTxType  = 0x7b
+	CeloDenominatedTxType = 0x7a
 )
 
 // Transaction is an Ethereum transaction.
@@ -110,6 +111,7 @@ type TxData interface {
 
 	// Celo specific fields
 	feeCurrency() *common.Address
+	maxFeeInFeeCurrency() *big.Int
 }
 
 // EncodeRLP implements rlp.Encoder
@@ -216,6 +218,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(DynamicFeeTx)
 	case CeloDynamicFeeTxType:
 		inner = new(CeloDynamicFeeTx)
+	case CeloDenominatedTxType:
+		inner = new(CeloDenominatedTx)
 	case BlobTxType:
 		inner = new(BlobTx)
 	case DepositTxType:
@@ -626,6 +630,11 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 // FeeCurrency returns the fee currency of the transaction. Nil implies paying in CELO.
 func (tx *Transaction) FeeCurrency() *common.Address {
 	return copyAddressPtr(tx.inner.feeCurrency())
+}
+
+// MaxFeeInFeeCurrency returns the max fee in the fee_currency for celo denominated txs.
+func (tx *Transaction) MaxFeeInFeeCurrency() *big.Int {
+	return new(big.Int).Set(tx.inner.maxFeeInFeeCurrency())
 }
 
 // Transactions implements DerivableList for transactions.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -632,7 +632,8 @@ func (tx *Transaction) FeeCurrency() *common.Address {
 	return copyAddressPtr(tx.inner.feeCurrency())
 }
 
-// MaxFeeInFeeCurrency returns the max fee in the fee_currency for celo denominated txs.
+// MaxFeeInFeeCurrency is only used to guard against very quickly changing exchange rates.
+// Txs must be discarded if MaxFeeInFeeCurrency is exceeded.
 func (tx *Transaction) MaxFeeInFeeCurrency() *big.Int {
 	mfifc := tx.inner.maxFeeInFeeCurrency()
 	if mfifc == nil {

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -129,4 +129,5 @@ func (tx *AccessListTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
-func (tx *AccessListTx) feeCurrency() *common.Address { return nil }
+func (tx *AccessListTx) feeCurrency() *common.Address  { return nil }
+func (tx *AccessListTx) maxFeeInFeeCurrency() *big.Int { return nil }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -238,4 +238,5 @@ func (tx *BlobTx) decode(input []byte) error {
 	return nil
 }
 
-func (tx *BlobTx) feeCurrency() *common.Address { return nil }
+func (tx *BlobTx) feeCurrency() *common.Address  { return nil }
+func (tx *BlobTx) maxFeeInFeeCurrency() *big.Int { return nil }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -125,4 +125,5 @@ func (tx *DynamicFeeTx) decode(input []byte) error {
 	return rlp.DecodeBytes(input, tx)
 }
 
-func (tx *DynamicFeeTx) feeCurrency() *common.Address { return nil }
+func (tx *DynamicFeeTx) feeCurrency() *common.Address  { return nil }
+func (tx *DynamicFeeTx) maxFeeInFeeCurrency() *big.Int { return nil }

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -125,4 +125,5 @@ func (tx *LegacyTx) decode([]byte) error {
 	panic("decode called on LegacyTx)")
 }
 
-func (tx *LegacyTx) feeCurrency() *common.Address { return nil }
+func (tx *LegacyTx) feeCurrency() *common.Address  { return nil }
+func (tx *LegacyTx) maxFeeInFeeCurrency() *big.Int { return nil }

--- a/internal/celoapi/backend.go
+++ b/internal/celoapi/backend.go
@@ -60,18 +60,18 @@ func (b *CeloAPIBackend) GetExchangeRates(ctx context.Context, blockNumOrHash rp
 	return er, nil
 }
 
-func (b *CeloAPIBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
+func (b *CeloAPIBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, goldAmount *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
 	er, err := b.GetExchangeRates(ctx, blockNumOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return exchange.ConvertGoldToCurrency(er, fromFeeCurrency, value)
+	return exchange.ConvertGoldToCurrency(er, toFeeCurrency, goldAmount)
 }
 
-func (b *CeloAPIBackend) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
+func (b *CeloAPIBackend) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, currencyAmount *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
 	er, err := b.GetExchangeRates(ctx, blockNumOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return exchange.ConvertCurrencyToGold(er, value, toFeeCurrency)
+	return exchange.ConvertCurrencyToGold(er, currencyAmount, fromFeeCurrency)
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1477,7 +1477,8 @@ type RPCTransaction struct {
 	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
 
 	// Celo
-	FeeCurrency *common.Address `json:"feeCurrency,omitempty"`
+	FeeCurrency         *common.Address `json:"feeCurrency,omitempty"`
+	MaxFeeInFeeCurrency *hexutil.Big    `json:"maxFeeInFeeCurrency,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1500,7 +1501,8 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
 		// Celo
-		FeeCurrency: tx.FeeCurrency(),
+		FeeCurrency:         tx.FeeCurrency(),
+		MaxFeeInFeeCurrency: (*hexutil.Big)(tx.MaxFeeInFeeCurrency()),
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash
@@ -1542,7 +1544,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 		result.YParity = &yparity
 
-	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType, types.CeloDenominatedTxType:
 		al := tx.AccessList()
 		yparity := hexutil.Uint64(v.Sign())
 		result.Accesses = &al

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -499,18 +499,19 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ex
 		maxFeeInFeeCurrency = args.MaxFeeInFeeCurrency.ToInt()
 	}
 	msg := &core.Message{
-		From:                addr,
-		To:                  args.To,
-		Value:               value,
-		GasLimit:            gas,
-		GasPrice:            gasPrice,
-		GasFeeCap:           gasFeeCap,
-		GasTipCap:           gasTipCap,
-		Data:                data,
-		AccessList:          accessList,
-		BlobGasFeeCap:       blobFeeCap,
-		BlobHashes:          args.BlobHashes,
-		SkipAccountChecks:   true,
+		From:              addr,
+		To:                args.To,
+		Value:             value,
+		GasLimit:          gas,
+		GasPrice:          gasPrice,
+		GasFeeCap:         gasFeeCap,
+		GasTipCap:         gasTipCap,
+		Data:              data,
+		AccessList:        accessList,
+		BlobGasFeeCap:     blobFeeCap,
+		BlobHashes:        args.BlobHashes,
+		SkipAccountChecks: true,
+		// Celo specific:
 		FeeCurrency:         args.FeeCurrency,
 		MaxFeeInFeeCurrency: maxFeeInFeeCurrency,
 	}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -555,16 +555,47 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
-		data = &types.DynamicFeeTx{
-			To:         args.To,
-			ChainID:    (*big.Int)(args.ChainID),
-			Nonce:      uint64(*args.Nonce),
-			Gas:        uint64(*args.Gas),
-			GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
-			GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
-			Value:      (*big.Int)(args.Value),
-			Data:       args.data(),
-			AccessList: al,
+		if args.FeeCurrency != nil {
+			if args.IsFeeCurrencyDenominated() {
+				data = &types.CeloDynamicFeeTx{
+					To:          args.To,
+					ChainID:     (*big.Int)(args.ChainID),
+					Nonce:       uint64(*args.Nonce),
+					Gas:         uint64(*args.Gas),
+					GasFeeCap:   (*big.Int)(args.MaxFeePerGas),
+					GasTipCap:   (*big.Int)(args.MaxPriorityFeePerGas),
+					Value:       (*big.Int)(args.Value),
+					Data:        args.data(),
+					AccessList:  al,
+					FeeCurrency: args.FeeCurrency,
+				}
+			} else {
+				data = &types.CeloDenominatedTx{
+					To:                  args.To,
+					ChainID:             (*big.Int)(args.ChainID),
+					Nonce:               uint64(*args.Nonce),
+					Gas:                 uint64(*args.Gas),
+					GasFeeCap:           (*big.Int)(args.MaxFeePerGas),
+					GasTipCap:           (*big.Int)(args.MaxPriorityFeePerGas),
+					Value:               (*big.Int)(args.Value),
+					Data:                args.data(),
+					AccessList:          al,
+					FeeCurrency:         args.FeeCurrency,
+					MaxFeeInFeeCurrency: (*big.Int)(args.MaxFeeInFeeCurrency),
+				}
+			}
+		} else {
+			data = &types.DynamicFeeTx{
+				To:         args.To,
+				ChainID:    (*big.Int)(args.ChainID),
+				Nonce:      uint64(*args.Nonce),
+				Gas:        uint64(*args.Gas),
+				GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
+				GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
+				Value:      (*big.Int)(args.Value),
+				Data:       args.data(),
+				AccessList: al,
+			}
 		}
 
 	case args.AccessList != nil:

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -75,12 +75,10 @@ type TransactionArgs struct {
 
 	// This configures whether blobs are allowed to be passed.
 	blobSidecarAllowed bool
-	// Celo specific
 
-	// CIP-64, CIP-66
-	FeeCurrency *common.Address `json:"feeCurrency,omitempty"`
-	// CIP-66
-	MaxFeeInFeeCurrency *hexutil.Big `json:"maxFeeInFeeCurrency,omitempty"`
+	// Celo specific:
+	FeeCurrency         *common.Address `json:"feeCurrency,omitempty"`         // CIP-64, CIP-66
+	MaxFeeInFeeCurrency *hexutil.Big    `json:"maxFeeInFeeCurrency,omitempty"` // CIP-66
 }
 
 // from retrieves the transaction sender address.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -445,10 +445,11 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ex
 		gas = globalGasCap
 	}
 	var (
-		gasPrice   *big.Int
-		gasFeeCap  *big.Int
-		gasTipCap  *big.Int
-		blobFeeCap *big.Int
+		gasPrice            *big.Int
+		gasFeeCap           *big.Int
+		gasTipCap           *big.Int
+		blobFeeCap          *big.Int
+		maxFeeInFeeCurrency *big.Int
 	)
 	if baseFee == nil {
 		// If there's no basefee, then it must be a non-1559 execution
@@ -501,20 +502,24 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ex
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
+	if args.MaxFeeInFeeCurrency != nil {
+		maxFeeInFeeCurrency = args.MaxFeeInFeeCurrency.ToInt()
+	}
 	msg := &core.Message{
-		From:              addr,
-		To:                args.To,
-		Value:             value,
-		GasLimit:          gas,
-		GasPrice:          gasPrice,
-		GasFeeCap:         gasFeeCap,
-		GasTipCap:         gasTipCap,
-		Data:              data,
-		AccessList:        accessList,
-		BlobGasFeeCap:     blobFeeCap,
-		BlobHashes:        args.BlobHashes,
-		SkipAccountChecks: true,
-		FeeCurrency:       args.FeeCurrency,
+		From:                addr,
+		To:                  args.To,
+		Value:               value,
+		GasLimit:            gas,
+		GasPrice:            gasPrice,
+		GasFeeCap:           gasFeeCap,
+		GasTipCap:           gasTipCap,
+		Data:                data,
+		AccessList:          accessList,
+		BlobGasFeeCap:       blobFeeCap,
+		BlobHashes:          args.BlobHashes,
+		SkipAccountChecks:   true,
+		FeeCurrency:         args.FeeCurrency,
+		MaxFeeInFeeCurrency: maxFeeInFeeCurrency,
 	}
 	return msg, nil
 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -51,11 +51,14 @@ func TestSetFeeDefaults(t *testing.T) {
 	}
 
 	var (
-		b        = newCeloBackendMock()
-		zero     = (*hexutil.Big)(big.NewInt(0))
-		fortytwo = (*hexutil.Big)(big.NewInt(42))
-		maxFee   = (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(b.current.BaseFee, big.NewInt(2)), fortytwo.ToInt()))
-		al       = &types.AccessList{types.AccessTuple{Address: common.Address{0xaa}, StorageKeys: []common.Hash{{0x01}}}}
+		b            = newCeloBackendMock()
+		zero         = (*hexutil.Big)(big.NewInt(0))
+		fortytwo     = (*hexutil.Big)(big.NewInt(42))
+		maxFee       = (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(b.current.BaseFee, big.NewInt(2)), fortytwo.ToInt()))
+		al           = &types.AccessList{types.AccessTuple{Address: common.Address{0xaa}, StorageKeys: []common.Hash{{0x01}}}}
+		feeCurrency  = common.BigToAddress(big.NewInt(42))
+		eightyfour   = (*hexutil.Big)(big.NewInt(84))
+		doubleMaxFee = (*hexutil.Big)(new(big.Int).Mul(maxFee.ToInt(), big.NewInt(2)))
 	)
 
 	tests := []test{
@@ -228,6 +231,37 @@ func TestSetFeeDefaults(t *testing.T) {
 			&TransactionArgs{BlobHashes: []common.Hash{}, BlobFeeCap: (*hexutil.Big)(big.NewInt(4)), MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
+		// CIP-64
+		{
+			"Fee-currency denominated tx, set maxPriorityFeePerGas in converted valued",
+			"cancun",
+			&TransactionArgs{MaxFeePerGas: doubleMaxFee, FeeCurrency: &feeCurrency},
+			// maxPriorityFeePerGas is double in feeCurrency
+			&TransactionArgs{MaxFeePerGas: doubleMaxFee, MaxPriorityFeePerGas: eightyfour, FeeCurrency: &feeCurrency},
+			nil,
+		},
+		{
+			"Fee-currency denominated tx, set maxFeePerGas in converted valued",
+			"cancun",
+			&TransactionArgs{MaxPriorityFeePerGas: eightyfour, FeeCurrency: &feeCurrency},
+			&TransactionArgs{MaxFeePerGas: doubleMaxFee, MaxPriorityFeePerGas: eightyfour, FeeCurrency: &feeCurrency},
+			nil,
+		},
+		// CIP-66
+		{
+			"CIP-66 transaction, maxPriorityFeePerGas gets set in non-converted value",
+			"cancun",
+			&TransactionArgs{MaxFeePerGas: maxFee, MaxFeeInFeeCurrency: fortytwo, FeeCurrency: &feeCurrency},
+			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo, MaxFeeInFeeCurrency: fortytwo, FeeCurrency: &feeCurrency},
+			nil,
+		},
+		{
+			"set maxFeeInFeeCurrency without feeCurrency",
+			"cancun",
+			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo, MaxFeeInFeeCurrency: fortytwo},
+			nil,
+			errors.New("feeCurrency must be set when maxFeeInFeeCurrency is given"),
+		},
 	}
 
 	ctx := context.Background()
@@ -271,18 +305,22 @@ func (c *celoBackendMock) GetFeeBalance(ctx context.Context, blockNumOrHash rpc.
 
 func (c *celoBackendMock) GetExchangeRates(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error) {
 	var er common.ExchangeRates
-	// Celo specific backend features are currently not tested
+	// This Celo specific backend features are currently not tested
 	return er, errCeloNotImplemented
 }
 
 func (c *celoBackendMock) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
-	// Celo specific backend features are currently not tested
-	return nil, errCeloNotImplemented
+	if fromFeeCurrency == nil {
+		return value, nil
+	}
+	return new(big.Int).Mul(value, big.NewInt(2)), nil
 }
 
 func (c *celoBackendMock) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
-	// Celo specific backend features are currently not tested
-	return nil, errCeloNotImplemented
+	if toFeeCurrency == nil {
+		return value, nil
+	}
+	return new(big.Int).Div(value, big.NewInt(2)), nil
 }
 
 type backendMock struct {


### PR DESCRIPTION
Fixes #109

#### Add CIP-66 transaction type

This introduces the `CeloDenominatedTx` type, which will [when implemented](https://github.com/celo-org/op-geth/issues/64) allow for the fee-currency to be denominated in cel2 native token.

#### Make the `TransactionArgs` CIP-64/CIP-66 compatible
The `TransactionArgs` are used in some API endpoints to fill incomplete fields of passed in transactions and then 
convert this internally to an EVM-message or `Transaction`. This PR adds code that distinguishes some combination of passed in fields for the `TransactionArgs` between CIP-64 and CIP-66 transactions in order to create the concrete internal transaction type. The filling of missing required fields now considers wether the transaction is Celo-denominated or not.
Additionally, the new `MaxFeeInFeeCurrency` field is passed along to the internal transaction representations.