### PR TITLE
Fix caller address check in transfer precompile

### DIFF
--- a/contracts/addresses/addresses.go
+++ b/contracts/addresses/addresses.go
@@ -1,4 +1,4 @@
-package contracts
+package addresses
 
 import "github.com/ethereum/go-ethereum/common"
 

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/contracts/celo/abigen"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -114,7 +115,7 @@ func CreditFees(
 // GetExchangeRates returns the exchange rates for all gas currencies from CELO
 func GetExchangeRates(caller bind.ContractCaller) (common.ExchangeRates, error) {
 	exchangeRates := map[common.Address]*big.Rat{}
-	directory, err := abigen.NewFeeCurrencyDirectoryCaller(FeeCurrencyDirectoryAddress, caller)
+	directory, err := abigen.NewFeeCurrencyDirectoryCaller(addresses.FeeCurrencyDirectoryAddress, caller)
 	if err != nil {
 		return exchangeRates, fmt.Errorf("Failed to access FeeCurrencyDirectory: %w", err)
 	}

--- a/core/blockchain_celo_test.go
+++ b/core/blockchain_celo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/exchange"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/contracts"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -137,7 +138,7 @@ func testNativeTransferWithFeeCurrency(t *testing.T, scheme string, feeCurrencyA
 	}
 
 	// 5: Check that base fee has been moved to the fee handler.
-	actual, _ = contracts.GetBalanceERC20(&backend, contracts.FeeHandlerAddress, feeCurrencyAddr)
+	actual, _ = contracts.GetBalanceERC20(&backend, addresses.FeeHandlerAddress, feeCurrencyAddr)
 	expected = new(big.Int).SetUint64(block.GasUsed() * baseFeeInFeeCurrency.Uint64())
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("fee handler balance incorrect: expected %d, got %d", expected, actual)

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/contracts"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/contracts/celo"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -95,7 +95,7 @@ func celoGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 		panic("Couldn not set faucet balance!")
 	}
 	genesisAccounts := map[common.Address]GenesisAccount{
-		contracts.RegistryAddress: { // Registry Proxy
+		addresses.RegistryAddress: { // Registry Proxy
 			Code: proxyBytecode,
 			Storage: map[common.Hash]common.Hash{
 				common.HexToHash("0x0"):   DevAddr32, // `_owner` slot in Registry contract
@@ -108,7 +108,7 @@ func celoGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			Code:    registryBytecode,
 			Balance: big.NewInt(0),
 		},
-		contracts.GoldTokenAddress: { // GoldToken Proxy
+		addresses.GoldTokenAddress: { // GoldToken Proxy
 			Code: proxyBytecode,
 			Storage: map[common.Hash]common.Hash{
 				proxy_implementation_slot: common.HexToHash("0xce13"),
@@ -176,7 +176,7 @@ func celoGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 	// add entries to currencyConfig mapping
 	addFeeCurrencyToStorage(DevFeeCurrencyAddr, mockOracleAddr, feeCurrencyDirectoryStorage)
 	addFeeCurrencyToStorage(DevFeeCurrencyAddr2, mockOracleAddr2, feeCurrencyDirectoryStorage)
-	genesisAccounts[contracts.FeeCurrencyDirectoryAddress] = GenesisAccount{
+	genesisAccounts[addresses.FeeCurrencyDirectoryAddress] = GenesisAccount{
 		Code:    feeCurrencyDirectoryBytecode,
 		Balance: big.NewInt(0),
 		Storage: feeCurrencyDirectoryStorage,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/exchange"
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/contracts"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -726,7 +727,7 @@ func (st *StateTransition) distributeTxFees() error {
 	tipTxFee := new(big.Int).Sub(totalTxFee, baseTxFee)
 
 	feeCurrency := st.msg.FeeCurrency
-	feeHandlerAddress := contracts.FeeHandlerAddress
+	feeHandlerAddress := addresses.FeeHandlerAddress
 
 	log.Trace("distributeTxFees", "from", from, "refund", refund, "feeCurrency", st.msg.FeeCurrency,
 		"coinbaseFeeRecipient", st.evm.Context.Coinbase, "coinbaseFee", tipTxFee,

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -10,6 +10,8 @@ import (
 	"github.com/holiman/uint256"
 )
 
+var GoldTokenAddress = common.HexToAddress("0x471ece3750da237f93b8e339c536989b8978a438")
+
 type CeloPrecompiledContract interface {
 	RequiredGas(input []byte) uint64                              // RequiredGas calculates the contract gas use
 	Run(input []byte, ctx *celoPrecompileContext) ([]byte, error) // Run runs the precompiled contract
@@ -46,7 +48,7 @@ func celoPrecompileAddress(index byte) common.Address {
 }
 
 func (ctx *celoPrecompileContext) IsCallerGoldToken() (bool, error) {
-	return true, nil // TODO
+	return GoldTokenAddress == ctx.caller, nil
 }
 
 // Native transfer contract to make Celo Gold ERC20 compatible.
@@ -60,7 +62,7 @@ func (c *transfer) Run(input []byte, ctx *celoPrecompileContext) ([]byte, error)
 	if isGoldToken, err := ctx.IsCallerGoldToken(); err != nil {
 		return nil, err
 	} else if !isGoldToken {
-		return nil, fmt.Errorf("Unable to call transfer from unpermissioned address")
+		return nil, fmt.Errorf("unable to call transfer from unpermissioned address")
 	}
 
 	// input is comprised of 3 arguments:

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -6,11 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
-
-var GoldTokenAddress = common.HexToAddress("0x471ece3750da237f93b8e339c536989b8978a438")
 
 type CeloPrecompiledContract interface {
 	RequiredGas(input []byte) uint64                              // RequiredGas calculates the contract gas use
@@ -48,7 +47,7 @@ func celoPrecompileAddress(index byte) common.Address {
 }
 
 func (ctx *celoPrecompileContext) IsCallerGoldToken() (bool, error) {
-	return GoldTokenAddress == ctx.caller, nil
+	return addresses.GoldTokenAddress == ctx.caller, nil
 }
 
 // Native transfer contract to make Celo Gold ERC20 compatible.

--- a/core/vm/celo_contracts_test.go
+++ b/core/vm/celo_contracts_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -78,7 +79,7 @@ func TestPrecompileTransfer(t *testing.T) {
 			name: "Test transfer with short input",
 			args: args{
 				input: []byte("0000"),
-				ctx:   NewContext(GoldTokenAddress, mockEVM),
+				ctx:   NewContext(addresses.GoldTokenAddress, mockEVM),
 			},
 			wantErr:     true,
 			expectedErr: "invalid input length",


### PR DESCRIPTION
Using the contract addresses in `contracts/addresses` creates cyclic imports, so I moved it here for now. But maybe we move them to `core`?