### PR TITLE
Fix `dependency-review` failing workflow after merged PR

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -16,11 +16,6 @@ jobs:
         with:
           fetch-depth: 0  # make sure to fetch the old commit we diff against
 
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
-        with:
-          warn-only: true
-
       - name: Build forkdiff
         uses: "docker://protolambda/forkdiff:0.1.0"
         with:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,7 +22,7 @@ jobs:
           warn-only: true
 
       - name: Build forkdiff
-        uses: "docker://protolambda/forkdiff:latest"
+        uses: "docker://protolambda/forkdiff:0.1.0"
         with:
           args: -repo=/github/workspace -fork=/github/workspace/fork.yaml -out=/github/workspace/index.html
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+name: PR only
+
+on:
+  pull_request:
+    branches:
+      - master
+      - celo*
+
+jobs:
+  dependencies:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v4
+        with:
+          warn-only: true


### PR DESCRIPTION
The `dependency-review` job introduced in #133 requires a `base_ref` and `head_ref` when the workflow is not run on a `pull_request` 
event:
> Provide custom git references for the git base/head when performing the comparison check. This is only used for event types other than pull_request and pull_request_target.

This was [failing](https://github.com/celo-org/op-geth/actions/runs/9363777751/job/25775295021) the `deploy` workflow after a PR has been merged, since the event triggering the job is a `push` and not a `pull_request`:

```
Error: Both a base ref and head ref must be provided, either via the `base_ref`/`head_ref` config options, `base-ref`/`head-ref` workflow action options, or by running a `pull_request`/`pull_request_target` workflow.
```

In this PR a new workflow is introduced for PR-only jobs, and the dependency-review job is moved to this workflow.
This makes sense to me, since newly introducing dependencies should be checked **before** merging a PR, and not after it has been merged.

If this job is also desired on a `push` event. The before-push (`github.event.before` var for push events) and after-push (`github.event.after` var for push events) refs have to be set as the `base_ref` and `head_ref` for dependency-review