### PR TITLE
Allow manually triggering CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ on:
       - master
       - celo*
 
+  workflow_dispatch:
+
 jobs:
   Test:
     runs-on: ["8-cpu","self-hosted","org"]


### PR DESCRIPTION
This is useful when preparing a branch that is not going to become a PR (e.g. a celo* rebased branch).

Unfortunately, I can't test this before it is merged to the default branch. See https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow.