### PR TITLE
ReadOnlyStateDB: Allow more calls

### DIFF
--- a/contracts/read_only_statedb.go
+++ b/contracts/read_only_statedb.go
@@ -15,6 +15,9 @@ import (
 //	GetState(common.Address, common.Hash) common.Hash
 //	GetCodeHash(common.Address) common.Hash
 //	GetCode(common.Address) []byte
+//	GetBalance(common.Address) *uint256.Int
+//	Exists(common.Address) bool
+//	Empty(common.Address) bool
 //
 // Gas calculations based on ReadOnlyStateDB will be wrong because the accessed storage slots and addresses are not tracked.
 type ReadOnlyStateDB struct {
@@ -34,10 +37,6 @@ func (r *ReadOnlyStateDB) AddBalance(_ common.Address, amount *uint256.Int) {
 		// Adding zero is safe, so we can return here
 		return
 	}
-	panic("not implemented")
-}
-
-func (r *ReadOnlyStateDB) GetBalance(common.Address) *uint256.Int {
 	panic("not implemented")
 }
 
@@ -94,14 +93,6 @@ func (r *ReadOnlyStateDB) HasSelfDestructed(common.Address) bool {
 }
 
 func (r *ReadOnlyStateDB) Selfdestruct6780(common.Address) {
-	panic("not implemented")
-}
-
-func (r *ReadOnlyStateDB) Exist(common.Address) bool {
-	panic("not implemented")
-}
-
-func (r *ReadOnlyStateDB) Empty(common.Address) bool {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
Allow more safe calls in the `ReadOnlyStateDB`

Fixes the culprit of https://github.com/celo-org/optimism/issues/181