### PR TITLE
Backport fixes for tests on arm64

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -326,6 +326,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 	// Create a temporary keystore to test with
 	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-updatedkeyfilecontents-test-%d-%d", os.Getpid(), rand.Int()))
+
+	// Create the directory
+	os.MkdirAll(dir, 0700)
+	defer os.RemoveAll(dir)
+
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()
@@ -335,9 +340,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	if !waitWatcherStart(ks) {
 		t.Fatal("keystore watcher didn't start in time")
 	}
-	// Create the directory and copy a key file into it.
-	os.MkdirAll(dir, 0700)
-	defer os.RemoveAll(dir)
+	// Copy a key file into it
 	file := filepath.Join(dir, "aaa")
 
 	// Place one of our testfiles in there

--- a/metrics/influxdb/influxdb_test.go
+++ b/metrics/influxdb/influxdb_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -37,6 +38,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestExampleV1(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("test skipped on ARM64 due to floating point precision differences")
+	}
+
 	r := internal.ExampleMetrics()
 	var have, want string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,6 +74,10 @@ func TestExampleV1(t *testing.T) {
 }
 
 func TestExampleV2(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("test skipped on ARM64 due to floating point precision differences")
+	}
+
 	r := internal.ExampleMetrics()
 	var have, want string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Without these commits the following tests fail reproducibly on arm64:
```
accounts/keystore TestUpdatedKeyfileContents
metrics/influxdb TestExampleV1
metrics/influxdb TestExampleV2
```

The fixes are backported from go-ethereum. They are not in op-geth, yet.