### PR TITLE
Add support for legacy transaction signing

### DIFF
--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -23,9 +23,9 @@ import (
 	"github.com/ethereum/go-ethereum/common/exchange"
 )
 
-// CeloLegacy returns true if the transaction is a legacy celo transaction.
+// IsCeloLegacy returns true if the transaction is a legacy celo transaction.
 // I.E. it has the fields feeCurrency, gatewayFee and gatewayFeeRecipient.
-func (tx *Transaction) CeloLegacy() bool {
+func (tx *Transaction) IsCeloLegacy() bool {
 	switch t := tx.inner.(type) {
 	case *LegacyTx:
 		return t.CeloLegacy

--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -50,6 +50,7 @@ func (tx *Transaction) FeeCurrency() *common.Address {
 }
 
 // GatewayFee returns the gateway fee of the transaction if there is one.
+// Note: this is here to support serving legacy transactions over the RPC, it should not be used in new code.
 func (tx *Transaction) GatewayFee() *big.Int {
 	var gatewayFee *big.Int
 	switch t := tx.inner.(type) {
@@ -62,6 +63,7 @@ func (tx *Transaction) GatewayFee() *big.Int {
 }
 
 // GatewayFeeRecipient returns the gateway fee recipient of the transaction if there is one.
+// Note: this is here to support serving legacy transactions over the RPC, it should not be used in new code.
 func (tx *Transaction) GatewayFeeRecipient() *common.Address {
 	var gatewayFeeRecipient *common.Address
 	switch t := tx.inner.(type) {

--- a/core/types/celo_transaction.go
+++ b/core/types/celo_transaction.go
@@ -23,14 +23,54 @@ import (
 	"github.com/ethereum/go-ethereum/common/exchange"
 )
 
+// CeloLegacy returns true if the transaction is a legacy celo transaction.
+// I.E. it has the fields feeCurrency, gatewayFee and gatewayFeeRecipient.
+func (tx *Transaction) CeloLegacy() bool {
+	switch t := tx.inner.(type) {
+	case *LegacyTx:
+		return t.CeloLegacy
+	}
+	return false
+}
+
 // FeeCurrency returns the fee currency of the transaction if there is one.
 func (tx *Transaction) FeeCurrency() *common.Address {
 	var feeCurrency *common.Address
 	switch t := tx.inner.(type) {
+	case *CeloDynamicFeeTx:
+		feeCurrency = t.FeeCurrency
 	case *CeloDynamicFeeTxV2:
+		feeCurrency = t.FeeCurrency
+	case *CeloDenominatedTx:
+		feeCurrency = t.FeeCurrency
+	case *LegacyTx:
 		feeCurrency = t.FeeCurrency
 	}
 	return feeCurrency
+}
+
+// GatewayFee returns the gateway fee of the transaction if there is one.
+func (tx *Transaction) GatewayFee() *big.Int {
+	var gatewayFee *big.Int
+	switch t := tx.inner.(type) {
+	case *CeloDynamicFeeTx:
+		gatewayFee = t.GatewayFee
+	case *LegacyTx:
+		gatewayFee = t.GatewayFee
+	}
+	return gatewayFee
+}
+
+// GatewayFeeRecipient returns the gateway fee recipient of the transaction if there is one.
+func (tx *Transaction) GatewayFeeRecipient() *common.Address {
+	var gatewayFeeRecipient *common.Address
+	switch t := tx.inner.(type) {
+	case *CeloDynamicFeeTx:
+		gatewayFeeRecipient = t.GatewayFeeRecipient
+	case *LegacyTx:
+		gatewayFeeRecipient = t.GatewayFeeRecipient
+	}
+	return gatewayFeeRecipient
 }
 
 // MaxFeeInFeeCurrency returns the maximum fee in the fee currency of the transaction if there is one.

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -20,9 +20,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 )
 
-type cel2Signer struct{ londonSigner }
+// type cel2Signer struct{ londonSigner }
 
 // NewCel2Signer returns a signer that accepts
 // - CIP-64 celo dynamic fee transaction (v2)
@@ -31,80 +32,298 @@ type cel2Signer struct{ londonSigner }
 // - EIP-2930 access list transactions,
 // - EIP-155 replay protected transactions, and
 // - legacy Homestead transactions.
-func NewCel2Signer(chainId *big.Int) Signer {
-	return cel2Signer{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}
+// func NewCel2Signer(chainId *big.Int) Signer {
+// 	return cel2Signer{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}
+// }
+
+// func (s cel2Signer) Sender(tx *Transaction) (common.Address, error) {
+// 	if tx.Type() != CeloDynamicFeeTxV2Type && tx.Type() != CeloDenominatedTxType {
+// 		return s.londonSigner.Sender(tx)
+// 	}
+// 	V, R, S := tx.RawSignatureValues()
+// 	// DynamicFee txs are defined to use 0 and 1 as their recovery
+// 	// id, add 27 to become equivalent to unprotected Homestead signatures.
+// 	V = new(big.Int).Add(V, big.NewInt(27))
+// 	if tx.ChainId().Cmp(s.chainId) != 0 {
+// 		return common.Address{}, ErrInvalidChainId
+// 	}
+// 	return recoverPlain(s.Hash(tx), R, S, V, true)
+// }
+
+// func (s cel2Signer) Equal(s2 Signer) bool {
+// 	x, ok := s2.(cel2Signer)
+// 	return ok && x.chainId.Cmp(s.chainId) == 0
+// }
+
+// func (s cel2Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+// 	if tx.Type() != CeloDynamicFeeTxV2Type && tx.Type() != CeloDenominatedTxType {
+// 		return s.londonSigner.SignatureValues(tx, sig)
+// 	}
+
+// 	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+// 	// because it indicates that the chain ID was not specified in the tx.
+// 	chainID := tx.inner.chainID()
+// 	if chainID.Sign() != 0 && chainID.Cmp(s.chainId) != 0 {
+// 		return nil, nil, nil, ErrInvalidChainId
+// 	}
+// 	R, S, _ = decodeSignature(sig)
+// 	V = big.NewInt(int64(sig[64]))
+// 	return R, S, V, nil
+// }
+
+// // Hash returns the hash to be signed by the sender.
+// // It does not uniquely identify the transaction.
+// func (s cel2Signer) Hash(tx *Transaction) common.Hash {
+// 	if tx.Type() == CeloDynamicFeeTxV2Type {
+// 		return prefixedRlpHash(
+// 			tx.Type(),
+// 			[]interface{}{
+// 				s.chainId,
+// 				tx.Nonce(),
+// 				tx.GasTipCap(),
+// 				tx.GasFeeCap(),
+// 				tx.Gas(),
+// 				tx.To(),
+// 				tx.Value(),
+// 				tx.Data(),
+// 				tx.AccessList(),
+// 				tx.FeeCurrency(),
+// 			})
+// 	}
+// 	if tx.Type() == CeloDenominatedTxType {
+// 		return prefixedRlpHash(
+// 			tx.Type(),
+// 			[]interface{}{
+// 				s.chainId,
+// 				tx.Nonce(),
+// 				tx.GasTipCap(),
+// 				tx.GasFeeCap(),
+// 				tx.Gas(),
+// 				tx.To(),
+// 				tx.Value(),
+// 				tx.Data(),
+// 				tx.AccessList(),
+// 				tx.FeeCurrency(),
+// 				tx.MaxFeeInFeeCurrency(),
+// 			})
+// 	}
+// 	return s.londonSigner.Hash(tx)
+// }
+
+// func makeCeloSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64, upstreamSigner Signer) Signer {
+// 	signer := upstreamSigner
+// 	switch {
+// 	case config.IsCel2(blockTime):
+// 		signer = NewCel2Signer(config.ChainID)
+// 	}
+// 	return signer
+// }
+
+type celoSigner struct {
+	upstreamSigner Signer
+	chainID        *big.Int
+	activatedForks []forkID
 }
 
-func (s cel2Signer) Sender(tx *Transaction) (common.Address, error) {
-	if tx.Type() != CeloDynamicFeeTxV2Type && tx.Type() != CeloDenominatedTxType {
-		return s.londonSigner.Sender(tx)
+// ChainID implements Signer.
+func (c *celoSigner) ChainID() *big.Int {
+	return c.chainID
+}
+
+// Equal implements Signer.
+func (c *celoSigner) Equal(s Signer) bool {
+	// Normally singers just check to see if the chainID and type are equal, because their logic is completely
+	// hardcoded to a specific fork. In our case we need to also know that the two signers have matching latest forks.
+	other, ok := s.(*celoSigner)
+	return ok && c.ChainID() == other.ChainID() && c.latestFork().Equal(other.latestFork())
+}
+
+// Hash implements Signer.
+func (c *celoSigner) Hash(tx *Transaction) common.Hash {
+	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+		return funcs.hash(tx, c.ChainID())
 	}
+	return c.upstreamSigner.Hash(tx)
+}
+
+// Sender implements Signer.
+func (c *celoSigner) Sender(tx *Transaction) (common.Address, error) {
+	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+		return funcs.sender(tx, funcs.hash, c.ChainID())
+	}
+	return c.upstreamSigner.Sender(tx)
+}
+
+// SignatureValues implements Signer.
+func (c *celoSigner) SignatureValues(tx *Transaction, sig []byte) (r *big.Int, s *big.Int, v *big.Int, err error) {
+	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+		return funcs.signatureValues(tx, sig, c.ChainID())
+	}
+	return c.upstreamSigner.SignatureValues(tx, sig)
+}
+
+func (c *celoSigner) latestFork() forkID {
+	return c.activatedForks[len(c.activatedForks)-1]
+}
+
+func (c *celoSigner) findTxFuncs(txType uint8) *txFuncs {
+	// iterate in reverse over the activeForks and if any of them have a non nil txFuncs
+	// for the tx type then return it.
+	for i := len(c.activatedForks) - 1; i >= 0; i-- {
+		if funcs := c.activatedForks[i].TxFuncs(txType); funcs != nil {
+			return funcs
+		}
+	}
+	return nil
+}
+
+func makeCeloSigner(chainConfig *params.ChainConfig, blockTime uint64, upstreamSigner Signer) Signer {
+	s := &celoSigner{
+		chainID:        chainConfig.ChainID,
+		upstreamSigner: upstreamSigner,
+	}
+	// Iterate over forks and set the activated forks
+	for i, fork := range forks {
+		if fork.Active(blockTime, chainConfig) {
+			s.activatedForks = forks[:i+1]
+			break
+		}
+	}
+	// If there are no active celo forks, return the upstream signer
+	if s.activatedForks == nil {
+		return upstreamSigner
+	}
+	return s
+}
+
+func latestCeloSigner(chainID *big.Int, upstreamSigner Signer) Signer {
+	return &celoSigner{
+		chainID:        chainID,
+		upstreamSigner: upstreamSigner,
+		activatedForks: forks,
+	}
+}
+
+type forkID interface {
+	Active(blockTime uint64, config *params.ChainConfig) bool
+	Equal(forkID) bool
+	TxFuncs(txType uint8) *txFuncs
+}
+
+type cel2 struct{}
+
+func (c *cel2) Active(blockTime uint64, config *params.ChainConfig) bool {
+	return config.IsCel2(blockTime)
+}
+func (c *cel2) Equal(other forkID) bool {
+	_, ok := other.(*cel2)
+	return ok
+}
+func (c *cel2) TxFuncs(txType uint8) *txFuncs {
+	switch txType {
+	case CeloDynamicFeeTxV2Type:
+		return CeloDynamicFeeTxV2Funcs
+	case CeloDenominatedTxType:
+		return CeloDenominatedTxFuncs
+	}
+	return nil
+}
+
+// Returns the signature values for CeloDynamicFeeTxV2 and CeloDenominatedTx transactions.
+func dynamicAndDenominatedTxSigValues(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	chainID := tx.inner.chainID()
+	if chainID.Sign() != 0 && chainID.Cmp(signerChainID) != 0 {
+		return nil, nil, nil, ErrInvalidChainId
+	}
+	r, s, _ = decodeSignature(sig)
+	v = big.NewInt(int64(sig[64]))
+	return r, s, v, nil
+}
+
+func dynamicAndDenominatedTxSender(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
 	V, R, S := tx.RawSignatureValues()
 	// DynamicFee txs are defined to use 0 and 1 as their recovery
 	// id, add 27 to become equivalent to unprotected Homestead signatures.
 	V = new(big.Int).Add(V, big.NewInt(27))
-	if tx.ChainId().Cmp(s.chainId) != 0 {
+	if tx.ChainId().Cmp(signerChainID) != 0 {
 		return common.Address{}, ErrInvalidChainId
 	}
-	return recoverPlain(s.Hash(tx), R, S, V, true)
+	return recoverPlain(hashFunc(tx, signerChainID), R, S, V, true)
 }
 
-func (s cel2Signer) Equal(s2 Signer) bool {
-	x, ok := s2.(cel2Signer)
-	return ok && x.chainId.Cmp(s.chainId) == 0
+type txFuncs struct {
+	hash            func(tx *Transaction, chainID *big.Int) common.Hash
+	signatureValues func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error)
+	sender          func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error)
 }
 
-func (s cel2Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
-	if tx.Type() != CeloDynamicFeeTxV2Type && tx.Type() != CeloDenominatedTxType {
-		return s.londonSigner.SignatureValues(tx, sig)
-	}
+var (
+	forks       = []forkID{&cel2{}}
+	celoTxTypes = []uint8{CeloDynamicFeeTxType, CeloDynamicFeeTxV2Type, CeloDenominatedTxType}
 
-	// Check that chain ID of tx matches the signer. We also accept ID zero here,
-	// because it indicates that the chain ID was not specified in the tx.
-	chainID := tx.inner.chainID()
-	if chainID.Sign() != 0 && chainID.Cmp(s.chainId) != 0 {
-		return nil, nil, nil, ErrInvalidChainId
+	CeloDynamicFeeTxV2Funcs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return prefixedRlpHash(
+				tx.Type(),
+				[]interface{}{
+					chainID,
+					tx.Nonce(),
+					tx.GasTipCap(),
+					tx.GasFeeCap(),
+					tx.Gas(),
+					tx.To(),
+					tx.Value(),
+					tx.Data(),
+					tx.AccessList(),
+					tx.FeeCurrency(),
+				})
+		},
+		signatureValues: dynamicAndDenominatedTxSigValues,
+		sender:          dynamicAndDenominatedTxSender,
 	}
-	R, S, _ = decodeSignature(sig)
-	V = big.NewInt(int64(sig[64]))
-	return R, S, V, nil
-}
+	CeloDenominatedTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return prefixedRlpHash(
+				tx.Type(),
+				[]interface{}{
+					chainID,
+					tx.Nonce(),
+					tx.GasTipCap(),
+					tx.GasFeeCap(),
+					tx.Gas(),
+					tx.To(),
+					tx.Value(),
+					tx.Data(),
+					tx.AccessList(),
+					tx.FeeCurrency(),
+					tx.MaxFeeInFeeCurrency(),
+				})
+		},
+		signatureValues: dynamicAndDenominatedTxSigValues,
+		sender:          dynamicAndDenominatedTxSender,
+	}
+)
 
-// Hash returns the hash to be signed by the sender.
-// It does not uniquely identify the transaction.
-func (s cel2Signer) Hash(tx *Transaction) common.Hash {
-	if tx.Type() == CeloDynamicFeeTxV2Type {
-		return prefixedRlpHash(
-			tx.Type(),
-			[]interface{}{
-				s.chainId,
-				tx.Nonce(),
-				tx.GasTipCap(),
-				tx.GasFeeCap(),
-				tx.Gas(),
-				tx.To(),
-				tx.Value(),
-				tx.Data(),
-				tx.AccessList(),
-				tx.FeeCurrency(),
-			})
-	}
-	if tx.Type() == CeloDenominatedTxType {
-		return prefixedRlpHash(
-			tx.Type(),
-			[]interface{}{
-				s.chainId,
-				tx.Nonce(),
-				tx.GasTipCap(),
-				tx.GasFeeCap(),
-				tx.Gas(),
-				tx.To(),
-				tx.Value(),
-				tx.Data(),
-				tx.AccessList(),
-				tx.FeeCurrency(),
-				tx.MaxFeeInFeeCurrency(),
-			})
-	}
-	return s.londonSigner.Hash(tx)
-}
+// CeloDynamicFeeTxFuncs = &txFuncs{
+// 	hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+// 		inner := tx.inner.(*CeloDynamicFeeTx)
+// 		return prefixedRlpHash(
+// 			tx.Type(),
+// 			[]interface{}{
+// 				s.chainId,
+// 				tx.Nonce(),
+// 				tx.GasTipCap(),
+// 				tx.GasFeeCap(),
+// 				tx.Gas(),
+// 				tx.FeeCurrency(),
+// 				inner.GatewayFeeRecipient,
+// 				inner.GatewayFee,
+// 				tx.To(),
+// 				tx.Value(),
+// 				tx.Data(),
+// 				tx.AccessList(),
+// 			})
+// 	},
+// }

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -94,7 +94,7 @@ func (c *celoSigner) Hash(tx *Transaction) common.Hash {
 
 // findTxFuncs returns the txFuncs for the given tx if it is supported by one
 // of the active forks. Note that this mechanism can be used to deprecate
-// support for tx types by having forks reutrn deprecatedTxFuncs for a tx type.
+// support for tx types by having forks return deprecatedTxFuncs for a tx type.
 func (c *celoSigner) findTxFuncs(tx *Transaction) *txFuncs {
 	return c.activatedForks.findTxFuncs(tx)
 }

--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -26,19 +26,18 @@ import (
 
 var (
 	ErrDeprecatedTxType = errors.New("deprecated transaction type")
-	forks               = []forkID{&cel2{}}
 )
 
 // celoSigner acts as an overlay signer that handles celo specific signing
 // functionality and hands off to an upstream signer for any other transaction
 // types. Unlike the signers in the go-ethereum library, the celoSigner is
-// configured with a list of forks that determine it's singing capabilities so
+// configured with a list of forks that determine it's signing capabilities so
 // there should not be a need to create any further signers to handle celo
 // specific transaction types.
 type celoSigner struct {
 	upstreamSigner Signer
 	chainID        *big.Int
-	activatedForks []forkID
+	activatedForks []fork
 }
 
 // makeCeloSigner creates a new celoSigner that is configured to handle all
@@ -76,7 +75,7 @@ func latestCeloSigner(chainID *big.Int, upstreamSigner Signer) Signer {
 
 // Sender implements Signer.
 func (c *celoSigner) Sender(tx *Transaction) (common.Address, error) {
-	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+	if funcs := c.findTxFuncs(tx); funcs != nil {
 		return funcs.sender(tx, funcs.hash, c.ChainID())
 	}
 	return c.upstreamSigner.Sender(tx)
@@ -84,7 +83,7 @@ func (c *celoSigner) Sender(tx *Transaction) (common.Address, error) {
 
 // SignatureValues implements Signer.
 func (c *celoSigner) SignatureValues(tx *Transaction, sig []byte) (r *big.Int, s *big.Int, v *big.Int, err error) {
-	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+	if funcs := c.findTxFuncs(tx); funcs != nil {
 		return funcs.signatureValues(tx, sig, c.ChainID())
 	}
 	return c.upstreamSigner.SignatureValues(tx, sig)
@@ -92,21 +91,20 @@ func (c *celoSigner) SignatureValues(tx *Transaction, sig []byte) (r *big.Int, s
 
 // Hash implements Signer.
 func (c *celoSigner) Hash(tx *Transaction) common.Hash {
-	if funcs := c.findTxFuncs(tx.Type()); funcs != nil {
+	if funcs := c.findTxFuncs(tx); funcs != nil {
 		return funcs.hash(tx, c.ChainID())
 	}
 	return c.upstreamSigner.Hash(tx)
 }
 
-// findTxFuncs returns the txFuncs for the given tx type if it is supported by
-// one of the active forks. note that this mechanism can be used to deprecate
-// support for tx types in future forks, by having forks reutrn
-// deprecatedTxFuncs for a tx type.
-func (c *celoSigner) findTxFuncs(txType uint8) *txFuncs {
+// findTxFuncs returns the txFuncs for the given tx if it is supported by one
+// of the active forks. Note that this mechanism can be used to deprecate
+// support for tx types by having forks reutrn deprecatedTxFuncs for a tx type.
+func (c *celoSigner) findTxFuncs(tx *Transaction) *txFuncs {
 	// iterate in reverse over the activeForks and if any of them have a non nil txFuncs
-	// for the tx type then return it.
+	// for the tx then return it.
 	for i := len(c.activatedForks) - 1; i >= 0; i-- {
-		if funcs := c.activatedForks[i].txFuncs(txType); funcs != nil {
+		if funcs := c.activatedForks[i].txFuncs(tx); funcs != nil {
 			return funcs
 		}
 	}
@@ -120,50 +118,13 @@ func (c *celoSigner) ChainID() *big.Int {
 
 // Equal implements Signer.
 func (c *celoSigner) Equal(s Signer) bool {
-	// Normally singers just check to see if the chainID and type are equal,
+	// Normally signers just check to see if the chainID and type are equal,
 	// because their logic is hardcoded to a specific fork. In our case we need
 	// to also know that the two signers have matching latest forks.
 	other, ok := s.(*celoSigner)
 	return ok && c.ChainID() == other.ChainID() && c.latestFork().equal(other.latestFork())
 }
 
-func (c *celoSigner) latestFork() forkID {
+func (c *celoSigner) latestFork() fork {
 	return c.activatedForks[len(c.activatedForks)-1]
-}
-
-// forkID represents a fork. It contains functionality to determine if it is
-// active for a given block time and chain config and also acts as a container
-// for functionality related to transactions enabled in that fork.
-type forkID interface {
-	// active returns true if the fork is active at the given block time.
-	active(blockTime uint64, config *params.ChainConfig) bool
-	// equal returns true if the given fork is the same underlying type as this fork.
-	equal(forkID) bool
-	// txFuncs returns the txFuncs for the given tx type if it is supported by
-	// the fork. If a fork deprecates a tx type then this function should
-	// return deprecatedTxFuncs for that tx type.
-	txFuncs(txType uint8) *txFuncs
-}
-
-// Cel2 is the fork marking the transition point from an L1 to an L2. At
-// present it provides support for all historical celo tx types.
-type cel2 struct{}
-
-func (c *cel2) active(blockTime uint64, config *params.ChainConfig) bool {
-	return config.IsCel2(blockTime)
-}
-
-func (c *cel2) equal(other forkID) bool {
-	_, ok := other.(*cel2)
-	return ok
-}
-
-func (c *cel2) txFuncs(txType uint8) *txFuncs {
-	switch txType {
-	case CeloDynamicFeeTxV2Type:
-		return celoDynamicFeeTxV2Funcs
-	case CeloDenominatedTxType:
-		return celoDenominatedTxFuncs
-	}
-	return nil
 }

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -62,7 +62,7 @@ func (c *cel2) equal(other fork) bool {
 func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 	t := tx.Type()
 	switch {
-	case t == LegacyTxType && tx.CeloLegacy():
+	case t == LegacyTxType && tx.IsCeloLegacy():
 		return deprecatedTxFuncs
 	case t == CeloDenominatedTxType:
 		return deprecatedTxFuncs
@@ -92,7 +92,7 @@ func (c *celoLegacy) equal(other fork) bool {
 func (c *celoLegacy) txFuncs(tx *Transaction) *txFuncs {
 	t := tx.Type()
 	switch {
-	case t == uint8(LegacyTxType) && tx.CeloLegacy():
+	case t == uint8(LegacyTxType) && tx.IsCeloLegacy():
 		if tx.Protected() {
 			return celoLegacyProtectedTxFuncs
 		}

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -54,7 +54,8 @@ func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 type celoLegacy struct{}
 
 func (c *celoLegacy) active(blockTime uint64, config *params.ChainConfig) bool {
-	return config.IsCel2(blockTime)
+	// The celo legacy fork is always active in a celo context
+	return config.Cel2Time != nil
 }
 
 func (c *celoLegacy) equal(other fork) bool {

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -1,0 +1,79 @@
+package types
+
+import "github.com/ethereum/go-ethereum/params"
+
+var (
+	forks = []fork{&celoLegacy{}, &cel2{}}
+)
+
+// fork contains functionality to determine if it is active for a given block
+// time and chain config. It also acts as a container for functionality related
+// to transactions enabled or deprecated in that fork.
+type fork interface {
+	// active returns true if the fork is active at the given block time.
+	active(blockTime uint64, config *params.ChainConfig) bool
+	// equal returns true if the given fork is the same underlying type as this fork.
+	equal(fork) bool
+	// txFuncs returns the txFuncs for the given tx if it is supported by the
+	// fork. If a fork deprecates a tx type then this function should return
+	// deprecatedTxFuncs for that tx type.
+	txFuncs(tx *Transaction) *txFuncs
+}
+
+// Cel2 is the fork marking the transition point from an L1 to an L2.
+// It deprecates CeloDynamicFeeTxType and LegacyTxTypes with CeloLegacy set to true.
+type cel2 struct{}
+
+func (c *cel2) active(blockTime uint64, config *params.ChainConfig) bool {
+	return config.IsCel2(blockTime)
+}
+
+func (c *cel2) equal(other fork) bool {
+	_, ok := other.(*cel2)
+	return ok
+}
+
+func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
+	t := tx.Type()
+	switch {
+	case t == LegacyTxType && tx.CeloLegacy():
+		return deprecatedTxFuncs
+	case t == CeloDenominatedTxType:
+		return deprecatedTxFuncs
+	}
+	return nil
+}
+
+// celoLegacy isn't actually a fork, but a placeholder for all historical celo
+// related forks occurring on the celo L1. We don't need to construct the full
+// signer chain from the celo legacy project because we won't support
+// historical transaction execution, so we just need to be able to derive the
+// senders for historical transactions and since we assume that the historical
+// data is correct we just need one blanket signer that can cover all legacy
+// celo transactions, before the L2 transition point.
+type celoLegacy struct{}
+
+func (c *celoLegacy) active(blockTime uint64, config *params.ChainConfig) bool {
+	return config.IsCel2(blockTime)
+}
+
+func (c *celoLegacy) equal(other fork) bool {
+	_, ok := other.(*cel2)
+	return ok
+}
+
+func (c *celoLegacy) txFuncs(tx *Transaction) *txFuncs {
+	t := tx.Type()
+	switch {
+	case t == uint8(LegacyTxType) && tx.CeloLegacy():
+		if tx.Protected() {
+			return celoLegacyProtectedTxFuncs
+		}
+		return celoLegacyUnprotectedTxFuncs
+	case t == CeloDynamicFeeTxV2Type:
+		return celoDynamicFeeTxV2Funcs
+	case t == CeloDenominatedTxType:
+		return celoDenominatedTxFuncs
+	}
+	return nil
+}

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -16,7 +16,7 @@ type forks []fork
 func (f forks) activeForks(blockTime uint64, config *params.ChainConfig) []fork {
 	for i, fork := range f {
 		if fork.active(blockTime, config) {
-			return f[:i+1]
+			return f[i:]
 		}
 	}
 	return nil

--- a/core/types/celo_transaction_signing_tx_funcs.go
+++ b/core/types/celo_transaction_signing_tx_funcs.go
@@ -1,0 +1,193 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+
+	// deprecatedTxFuncs should be returned by forks that have deprecated support for a tx type.
+	deprecatedTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return tx.Hash()
+		},
+		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+			return nil, nil, nil, fmt.Errorf("%w %v", ErrDeprecatedTxType, tx.Type())
+		},
+		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+			return common.Address{}, fmt.Errorf("%w %v", ErrDeprecatedTxType, tx.Type())
+		},
+	}
+
+	celoLegacyUnprotectedTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return rlpHash([]interface{}{
+				tx.Nonce(),
+				tx.GasPrice(),
+				tx.Gas(),
+				tx.FeeCurrency(),
+				tx.GatewayFeeRecipient(),
+				tx.GatewayFee(),
+				tx.To(),
+				tx.Value(),
+				tx.Data(),
+			})
+
+		},
+		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+			r, s, v = decodeSignature(sig)
+			return r, s, v, nil
+		},
+		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+			v, r, s := tx.RawSignatureValues()
+			return recoverPlain(hashFunc(tx, signerChainID), r, s, v, true)
+		},
+	}
+
+	celoLegacyProtectedTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return rlpHash([]interface{}{
+				tx.Nonce(),
+				tx.GasPrice(),
+				tx.Gas(),
+				tx.FeeCurrency(),
+				tx.GatewayFeeRecipient(),
+				tx.GatewayFee(),
+				tx.To(),
+				tx.Value(),
+				tx.Data(),
+				chainID, uint(0), uint(0),
+			})
+
+		},
+		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+			r, s, v = decodeSignature(sig)
+			if signerChainID.Sign() != 0 {
+				v = big.NewInt(int64(sig[64] + 35))
+				signerChainMul := new(big.Int).Mul(signerChainID, big.NewInt(2))
+				v.Add(v, signerChainMul)
+			}
+			return r, s, v, nil
+		},
+		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+			if tx.ChainId().Cmp(signerChainID) != 0 {
+				return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), signerChainID)
+			}
+			v, r, s := tx.RawSignatureValues()
+			signerChainMul := new(big.Int).Mul(signerChainID, big.NewInt(2))
+			v = new(big.Int).Sub(v, signerChainMul)
+			v.Sub(v, big8)
+			return recoverPlain(hashFunc(tx, signerChainID), r, s, v, true)
+		},
+	}
+
+	CeloDynamicFeeTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return prefixedRlpHash(
+				tx.Type(),
+				[]interface{}{
+					chainID,
+					tx.Nonce(),
+					tx.GasTipCap(),
+					tx.GasFeeCap(),
+					tx.Gas(),
+					tx.FeeCurrency(),
+					tx.GatewayFeeRecipient(),
+					tx.GatewayFee(),
+					tx.To(),
+					tx.Value(),
+					tx.Data(),
+					tx.AccessList(),
+				})
+		},
+		signatureValues: dynamicAndDenominatedTxSigValues,
+		sender:          dynamicAndDenominatedTxSender,
+	}
+
+	// Custom signing functionality for CeloDynamicFeeTxV2 txs.
+	celoDynamicFeeTxV2Funcs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return prefixedRlpHash(
+				tx.Type(),
+				[]interface{}{
+					chainID,
+					tx.Nonce(),
+					tx.GasTipCap(),
+					tx.GasFeeCap(),
+					tx.Gas(),
+					tx.To(),
+					tx.Value(),
+					tx.Data(),
+					tx.AccessList(),
+					tx.FeeCurrency(),
+				})
+		},
+		signatureValues: dynamicAndDenominatedTxSigValues,
+		sender:          dynamicAndDenominatedTxSender,
+	}
+
+	// Custom signing functionality for CeloDenominatedTx txs.
+	celoDenominatedTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return prefixedRlpHash(
+				tx.Type(),
+				[]interface{}{
+					chainID,
+					tx.Nonce(),
+					tx.GasTipCap(),
+					tx.GasFeeCap(),
+					tx.Gas(),
+					tx.To(),
+					tx.Value(),
+					tx.Data(),
+					tx.AccessList(),
+					tx.FeeCurrency(),
+					tx.MaxFeeInFeeCurrency(),
+				})
+		},
+		signatureValues: dynamicAndDenominatedTxSigValues,
+		sender:          dynamicAndDenominatedTxSender,
+	}
+)
+
+// txFuncs serves as a container to hold custom signing functionality for a tranaction.
+//
+// TODO consider changing this to an interface, it might probably make thigs
+// easier because then I could store custom bits of data relevant to each tx
+// type / signer such as the signerChainMul. It would also solve the problem of
+// having to pass the hash function into the sender function.
+type txFuncs struct {
+	hash            func(tx *Transaction, chainID *big.Int) common.Hash
+	signatureValues func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error)
+	sender          func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error)
+}
+
+// Returns the signature values for CeloDynamicFeeTxV2 and CeloDenominatedTx
+// transactions.
+func dynamicAndDenominatedTxSigValues(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	chainID := tx.inner.chainID()
+	if chainID.Sign() != 0 && chainID.Cmp(signerChainID) != 0 {
+		return nil, nil, nil, ErrInvalidChainId
+	}
+	r, s, _ = decodeSignature(sig)
+	v = big.NewInt(int64(sig[64]))
+	return r, s, v, nil
+}
+
+// Returns the sender for CeloDynamicFeeTxV2 and CeloDenominatedTx
+// transactions.
+func dynamicAndDenominatedTxSender(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+	if tx.ChainId().Cmp(signerChainID) != 0 {
+		return common.Address{}, ErrInvalidChainId
+	}
+	V, R, S := tx.RawSignatureValues()
+	// DynamicFee txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	return recoverPlain(hashFunc(tx, signerChainID), R, S, V, true)
+}

--- a/core/types/celo_transaction_signing_tx_funcs.go
+++ b/core/types/celo_transaction_signing_tx_funcs.go
@@ -103,12 +103,12 @@ var (
 	}
 )
 
-// txFuncs serves as a container to hold custom signing functionality for a tranaction.
+// txFuncs serves as a container to hold custom signing functionality for a transaction.
 //
-// TODO consider changing this to an interface, it might probably make thigs
-// easier because then I could store custom bits of data relevant to each tx
-// type / signer such as the signerChainMul. It would also solve the problem of
-// having to pass the hash function into the sender function.
+// TODO consider changing this to an interface, it might make things easier
+// because then I could store custom bits of data relevant to each tx type /
+// signer such as the signerChainMul. It would also solve the problem of having
+// to pass the hash function into the sender function.
 type txFuncs struct {
 	hash            func(tx *Transaction, chainID *big.Int) common.Hash
 	signatureValues func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -42,8 +42,6 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 	switch {
 	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
 		signer = NewCancunSigner(config.ChainID)
-	case config.IsCel2(blockTime):
-		signer = NewCel2Signer(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsBerlin(blockNumber):
@@ -55,6 +53,10 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 	default:
 		signer = FrontierSigner{}
 	}
+
+	// Apply the celo overlay signer, if no celo forks have been enabled then the given signer is returned.
+	signer = makeCeloSigner(config, blockTime, signer)
+
 	return signer
 }
 
@@ -66,12 +68,13 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
+
 	if config.ChainID != nil {
 		if config.CancunTime != nil && !config.IsOptimism() {
 			return NewCancunSigner(config.ChainID)
 		}
 		if config.Cel2Time != nil {
-			return NewCel2Signer(config.ChainID)
+			return latestCeloSigner(config.ChainID, NewLondonSigner(config.ChainID))
 		}
 		if config.LondonBlock != nil {
 			return NewLondonSigner(config.ChainID)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -68,7 +68,6 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
-
 	if config.ChainID != nil {
 		if config.CancunTime != nil && !config.IsOptimism() {
 			return NewCancunSigner(config.ChainID)


### PR DESCRIPTION
Introduces an overlay celo signer that is able to handle all celo related transaction signing and hand off to an upstream signer for everything non celo.

Also adds signing support for celo legacy transactions, which we need because signers are required to derive transaction senders, so without singers we won't be able to correctly serve historical transactions over the RPC API.

Also adds support for deprecating transactions.

In it's current form the code considers that celo legacy transactions (type 0 with feeCurrency, gatewayFee & gatewayFeeRecipient) and CeloDynamicFeeTx (type 124) will be deprecated by the cel2 fork. This may not be the case but it is very easy to change that.


- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/269
- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/366

