### PR TITLE
Increase MaxCodeSize to 65536 as in Celo L1

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -128,8 +128,8 @@ func TestStateProcessorErrors(t *testing.T) {
 					},
 				},
 			}
-			blockchain, _  = NewBlockChain(db, nil, gspec, nil, beacon.New(ethash.NewFaker()), vm.Config{}, nil, nil)
-			tooBigInitCode = [params.MaxInitCodeSize + 1]byte{}
+			blockchain, _ = NewBlockChain(db, nil, gspec, nil, beacon.New(ethash.NewFaker()), vm.Config{}, nil, nil)
+			//tooBigInitCode = [params.MaxInitCodeSize + 1]byte{}
 		)
 
 		defer blockchain.Stop()
@@ -234,12 +234,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				},
 				want: "could not apply tx 0 [0xd82a0c2519acfeac9a948258c47e784acd20651d9d80f9a1c67b4137651c3a24]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 required balance exceeds 256 bits",
 			},
-			{ // ErrMaxInitCodeSizeExceeded
-				txs: []*types.Transaction{
-					mkDynamicCreationTx(0, 500000, common.Big0, big.NewInt(params.InitialBaseFee), tooBigInitCode[:]),
-				},
-				want: "could not apply tx 0 [0xd491405f06c92d118dd3208376fcee18a57c54bc52063ee4a26b1cf296857c25]: max initcode size exceeded: code size 49153 limit 49152",
-			},
+			// Disabled due to Celo MaxCodeSize change
+			// { // ErrMaxInitCodeSizeExceeded
+			// 	txs: []*types.Transaction{
+			// 		mkDynamicCreationTx(0, 500000, common.Big0, big.NewInt(params.InitialBaseFee), tooBigInitCode[:]),
+			// 	},
+			// 	want: "could not apply tx 0 [0xd491405f06c92d118dd3208376fcee18a57c54bc52063ee4a26b1cf296857c25]: max initcode size exceeded: code size 49153 limit 49152",
+			// },
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 54299, common.Big0, big.NewInt(params.InitialBaseFee), make([]byte, 320)),

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -123,13 +123,13 @@ var createGasTests = []struct {
 	// create2(0, 0, 0xc001, 0) without 3860
 	{"0x600061C00160006000f5" + "600052" + "60206000F3", false, 50471, 50471},
 	// create2(0, 0, 0xc001, 0) (too large), with 3860
-	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32012, 100_000},
+	//{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32012, 100_000},  // Disabled due to Celo MaxCodeSize change
 	// create2(0, 0, 0xc000, 0)
 	// This case is trying to deploy code at (within) the limit
 	{"0x600061C00060006000f5" + "600052" + "60206000F3", true, 53528, 53528},
 	// create2(0, 0, 0xc001, 0)
 	// This case is trying to deploy code exceeding the limit
-	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32024, 100000},
+	//{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32024, 100000},  // Disabled due to Celo MaxCodeSize change
 }
 
 func TestCreateGas(t *testing.T) {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -135,7 +135,7 @@ const (
 	DefaultElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee                  = 1000000000 // Initial base fee for EIP-1559 blocks.
 
-	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+	MaxCodeSize     = 65536           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
 
 	// Precompiled contract gas prices

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"math/rand"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -69,6 +70,13 @@ func TestExecutionSpecBlocktests(t *testing.T) {
 	bt := new(testMatcher)
 
 	bt.walk(t, executionSpecBlockchainTestDir, func(t *testing.T, name string, test *BlockTest) {
+		matches, err := regexp.MatchString("blockchain_test-create2?-over_limit_(ones|zeros)", name)
+		if err != nil {
+			t.Errorf("Bad regexp: %s", err)
+		}
+		if matches {
+			t.Skipf("Celo has increased the MaxCodeSize, which makes some tests invalid")
+		}
 		execBlockTest(t, bt, test)
 	})
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -94,6 +95,13 @@ func TestExecutionSpecState(t *testing.T) {
 	st := new(testMatcher)
 
 	st.walk(t, executionSpecStateTestDir, func(t *testing.T, name string, test *StateTest) {
+		matches, err := regexp.MatchString("state_test-(create2?-)?over_limit_(ones|zeros)", name)
+		if err != nil {
+			t.Errorf("Bad regexp: %s", err)
+		}
+		if matches {
+			t.Skipf("Celo has increased the MaxCodeSize, which makes some tests invalid")
+		}
 		execStateTest(t, st, test)
 	})
 }


### PR DESCRIPTION
This keeps compatibility with the Celo L1, so that both core contracts and third party contracts will be able to do fresh deploys after the L2 migration. If we want to go the Ethereum's value, it is better done some time after the L2 migration to avoid having many breaking changes at the same time.