### PR TITLE
Set random in CeloBackend to ensure IsMerge

### DIFF
--- a/contracts/celo_backend.go
+++ b/contracts/celo_backend.go
@@ -40,7 +40,11 @@ func (b *CeloBackend) CallContract(ctx context.Context, call ethereum.CallMsg, b
 	if blockNumber == nil {
 		blockNumber = common.Big0
 	}
-	blockCtx := vm.BlockContext{BlockNumber: blockNumber, Time: 0}
+	blockCtx := vm.BlockContext{
+		BlockNumber: blockNumber,
+		Time:        0,
+		Random:      &common.Hash{}, // Setting this is important since it is used to set IsMerge
+	}
 	txCtx := vm.TxContext{}
 	vmConfig := vm.Config{}
 


### PR DESCRIPTION
If this is not set, the PUSH0 instruction is not enabled, since both IsMerge and IsShanghai have to be true to enable it. Not enabling it can lead to reverts when calling core contracts from within op-geth (not via RPC).

The PR changes the result of `IsMerge` (second parameter) in https://github.com/celo-org/op-geth/blob/dbf5d2c55b61dbb51009ca360e4de682d2defc41/core/vm/evm.go#L175