### PR TITLE
Allow non-hash based blocknum argument in CeloAPI backend

### DIFF
--- a/internal/celoapi/backend.go
+++ b/internal/celoapi/backend.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/exchange"
-	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/contracts"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -15,8 +14,7 @@ import (
 
 func NewCeloAPIBackend(b ethapi.Backend) *CeloAPIBackend {
 	return &CeloAPIBackend{
-		Backend:            b,
-		exchangeRatesCache: lru.NewCache[common.Hash, common.ExchangeRates](128),
+		Backend: b,
 	}
 }
 
@@ -24,17 +22,8 @@ func NewCeloAPIBackend(b ethapi.Backend) *CeloAPIBackend {
 // functionality. CeloAPIBackend is mainly passed to the JSON RPC services and provides
 // an easy way to make extra functionality available in the service internal methods without
 // having to change their call signature significantly.
-// CeloAPIBackend keeps a threadsafe LRU cache of block-hash to exchange rates for that block.
-// Cache invalidation is only a problem when an already existing blocks' hash
-// doesn't change, but the rates change. That shouldn't be possible, since changing the rates
-// requires different transaction hashes / state and thus a different block hash.
-// If the previous rates change during a reorg, the previous block hash should also change
-// and with it the new block's hash.
-// Stale branches cache values will get evicted eventually.
 type CeloAPIBackend struct {
 	ethapi.Backend
-
-	exchangeRatesCache *lru.Cache[common.Hash, common.ExchangeRates]
 }
 
 func (b *CeloAPIBackend) getContractCaller(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (*contracts.CeloBackend, error) {
@@ -60,23 +49,13 @@ func (b *CeloAPIBackend) GetFeeBalance(ctx context.Context, blockNumOrHash rpc.B
 }
 
 func (b *CeloAPIBackend) GetExchangeRates(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error) {
-	blockHash, isHash := blockNumOrHash.Hash()
-	if isHash {
-		cachedRates, ok := b.exchangeRatesCache.Get(blockHash)
-		if ok {
-			return cachedRates, nil
-		}
-	}
-	cb, err := b.getContractCaller(ctx, blockNumOrHash)
+	contractBackend, err := b.getContractCaller(ctx, blockNumOrHash)
 	if err != nil {
 		return nil, err
 	}
-	er, err := contracts.GetExchangeRates(cb)
+	er, err := contracts.GetExchangeRates(contractBackend)
 	if err != nil {
 		return nil, err
-	}
-	if isHash {
-		b.exchangeRatesCache.Add(blockHash, er)
 	}
 	return er, nil
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -590,9 +590,9 @@ type celoTestBackend struct {
 	*testBackend
 }
 
-func (c *celoTestBackend) GetFeeBalance(ctx context.Context, atBlock common.Hash, account common.Address, feeCurrency *common.Address) (*big.Int, error) {
+func (c *celoTestBackend) GetFeeBalance(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, account common.Address, feeCurrency *common.Address) (*big.Int, error) {
 	if feeCurrency == nil {
-		header, err := c.HeaderByHash(ctx, atBlock)
+		header, err := c.HeaderByNumberOrHash(ctx, blockNumOrHash)
 		if err != nil {
 			return nil, fmt.Errorf("retrieve header by hash in testBackend: %w", err)
 		}
@@ -607,12 +607,12 @@ func (c *celoTestBackend) GetFeeBalance(ctx context.Context, atBlock common.Hash
 	return nil, errCeloNotImplemented
 }
 
-func (c *celoTestBackend) GetExchangeRates(ctx context.Context, atBlock common.Hash) (common.ExchangeRates, error) {
+func (c *celoTestBackend) GetExchangeRates(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error) {
 	var er common.ExchangeRates
 	return er, nil
 }
 
-func (c *celoTestBackend) ConvertToCurrency(ctx context.Context, atBlock common.Hash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+func (c *celoTestBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
 	if feeCurrency == nil {
 		return value, nil
 	}
@@ -620,7 +620,7 @@ func (c *celoTestBackend) ConvertToCurrency(ctx context.Context, atBlock common.
 	return nil, errCeloNotImplemented
 }
 
-func (c *celoTestBackend) ConvertToGold(ctx context.Context, atBlock common.Hash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+func (c *celoTestBackend) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
 	if feeCurrency == nil {
 		return value, nil
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -40,10 +40,10 @@ import (
 type CeloBackend interface {
 	Backend
 
-	GetFeeBalance(ctx context.Context, atBlock common.Hash, account common.Address, feeCurrency *common.Address) (*big.Int, error)
-	GetExchangeRates(ctx context.Context, atBlock common.Hash) (common.ExchangeRates, error)
-	ConvertToCurrency(ctx context.Context, atBlock common.Hash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
-	ConvertToGold(ctx context.Context, atBlock common.Hash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
+	GetFeeBalance(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, account common.Address, feeCurrency *common.Address) (*big.Int, error)
+	GetExchangeRates(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error)
+	ConvertToCurrency(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
+	ConvertToGold(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
 }
 
 // Backend interface provides the common API services (that are provided by both full and light clients) with access to necessary functions.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -248,7 +248,12 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b CeloBackend) 
 			return err
 		}
 		if args.IsFeeCurrencyDenominated() {
-			price, err = b.ConvertToCurrency(ctx, head.Hash(), price, args.FeeCurrency)
+			price, err = b.ConvertToCurrency(
+				ctx,
+				rpc.BlockNumberOrHashWithHash(head.Hash(), false),
+				price,
+				args.FeeCurrency,
+			)
 			if err != nil {
 				return fmt.Errorf("can't convert suggested gasTipCap to fee-currency: %w", err)
 			}
@@ -272,7 +277,12 @@ func (args *TransactionArgs) setCancunFeeDefaults(ctx context.Context, head *typ
 			// wether the blob-fee will be used like that in Cel2 or not,
 			// at least this keeps it consistent with the rest of the gas-fees
 			var err error
-			blobBaseFee, err = b.ConvertToCurrency(ctx, head.Hash(), blobBaseFee, args.FeeCurrency)
+			blobBaseFee, err = b.ConvertToCurrency(
+				ctx,
+				rpc.BlockNumberOrHashWithHash(head.Hash(), false),
+				blobBaseFee,
+				args.FeeCurrency,
+			)
 			if err != nil {
 				return fmt.Errorf("can't convert blob-fee to fee-currency: %w", err)
 			}
@@ -295,7 +305,12 @@ func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *typ
 			return err
 		}
 		if args.IsFeeCurrencyDenominated() {
-			tip, err = b.ConvertToCurrency(ctx, head.Hash(), tip, args.FeeCurrency)
+			tip, err = b.ConvertToCurrency(
+				ctx,
+				rpc.BlockNumberOrHashWithHash(head.Hash(), false),
+				tip,
+				args.FeeCurrency,
+			)
 			if err != nil {
 				return fmt.Errorf("can't convert suggested gasTipCap to fee-currency: %w", err)
 			}
@@ -310,7 +325,12 @@ func (args *TransactionArgs) setLondonFeeDefaults(ctx context.Context, head *typ
 		baseFee := head.BaseFee
 		if args.IsFeeCurrencyDenominated() {
 			var err error
-			baseFee, err = b.ConvertToCurrency(ctx, head.Hash(), baseFee, args.FeeCurrency)
+			baseFee, err = b.ConvertToCurrency(
+				ctx,
+				rpc.BlockNumberOrHashWithHash(head.Hash(), false),
+				baseFee,
+				args.FeeCurrency,
+			)
 			if err != nil {
 				return fmt.Errorf("can't convert base-fee to fee-currency: %w", err)
 			}

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -264,23 +264,23 @@ func newCeloBackendMock() *celoBackendMock {
 	}
 }
 
-func (c *celoBackendMock) GetFeeBalance(ctx context.Context, atBlock common.Hash, account common.Address, feeCurrency *common.Address) (*big.Int, error) {
+func (c *celoBackendMock) GetFeeBalance(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, account common.Address, feeCurrency *common.Address) (*big.Int, error) {
 	// Celo specific backend features are currently not tested
 	return nil, errCeloNotImplemented
 }
 
-func (c *celoBackendMock) GetExchangeRates(ctx context.Context, atBlock common.Hash) (common.ExchangeRates, error) {
+func (c *celoBackendMock) GetExchangeRates(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error) {
 	var er common.ExchangeRates
 	// Celo specific backend features are currently not tested
 	return er, errCeloNotImplemented
 }
 
-func (c *celoBackendMock) ConvertToCurrency(ctx context.Context, atBlock common.Hash, value *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
+func (c *celoBackendMock) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
 	// Celo specific backend features are currently not tested
 	return nil, errCeloNotImplemented
 }
 
-func (c *celoBackendMock) ConvertToGold(ctx context.Context, atBlock common.Hash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
+func (c *celoBackendMock) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
 	// Celo specific backend features are currently not tested
 	return nil, errCeloNotImplemented
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // API describes the set of methods offered over the RPC interface
@@ -251,44 +250,4 @@ func BlockNumberOrHashWithHash(hash common.Hash, canonical bool) BlockNumberOrHa
 		BlockHash:        &hash,
 		RequireCanonical: canonical,
 	}
-}
-
-type HeaderRetriever interface {
-	HeaderByNumber(ctx context.Context, number BlockNumber) (*types.Header, error)
-	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
-}
-
-func BlockNumberOrHashEnsureHashOnly(
-	ctx context.Context,
-	backend HeaderRetriever,
-	blockNumOrHash BlockNumberOrHash,
-	useParentForPending bool,
-	forceUseParent bool,
-) (BlockNumberOrHash, error) {
-	blockNum, isNum := blockNumOrHash.Number()
-	if !isNum {
-		if forceUseParent {
-			hash, _ := blockNumOrHash.Hash()
-			h, err := backend.HeaderByHash(ctx, hash)
-			if err != nil {
-				return blockNumOrHash, err
-			}
-			return BlockNumberOrHashWithHash(h.ParentHash, false), nil
-		}
-		return blockNumOrHash, nil
-	}
-	var hash common.Hash
-	h, err := backend.HeaderByNumber(ctx, blockNum)
-	if err != nil {
-		return blockNumOrHash, err
-	}
-	if (blockNum == PendingBlockNumber && useParentForPending) || forceUseParent {
-		// use the parent hash, since the pending hash
-		// may be changing and is not presisted in the StateDB yet,
-		// or the caller required to use the parent.
-		hash = h.ParentHash
-	} else {
-		hash = h.Hash()
-	}
-	return BlockNumberOrHashWithHash(hash, false), nil
 }


### PR DESCRIPTION
Fixes #136 

- removes the LRU cache in the `CeloAPIBackend.GetExchangeRates` call because of premature optmisation
- adds a function `rpc.BlockNumberOrHashEnsureHashOnly`:
  - converts number and `latest, pending, earliest, ...`  based block-number arguments to their hash based on the blockchain state
  - has extra argument flags that force the returned hash to be the block's parent hash
- changes the call signature of `ethapi.CeloBackend` methods to accept `rpc.BlockNumberOrHash` instead of `common.Hash` for specifying blocks to query
- uses `rpc.BlockNumberOrHashEnsureHashOnly` to convert `pending` RPC arguments in `eth_estimateGas` to the pending block's parent hash, so that state-db queries don't fail (#136)

Unfortunately the fix for #136 is not easily tested in a unit-test, since the `ethapi/api_test.go`'s mock backend does not fully implement querying state of the `pending` block. We should re-evaluate in the future, if it is worth to change the mock implementation here.