### PR TITLE
add dependency review github action

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0  # make sure to fetch the old commit we diff against
 
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          warn-only: true
+
       - name: Build forkdiff
         uses: "docker://protolambda/forkdiff:latest"
         with:


### PR DESCRIPTION
I want to test out this security action. It should let us know if a pull request adds a dependency that has a known vulnerability. It can also check for licenses if needed.

It's set to warn so shouldn't stop the workflow, just give information if a PR adds a vulnerable dependency