### PR TITLE
Add simple tool for sending CIP-64 transactions

### DIFF
--- a/cmd/celotool/main.go
+++ b/cmd/celotool/main.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The celo Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/internal/flags"
+	"github.com/urfave/cli/v2"
+)
+
+var app *cli.App
+
+func init() {
+	app = flags.NewApp("Celo tool")
+	app.Commands = []*cli.Command{
+		commandSend,
+	}
+}
+
+func main() {
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/celotool/send-tx.go
+++ b/cmd/celotool/send-tx.go
@@ -1,0 +1,141 @@
+// Copyright 2024 The celo Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	rpcUrlFlag = &cli.StringFlag{
+		Name:        "rpc-url",
+		Aliases:     []string{"r"},
+		DefaultText: "http://localhost:8545",
+		Usage:       "The rpc endpoint",
+	}
+	privKeyFlag = &cli.StringFlag{
+		Name:     "private-key",
+		Usage:    "Use the provided private key",
+		Required: true,
+	}
+	valueFlag = &cli.Int64Flag{
+		Name:        "value",
+		DefaultText: "0",
+		Usage:       "The value to send, in wei",
+	}
+)
+
+var commandSend = &cli.Command{
+	Name:      "send",
+	Usage:     "send celo tx (cip-64)",
+	ArgsUsage: "[to] [feeCurrency]",
+	Description: `
+Send a CIP-64 transaction.
+
+- to: the address to send the transaction to, in hex format
+- feeCurrency: the fee currency address, in hex format
+
+Example:
+$ celotool send --rpc-url $RPC_URL --private-key $PRIVATE_KEY $TO $FEECURRENCY --value 1
+`,
+	Flags: []cli.Flag{
+		rpcUrlFlag,
+		privKeyFlag,
+		valueFlag,
+	},
+	Action: func(ctx *cli.Context) error {
+		privKeyRaw := ctx.String("private-key")
+		if len(privKeyRaw) >= 2 && privKeyRaw[0] == '0' && (privKeyRaw[1] == 'x' || privKeyRaw[1] == 'X') {
+			privKeyRaw = privKeyRaw[2:]
+		}
+		privateKey, err := crypto.HexToECDSA(privKeyRaw)
+		if err != nil {
+			return err
+		}
+
+		to := ctx.Args().Get(0)
+		if to == "" {
+			fmt.Println("missing 'to' address")
+			return nil
+		}
+		toAddress := common.HexToAddress(to)
+
+		feeCurrency := ctx.Args().Get(1)
+		if feeCurrency == "" {
+			fmt.Println("missing 'feeCurrency' address")
+			return nil
+		}
+		feeCurrencyAddress := common.HexToAddress(feeCurrency)
+
+		value := big.NewInt(ctx.Int64("value"))
+
+		rpcUrl := ctx.String("rpc-url")
+		client, err := ethclient.Dial(rpcUrl)
+		if err != nil {
+			return err
+		}
+
+		chainId, err := client.ChainID(context.Background())
+		if err != nil {
+			return err
+		}
+
+		nonce, err := client.PendingNonceAt(context.Background(), crypto.PubkeyToAddress(privateKey.PublicKey))
+		if err != nil {
+			return err
+		}
+
+		feeCap, err := client.SuggestGasPriceForCurrency(context.Background(), &feeCurrencyAddress)
+		if err != nil {
+			return err
+		}
+
+		txdata := &types.CeloDynamicFeeTxV2{
+			ChainID:     chainId,
+			Nonce:       nonce,
+			To:          &toAddress,
+			Gas:         100_000,
+			GasFeeCap:   feeCap,
+			GasTipCap:   big.NewInt(2),
+			FeeCurrency: &feeCurrencyAddress,
+			Value:       value,
+		}
+
+		signer := types.LatestSignerForChainID(chainId)
+		tx, err := types.SignNewTx(privateKey, signer, txdata)
+		if err != nil {
+			return err
+		}
+
+		err = client.SendTransaction(context.Background(), tx)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("tx sent: %s\n", tx.Hash().Hex())
+
+		return nil
+	},
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -372,7 +372,7 @@ func (st *StateTransition) canPayFee(checkAmount *uint256.Int) error {
 		// Token amount can't be bigger than 256 bit
 		balanceU256, _ := uint256.FromBig(balance)
 		if balanceU256.Cmp(checkAmount) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmount)
+			return fmt.Errorf("%w: address %v have %v want %v, fee currency: %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmount, st.msg.FeeCurrency.Hex())
 		}
 	}
 	return nil

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -278,7 +278,7 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 	if feeCurrencyBalance.Cmp(feeCurrencyCost) < 0 {
-		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, feeCurrencyBalance, feeCurrencyCost, new(big.Int).Sub(feeCurrencyCost, feeCurrencyBalance))
+		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v, fee currency: %v", core.ErrInsufficientFunds, feeCurrencyBalance, feeCurrencyCost, new(big.Int).Sub(feeCurrencyCost, feeCurrencyBalance), tx.FeeCurrency().Hex())
 	}
 	if nativeBalance.Cmp(nativeCost) < 0 {
 		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, nativeBalance, nativeCost, new(big.Int).Sub(nativeCost, nativeBalance))

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -99,7 +99,7 @@ func LatestSignerForChainID(chainID *big.Int) Signer {
 	if chainID == nil {
 		return HomesteadSigner{}
 	}
-	return NewCancunSigner(chainID)
+	return latestCeloSigner(chainID, NewCancunSigner(chainID))
 }
 
 // SignTx signs the transaction using the given signer and private key.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -557,11 +557,31 @@ func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
+// SuggestGasPriceForCurrency retrieves the currently suggested gas price to allow a timely
+// execution of a transaction in the given fee currency.
+func (ec *Client) SuggestGasPriceForCurrency(ctx context.Context, feeCurrency *common.Address) (*big.Int, error) {
+	var hex hexutil.Big
+	if err := ec.c.CallContext(ctx, &hex, "eth_gasPrice", feeCurrency); err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
 // SuggestGasTipCap retrieves the currently suggested gas tip cap after 1559 to
 // allow a timely execution of a transaction.
 func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	var hex hexutil.Big
 	if err := ec.c.CallContext(ctx, &hex, "eth_maxPriorityFeePerGas"); err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
+// SuggestGasTipCapForCurrency retrieves the currently suggested gas tip cap after 1559 to
+// allow a timely execution of a transaction in the given fee currency.
+func (ec *Client) SuggestGasTipCapForCurrency(ctx context.Context, feeCurrency *common.Address) (*big.Int, error) {
+	var hex hexutil.Big
+	if err := ec.c.CallContext(ctx, &hex, "eth_maxPriorityFeePerGas", feeCurrency); err != nil {
 		return nil, err
 	}
 	return (*big.Int)(&hex), nil


### PR DESCRIPTION
Currently we use viem for sending CIP-64 transactions. This PR adds a simple tool `celotool` to send those transactions from the commandline. The usage is similar to `cast send`.

It's currently minimal, with no gas estimation and limited functionality. Opinions on what should be added are welcome, as are better naming suggestions.

- This also changes `LatestSignerForChainID`, to make it sign celo transactions.