### PR TITLE
Cel2 precompiles refactoring

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -128,7 +128,7 @@ var PrecompiledContractsFjord = map[common.Address]PrecompiledContract{
 // contracts used in the Cel2 release which don't require the extra
 // celoPrecompileContext, while PrecompiledCeloContractsCel2 contains those
 // that do.
-var PrecompiledContractsCel2 = PrecompiledContractsCancun
+var PrecompiledContractsCel2 = PrecompiledContractsFjord
 var PrecompiledCeloContractsCel2 = map[common.Address]CeloPrecompiledContract{
 	celoPrecompileAddress(2): &transfer{},
 }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -175,24 +175,28 @@ func init() {
 	}
 }
 
-// ActivePrecompiles returns the precompiles enabled with the current configuration.
-func ActivePrecompiles(rules params.Rules) []common.Address {
-	var addresses []common.Address
-
+// OptimismPrecompiles returns the original Optimism precompiles enabled with
+// the current configuration.
+func OptimismPrecompiles(rules params.Rules) []common.Address {
 	switch {
 	case rules.IsOptimismFjord:
-		addresses = PrecompiledAddressesFjord
+		return PrecompiledAddressesFjord
 	case rules.IsCancun:
-		addresses = PrecompiledAddressesCancun
+		return PrecompiledAddressesCancun
 	case rules.IsBerlin:
-		addresses = PrecompiledAddressesBerlin
+		return PrecompiledAddressesBerlin
 	case rules.IsIstanbul:
-		addresses = PrecompiledAddressesIstanbul
+		return PrecompiledAddressesIstanbul
 	case rules.IsByzantium:
-		addresses = PrecompiledAddressesByzantium
+		return PrecompiledAddressesByzantium
 	default:
-		addresses = PrecompiledAddressesHomestead
+		return PrecompiledAddressesHomestead
 	}
+}
+
+// ActivePrecompiles returns the precompiles enabled with the current configuration.
+func ActivePrecompiles(rules params.Rules) []common.Address {
+	addresses := OptimismPrecompiles(rules)
 
 	if !rules.IsCel2 {
 		return addresses

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -124,11 +124,8 @@ var PrecompiledContractsFjord = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 }
 
-// PrecompiledContractsCel2 contains the default set of pre-compiled Ethereum
-// contracts used in the Cel2 release which don't require the extra
-// celoPrecompileContext, while PrecompiledCeloContractsCel2 contains those
-// that do.
-var PrecompiledContractsCel2 = PrecompiledContractsFjord
+// PrecompiledCeloContractsCel2 contains a set of pre-compiled contracts used
+// in the Cel2 release which require the extra celoPrecompileContext.
 var PrecompiledCeloContractsCel2 = map[common.Address]CeloPrecompiledContract{
 	celoPrecompileAddress(2): &transfer{},
 }
@@ -176,32 +173,39 @@ func init() {
 	for k := range PrecompiledContractsFjord {
 		PrecompiledAddressesFjord = append(PrecompiledAddressesFjord, k)
 	}
-	for k := range PrecompiledContractsCel2 {
-		PrecompiledAddressesCel2 = append(PrecompiledAddressesCel2, k)
-	}
-	for k := range PrecompiledCeloContractsCel2 {
-		PrecompiledAddressesCel2 = append(PrecompiledAddressesCel2, k)
-	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
+	var addresses []common.Address
+
 	switch {
-	case rules.IsCel2:
-		return PrecompiledAddressesCel2
 	case rules.IsOptimismFjord:
-		return PrecompiledAddressesFjord
+		addresses = PrecompiledAddressesFjord
 	case rules.IsCancun:
-		return PrecompiledAddressesCancun
+		addresses = PrecompiledAddressesCancun
 	case rules.IsBerlin:
-		return PrecompiledAddressesBerlin
+		addresses = PrecompiledAddressesBerlin
 	case rules.IsIstanbul:
-		return PrecompiledAddressesIstanbul
+		addresses = PrecompiledAddressesIstanbul
 	case rules.IsByzantium:
-		return PrecompiledAddressesByzantium
+		addresses = PrecompiledAddressesByzantium
 	default:
-		return PrecompiledAddressesHomestead
+		addresses = PrecompiledAddressesHomestead
 	}
+
+	if !rules.IsCel2 {
+		return addresses
+	}
+
+	PrecompiledAddressesCel2 = PrecompiledAddressesCel2[:0]
+	PrecompiledAddressesCel2 = append(PrecompiledAddressesCel2, addresses...)
+
+	for k := range PrecompiledCeloContractsCel2 {
+		PrecompiledAddressesCel2 = append(PrecompiledAddressesCel2, k)
+	}
+
+	return PrecompiledAddressesCel2
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -41,8 +41,6 @@ type (
 func (evm *EVM) precompile(addr common.Address) (CeloPrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsCel2:
-		precompiles = PrecompiledContractsCel2
 	case evm.chainRules.IsOptimismFjord:
 		precompiles = PrecompiledContractsFjord
 	case evm.chainRules.IsCancun:


### PR DESCRIPTION
Refactors the way Celo precompiles are handled, making them less dependant on the temporal sequence of upstream hardforks.