### PR TITLE
Add support for signing pre cel2 DynamicFeeTxs

### DIFF
--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -65,6 +65,9 @@ func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 	case t == LegacyTxType && tx.IsCeloLegacy():
 		return deprecatedTxFuncs
 	case t == DynamicFeeTxType:
+		// We deprecate celo support of the DynamicFeeTxType in the cel2 fork
+		// since at this point it will be supported by the upstream London
+		// hardfork.
 		return deprecatedTxFuncs
 	case t == CeloDynamicFeeTxType:
 		return deprecatedTxFuncs

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -64,6 +64,8 @@ func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 	switch {
 	case t == LegacyTxType && tx.IsCeloLegacy():
 		return deprecatedTxFuncs
+	case t == DynamicFeeTxType:
+		return deprecatedTxFuncs
 	case t == CeloDynamicFeeTxType:
 		return deprecatedTxFuncs
 	}
@@ -97,6 +99,15 @@ func (c *celoLegacy) txFuncs(tx *Transaction) *txFuncs {
 			return celoLegacyProtectedTxFuncs
 		}
 		return celoLegacyUnprotectedTxFuncs
+	case t == DynamicFeeTxType:
+		// We handle the dynamic fee tx type here because we need to handle
+		// migrated dynamic fee txs. These were enabeled in celo in the Espresso
+		// hardfork, which doesn't have any analogue in op-geth. Even though
+		// op-geth does enable support for dynamic fee txs in the London
+		// hardfork (which we set to the cel2 block) that fork contains a lot of
+		// changes that were not part of Espresso. So instead we handle
+		// DynamicFeeTxTypes ocurring before the cel2 block here.
+		return dynamicFeeTxFuncs
 	case t == CeloDynamicFeeTxV2Type:
 		return celoDynamicFeeTxV2Funcs
 	case t == CeloDynamicFeeTxType:

--- a/core/types/celo_transaction_signing_tx_funcs.go
+++ b/core/types/celo_transaction_signing_tx_funcs.go
@@ -61,6 +61,18 @@ var (
 		},
 	}
 
+	dynamicFeeTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return NewEIP155Signer(chainID).Hash(tx)
+		},
+		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+			return NewEIP155Signer(signerChainID).SignatureValues(tx, sig)
+		},
+		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+			return NewEIP155Signer(signerChainID).Sender(tx)
+		},
+	}
+
 	celoDynamicFeeTxFuncs = &txFuncs{
 		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
 			return prefixedRlpHash(

--- a/core/types/celo_transaction_signing_tx_funcs.go
+++ b/core/types/celo_transaction_signing_tx_funcs.go
@@ -63,13 +63,13 @@ var (
 
 	dynamicFeeTxFuncs = &txFuncs{
 		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
-			return NewEIP155Signer(chainID).Hash(tx)
+			return NewLondonSigner(chainID).Hash(tx)
 		},
 		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
-			return NewEIP155Signer(signerChainID).SignatureValues(tx, sig)
+			return NewLondonSigner(signerChainID).SignatureValues(tx, sig)
 		},
 		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
-			return NewEIP155Signer(signerChainID).Sender(tx)
+			return NewLondonSigner(signerChainID).Sender(tx)
 		},
 	}
 


### PR DESCRIPTION
Op-geth adds this support in the London hardfork, but that is enabled at the cel2 block, and shouldn't be enabled earlier since it includes many features beyond just singing DynamicFeeTxs.

Celo added this signing support in the Espresso hardfork.

So we add signing support for DynamicFeeTxs to the celoLegacy signing meta fork (which is a stand in for all signing provided by celo forks before cel2).

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/375