### PR TITLE
Handle migrated blocks and headers run tests with cel2

### DIFF
--- a/cmd/utils/history_test.go
+++ b/cmd/utils/history_test.go
@@ -49,7 +49,7 @@ func TestHistoryImportAndExport(t *testing.T) {
 		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		address = crypto.PubkeyToAddress(key.PublicKey)
 		genesis = &core.Genesis{
-			Config: params.TestChainConfig,
+			Config: params.TestChainConfigNoCel2,
 			Alloc:  types.GenesisAlloc{address: {Balance: big.NewInt(1000000000000000000)}},
 		}
 		signer = types.LatestSigner(genesis.Config)

--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -412,7 +412,7 @@ func (tt *cliqueTest) run(t *testing.T) {
 	}
 
 	// Assemble a chain of headers from the cast votes
-	config := *params.TestChainConfig
+	config := *params.TestChainConfigNoCel2
 	config.Clique = &params.CliqueConfig{
 		Period: 1,
 		Epoch:  tt.epoch,

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -41,7 +41,7 @@ var (
 	testKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddress = crypto.PubkeyToAddress(testKey.PublicKey)
 	gspec       = &core.Genesis{
-		Config:  params.TestChainConfig,
+		Config:  params.TestChainConfigNoCel2,
 		Alloc:   types.GenesisAlloc{testAddress: {Balance: big.NewInt(1000000000000000)}},
 		BaseFee: big.NewInt(params.InitialBaseFee),
 	}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -819,7 +819,7 @@ func TestLightFilterLogs(t *testing.T) {
 
 		key, _  = crypto.GenerateKey()
 		addr    = crypto.PubkeyToAddress(key.PublicKey)
-		genesis = &core.Genesis{Config: params.TestChainConfig,
+		genesis = &core.Genesis{Config: params.TestChainConfigNoCel2,
 			Alloc: types.GenesisAlloc{
 				addr: {Balance: big.NewInt(params.Ether)},
 			},

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -123,7 +123,7 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBacke
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr   = crypto.PubkeyToAddress(key.PublicKey)
-		config = *params.TestChainConfig // needs copy because it is modified below
+		config = *params.TestChainConfigNoCel2 // needs copy because it is modified below
 		gspec  = &core.Genesis{
 			Config: &config,
 			Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(math.MaxInt64)}},

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -69,7 +69,7 @@ func newTestBackendWithGenerator(blocks int, shanghai bool, generator func(int, 
 	var (
 		// Create a database pre-initialize with a genesis block
 		db                      = rawdb.NewMemoryDatabase()
-		config                  = params.TestChainConfig
+		config                  = params.TestChainConfigNoCel2
 		engine consensus.Engine = ethash.NewFaker()
 	)
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -273,7 +273,7 @@ func TestTraceCall(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfigNoCel2,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
@@ -491,7 +491,7 @@ func TestTraceTransaction(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(2)
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfigNoCel2,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
@@ -593,7 +593,7 @@ func TestTraceBlock(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfigNoCel2,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
@@ -736,7 +736,7 @@ func TestTracingWithOverrides(t *testing.T) {
 	accounts := newAccounts(3)
 	storageAccount := common.Address{0x13, 37}
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfigNoCel2,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
@@ -1105,7 +1105,7 @@ func TestTraceChain(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: params.TestChainConfigNoCel2,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2273,10 +2273,8 @@ func testRPCResponseWithFile(t *testing.T, testid int, result interface{}, rpc s
 }
 
 func TestCeloTransaction_RoundTripRpcJSON(t *testing.T) {
-	config := params.TestChainConfig
-	var cel2Time uint64 = 0
-	config.Cel2Time = &cel2Time
 	var (
+		config = params.TestChainConfig
 		signer = types.LatestSigner(config)
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		tests  = celoTransactionTypes(common.Address{0xde, 0xad}, config)

--- a/params/config.go
+++ b/params/config.go
@@ -269,6 +269,7 @@ var (
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		VerkleTime:                    nil,
+		Cel2Time:                      newUint64(0),
 		TerminalTotalDifficulty:       nil,
 		TerminalTotalDifficultyPassed: false,
 		Ethash:                        new(EthashConfig),


### PR DESCRIPTION
A PR to see what it looks like to run tests with Cel2Time generally enabled, with specific disablings of Cel2Time.