### PR TITLE
Rename Gold to CELO

### DIFF
--- a/common/exchange/rates.go
+++ b/common/exchange/rates.go
@@ -18,18 +18,18 @@ var (
 
 // ConvertCurrency does an exchange conversion from currencyFrom to currencyTo of the value given.
 func ConvertCurrency(exchangeRates common.ExchangeRates, val1 *big.Int, currencyFrom *common.Address, currencyTo *common.Address) *big.Int {
-	goldAmount, err := ConvertCurrencyToGold(exchangeRates, val1, currencyFrom)
+	celoAmount, err := ConvertCurrencyToCelo(exchangeRates, val1, currencyFrom)
 	if err != nil {
-		log.Error("Error trying to convert from currency to gold.", "value", val1, "fromCurrency", currencyFrom.Hex())
+		log.Error("Error trying to convert from currency to CELO.", "value", val1, "fromCurrency", currencyFrom.Hex())
 	}
-	toAmount, err := ConvertGoldToCurrency(exchangeRates, currencyTo, goldAmount)
+	toAmount, err := ConvertCeloToCurrency(exchangeRates, currencyTo, celoAmount)
 	if err != nil {
-		log.Error("Error trying to convert from gold to currency.", "value", goldAmount, "toCurrency", currencyTo.Hex())
+		log.Error("Error trying to convert from CELO to currency.", "value", celoAmount, "toCurrency", currencyTo.Hex())
 	}
 	return toAmount
 }
 
-func ConvertCurrencyToGold(exchangeRates common.ExchangeRates, currencyAmount *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+func ConvertCurrencyToCelo(exchangeRates common.ExchangeRates, currencyAmount *big.Int, feeCurrency *common.Address) (*big.Int, error) {
 	if feeCurrency == nil {
 		return currencyAmount, nil
 	}
@@ -42,15 +42,15 @@ func ConvertCurrencyToGold(exchangeRates common.ExchangeRates, currencyAmount *b
 	return new(big.Int).Div(new(big.Int).Mul(currencyAmount, exchangeRate.Denom()), exchangeRate.Num()), nil
 }
 
-func ConvertGoldToCurrency(exchangeRates common.ExchangeRates, feeCurrency *common.Address, goldAmount *big.Int) (*big.Int, error) {
+func ConvertCeloToCurrency(exchangeRates common.ExchangeRates, feeCurrency *common.Address, celoAmount *big.Int) (*big.Int, error) {
 	if feeCurrency == nil {
-		return goldAmount, nil
+		return celoAmount, nil
 	}
 	exchangeRate, ok := exchangeRates[*feeCurrency]
 	if !ok {
 		return nil, fmt.Errorf("could not convert from native to fee currency (fee-currency=%s): %w ", feeCurrency, ErrNonWhitelistedFeeCurrency)
 	}
-	return new(big.Int).Div(new(big.Int).Mul(goldAmount, exchangeRate.Num()), exchangeRate.Denom()), nil
+	return new(big.Int).Div(new(big.Int).Mul(celoAmount, exchangeRate.Num()), exchangeRate.Denom()), nil
 }
 
 func getRate(exchangeRates common.ExchangeRates, feeCurrency *common.Address) (*big.Rat, error) {
@@ -150,7 +150,7 @@ func (rf *RatesAndFees) GetBaseFeeIn(currency *common.Address) *big.Int {
 		return baseFee
 	}
 	// Not found, calculate
-	calculatedBaseFee, err := ConvertGoldToCurrency(rf.Rates, currency, rf.nativeBaseFee)
+	calculatedBaseFee, err := ConvertCeloToCurrency(rf.Rates, currency, rf.nativeBaseFee)
 	if err != nil {
 		// Should never happen: error lvl log line
 		log.Error("BaseFee requested for non whitelisted currency",

--- a/contracts/celo/README.md
+++ b/contracts/celo/README.md
@@ -4,7 +4,7 @@
 
 The contracts bytecode is used to generate the genesis block in `geth --dev`
 mode while the ABI is used to generate the contract bindings in `abigen`. The
-bindings are necessary to access the Registry and GoldToken to support Celo
+bindings are necessary to access the CeloToken to support Celo
 features like token duality.
 
 ## How to update to newer contracts

--- a/core/blockchain_celo_test.go
+++ b/core/blockchain_celo_test.go
@@ -120,7 +120,7 @@ func testNativeTransferWithFeeCurrency(t *testing.T, scheme string, feeCurrencyA
 	if err != nil {
 		t.Fatal("could not get exchange rates")
 	}
-	baseFeeInFeeCurrency, _ := exchange.ConvertGoldToCurrency(exchangeRates, &feeCurrencyAddr, block.BaseFee())
+	baseFeeInFeeCurrency, _ := exchange.ConvertCeloToCurrency(exchangeRates, &feeCurrencyAddr, block.BaseFee())
 	actual, _ := contracts.GetBalanceERC20(&backend, block.Coinbase(), feeCurrencyAddr)
 
 	// 3: Ensure that miner received only the tx's tip.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -156,7 +156,7 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 	if tx.Type() == types.CeloDynamicFeeTxV2Type {
 		alternativeBaseFee := evm.Context.BaseFee
 		if msg.FeeCurrency != nil {
-			alternativeBaseFee, err = exchange.ConvertGoldToCurrency(evm.Context.ExchangeRates, msg.FeeCurrency, evm.Context.BaseFee)
+			alternativeBaseFee, err = exchange.ConvertCeloToCurrency(evm.Context.ExchangeRates, msg.FeeCurrency, evm.Context.BaseFee)
 			if err != nil {
 				return nil, err
 			}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -180,7 +180,7 @@ type Message struct {
 	// Celo additions
 
 	// FeeCurrency specifies the currency for gas fees.
-	// `nil` corresponds to Celo Gold (native currency).
+	// `nil` corresponds to CELO (native currency).
 	// All other values should correspond to ERC20 contract addresses.
 	FeeCurrency         *common.Address
 	MaxFeeInFeeCurrency *big.Int // MaxFeeInFeeCurrency is the maximum fee that can be charged in the fee currency.
@@ -214,7 +214,7 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 	if baseFee != nil {
 		if tx.Type() == types.CeloDynamicFeeTxV2Type {
 			var err error
-			baseFee, err = exchange.ConvertGoldToCurrency(exchangeRates, msg.FeeCurrency, baseFee)
+			baseFee, err = exchange.ConvertCeloToCurrency(exchangeRates, msg.FeeCurrency, baseFee)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +305,7 @@ func (st *StateTransition) buyGas() error {
 		// L1 data fee needs to be converted in fee currency
 		if st.msg.FeeCurrency != nil && l1Cost != nil {
 			// Existence of the fee currency has been checked in `preCheck`
-			l1Cost, _ = exchange.ConvertGoldToCurrency(st.evm.Context.ExchangeRates, st.msg.FeeCurrency, l1Cost)
+			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, st.msg.FeeCurrency, l1Cost)
 		}
 	}
 	if l1Cost != nil {
@@ -463,7 +463,7 @@ func (st *StateTransition) preCheck() error {
 
 			// This will panic if baseFee is nil, but basefee presence is verified
 			// as part of header validation.
-			baseFeeInFeeCurrency, err := exchange.ConvertGoldToCurrency(st.evm.Context.ExchangeRates, msg.FeeCurrency, st.evm.Context.BaseFee)
+			baseFeeInFeeCurrency, err := exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, msg.FeeCurrency, st.evm.Context.BaseFee)
 			if err != nil {
 				return fmt.Errorf("preCheck: %w", err)
 			}
@@ -776,7 +776,7 @@ func (st *StateTransition) distributeTxFees() error {
 		}
 	} else {
 		if l1Cost != nil {
-			l1Cost, _ = exchange.ConvertGoldToCurrency(st.evm.Context.ExchangeRates, feeCurrency, l1Cost)
+			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, feeCurrency, l1Cost)
 		}
 		if err := contracts.CreditFees(st.evm, feeCurrency, from, st.evm.Context.Coinbase, feeHandlerAddress, params.OptimismL1FeeRecipient, refund, tipTxFee, baseTxFee, l1Cost); err != nil {
 			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "feeHandler", feeHandlerAddress, "err", err)
@@ -798,7 +798,7 @@ func (st *StateTransition) calculateBaseFee() *big.Int {
 
 	if st.msg.FeeCurrency != nil {
 		// Existence of the fee currency has been checked in `preCheck`
-		baseFee, _ = exchange.ConvertGoldToCurrency(st.evm.Context.ExchangeRates, st.msg.FeeCurrency, baseFee)
+		baseFee, _ = exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, st.msg.FeeCurrency, baseFee)
 	}
 
 	return baseFee

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -54,7 +54,7 @@ func (ctx *celoPrecompileContext) IsCallerCeloToken() (bool, error) {
 	return tokenAddress == ctx.caller, nil
 }
 
-// Native transfer contract to make Celo Gold ERC20 compatible.
+// Native transfer contract to make CELO ERC20 compatible.
 type transfer struct{}
 
 func (c *transfer) RequiredGas(input []byte) uint64 {
@@ -71,7 +71,7 @@ func (c *transfer) Run(input []byte, ctx *celoPrecompileContext) ([]byte, error)
 	// input is comprised of 3 arguments:
 	//   from:  32 bytes representing the address of the sender
 	//   to:    32 bytes representing the address of the recipient
-	//   value: 32 bytes, a 256 bit integer representing the amount of Celo Gold to transfer
+	//   value: 32 bytes, a 256 bit integer representing the amount of CELO to transfer
 	// 3 arguments x 32 bytes each = 96 bytes total input
 	if len(input) != 96 {
 		return nil, ErrInputLength

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -78,7 +78,7 @@ func Estimate(ctx context.Context, call *core.Message, opts *Options, gasCap uin
 				// CIP-66, prices are given in native token.
 				// We need to check the allowance in the converted feeCurrency
 				var err error
-				feeCap, err = exchange.ConvertGoldToCurrency(exchangeRates, call.FeeCurrency, feeCap)
+				feeCap, err = exchange.ConvertCeloToCurrency(exchangeRates, call.FeeCurrency, feeCap)
 				if err != nil {
 					return 0, nil, err
 				}

--- a/internal/celoapi/api.go
+++ b/internal/celoapi/api.go
@@ -31,7 +31,7 @@ func NewCeloAPI(e Ethereum, b ethapi.CeloBackend) *CeloAPI {
 
 func (c *CeloAPI) convertedCurrencyValue(v *hexutil.Big, feeCurrency *common.Address) (*hexutil.Big, error) {
 	if feeCurrency != nil {
-		convertedTipCap, err := c.convertGoldToCurrency(v.ToInt(), feeCurrency)
+		convertedTipCap, err := c.convertCeloToCurrency(v.ToInt(), feeCurrency)
 		if err != nil {
 			return nil, fmt.Errorf("convert to feeCurrency: %w", err)
 		}
@@ -53,7 +53,7 @@ func (c *CeloAPI) celoBackendCurrentState() (*contracts.CeloBackend, error) {
 	return cb, nil
 }
 
-func (c *CeloAPI) convertGoldToCurrency(nativePrice *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+func (c *CeloAPI) convertCeloToCurrency(nativePrice *big.Int, feeCurrency *common.Address) (*big.Int, error) {
 	cb, err := c.celoBackendCurrentState()
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (c *CeloAPI) convertGoldToCurrency(nativePrice *big.Int, feeCurrency *commo
 	if err != nil {
 		return nil, fmt.Errorf("retrieve exchange rates from current state: %w", err)
 	}
-	return exchange.ConvertGoldToCurrency(er, feeCurrency, nativePrice)
+	return exchange.ConvertCeloToCurrency(er, feeCurrency, nativePrice)
 }
 
 // GasPrice wraps the original JSON RPC `eth_gasPrice` and adds an additional

--- a/internal/celoapi/backend.go
+++ b/internal/celoapi/backend.go
@@ -60,18 +60,18 @@ func (b *CeloAPIBackend) GetExchangeRates(ctx context.Context, blockNumOrHash rp
 	return er, nil
 }
 
-func (b *CeloAPIBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, goldAmount *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
+func (b *CeloAPIBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, celoAmount *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
 	er, err := b.GetExchangeRates(ctx, blockNumOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return exchange.ConvertGoldToCurrency(er, toFeeCurrency, goldAmount)
+	return exchange.ConvertCeloToCurrency(er, toFeeCurrency, celoAmount)
 }
 
-func (b *CeloAPIBackend) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, currencyAmount *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
+func (b *CeloAPIBackend) ConvertToCelo(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, currencyAmount *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
 	er, err := b.GetExchangeRates(ctx, blockNumOrHash)
 	if err != nil {
 		return nil, err
 	}
-	return exchange.ConvertCurrencyToGold(er, currencyAmount, fromFeeCurrency)
+	return exchange.ConvertCurrencyToCelo(er, currencyAmount, fromFeeCurrency)
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -620,7 +620,7 @@ func (c *celoTestBackend) ConvertToCurrency(ctx context.Context, blockNumOrHash 
 	return nil, errCeloNotImplemented
 }
 
-func (c *celoTestBackend) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+func (c *celoTestBackend) ConvertToCelo(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error) {
 	if feeCurrency == nil {
 		return value, nil
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -43,7 +43,7 @@ type CeloBackend interface {
 	GetFeeBalance(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, account common.Address, feeCurrency *common.Address) (*big.Int, error)
 	GetExchangeRates(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error)
 	ConvertToCurrency(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
-	ConvertToGold(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
+	ConvertToCelo(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, value *big.Int, feeCurrency *common.Address) (*big.Int, error)
 }
 
 // Backend interface provides the common API services (that are provided by both full and light clients) with access to necessary functions.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -472,7 +472,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ex
 			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
 				if args.IsFeeCurrencyDenominated() {
 					var err error
-					baseFee, err = exchange.ConvertGoldToCurrency(exchangeRates, args.FeeCurrency, baseFee)
+					baseFee, err = exchange.ConvertCeloToCurrency(exchangeRates, args.FeeCurrency, baseFee)
 					if err != nil {
 						return nil, fmt.Errorf("can't convert base-fee to fee-currency: %w", err)
 					}

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -316,7 +316,7 @@ func (c *celoBackendMock) ConvertToCurrency(ctx context.Context, blockNumOrHash 
 	return new(big.Int).Mul(value, big.NewInt(2)), nil
 }
 
-func (c *celoBackendMock) ConvertToGold(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
+func (c *celoBackendMock) ConvertToCelo(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, toFeeCurrency *common.Address) (*big.Int, error) {
 	if toFeeCurrency == nil {
 		return value, nil
 	}


### PR DESCRIPTION
I didn't use ALLCAPS in go identifiers. That leaves some ambiguity between Celo (the blockchain) and the CELO token, but I think it is clear enough in context.

Relates to https://github.com/celo-org/celo-blockchain-planning/issues/348