### PR TITLE
Read IntrinsicGas from FeeCurrencyDirectory 

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -206,7 +206,12 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, errMsg})
 			continue
 		}
-		msg, err := core.TransactionToMessage(tx, signer, pre.Env.BaseFee, vmContext.ExchangeRates)
+		// NOTE: we can't provide exchange rates
+		// for fee-currencies here, since those are dynamically changing
+		// based on the oracle's exchange rates.
+		// When a Celo transaction with specified fee-currency is validated with this tool,
+		// this will thus result in a ErrNonWhitelistedFeeCurrency error for now.
+		msg, err := core.TransactionToMessage(tx, signer, pre.Env.BaseFee, vmContext.FeeCurrencyContext.ExchangeRates)
 		if err != nil {
 			log.Warn("rejected tx", "index", i, "hash", tx.Hash(), "error", err)
 			rejectedTxs = append(rejectedTxs, &rejectedTx{i, err.Error()})

--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -133,8 +133,14 @@ func Transaction(ctx *cli.Context) error {
 			r.Address = sender
 		}
 		// Check intrinsic gas
+		// NOTE: we can't provide specific intrinsic gas costs
+		// for fee-currencies here, since those are written to the
+		// FeeCurrencyDirectory contract and are chain-specific.
+		// When a Celo transaction with specified fee-currency is validated with this tool,
+		// this will thus result in a ErrNonWhitelistedFeeCurrency error for now.
+		var feeIntrinsic common.IntrinsicGasCosts
 		if gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil,
-			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int)), chainConfig.IsShanghai(new(big.Int), 0), tx.FeeCurrency()); err != nil {
+			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int)), chainConfig.IsShanghai(new(big.Int), 0), tx.FeeCurrency(), feeIntrinsic); err != nil {
 			r.Error = err
 			results = append(results, r)
 			continue

--- a/common/celo_types.go
+++ b/common/celo_types.go
@@ -10,6 +10,10 @@ var (
 
 type ExchangeRates = map[Address]*big.Rat
 
+type FeeCurrencyContext struct {
+	ExchangeRates ExchangeRates
+}
+
 func CurrencyWhitelist(exchangeRates ExchangeRates) []Address {
 	addrs := make([]Address, len(exchangeRates))
 	i := 0

--- a/common/celo_types.go
+++ b/common/celo_types.go
@@ -25,6 +25,7 @@ func MaxAllowedIntrinsicGasCost(i IntrinsicGasCosts, feeCurrency *Address) (uint
 	// during execution
 	return intrinsicGas * 3, true
 }
+
 func CurrencyIntrinsicGasCost(i IntrinsicGasCosts, feeCurrency *Address) (uint64, bool) {
 	if feeCurrency == nil {
 		return 0, true

--- a/common/celo_types.go
+++ b/common/celo_types.go
@@ -21,12 +21,16 @@ func MaxAllowedIntrinsicGasCost(i IntrinsicGasCosts, feeCurrency *Address) (uint
 	if !ok {
 		return 0, false
 	}
-	// allow the contract to overshoot 2 times the deducted intrinsic gas
-	// during execution
+	// Allow the contract to overshoot 2 times the deducted intrinsic gas
+	// during execution.
+	// If the feeCurrency is nil, then the max allowed intrinsic gas cost
+	// is 0 (i.e. not allowed) for a fee-currency specific EVM call within the STF.
 	return intrinsicGas * 3, true
 }
 
 func CurrencyIntrinsicGasCost(i IntrinsicGasCosts, feeCurrency *Address) (uint64, bool) {
+	// the additional intrinsic gas cost for a non fee-currency
+	// transaction is 0
 	if feeCurrency == nil {
 		return 0, true
 	}

--- a/contracts/celo_backend.go
+++ b/contracts/celo_backend.go
@@ -57,13 +57,18 @@ func (b *CeloBackend) CallContract(ctx context.Context, call ethereum.CallMsg, b
 
 // Get a vm.EVM object of you can't use the abi wrapper via the ContractCaller interface
 // This is usually the case when executing functions that modify state.
-func (b *CeloBackend) NewEVM() *vm.EVM {
-	blockCtx := vm.BlockContext{BlockNumber: new(big.Int), Time: 0,
+func (b *CeloBackend) NewEVM(feeCurrencyContext *common.FeeCurrencyContext) *vm.EVM {
+	blockCtx := vm.BlockContext{
+		BlockNumber: new(big.Int),
+		Time:        0,
 		Transfer: func(state vm.StateDB, from common.Address, to common.Address, value *uint256.Int) {
 			if value.Cmp(common.U2560) != 0 {
 				panic("Non-zero transfers not implemented, yet.")
 			}
 		},
+	}
+	if feeCurrencyContext != nil {
+		blockCtx.FeeCurrencyContext = *feeCurrencyContext
 	}
 	txCtx := vm.TxContext{}
 	vmConfig := vm.Config{}

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -33,8 +33,7 @@ func TryDebitFees(tx *types.Transaction, from common.Address, backend *CeloBacke
 	amount.Mul(amount, tx.GasFeeCap())
 
 	snapshot := backend.State.Snapshot()
-	evm := backend.NewEVM()
-	evm.Context.FeeCurrencyContext = feeContext
+	evm := backend.NewEVM(&feeContext)
 	_, err := DebitFees(evm, tx.FeeCurrency(), from, amount)
 	backend.State.RevertToSnapshot(snapshot)
 	return err

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -140,6 +140,17 @@ func GetExchangeRates(caller bind.ContractCaller) (common.ExchangeRates, error) 
 	return exchangeRates, nil
 }
 
+// GetFeeCurrencyContext returns the fee-currency context for all gas currencies from CELO
+func GetFeeCurrencyContext(caller bind.ContractCaller) (common.FeeCurrencyContext, error) {
+	rates, err := GetExchangeRates(caller)
+	if err != nil {
+		return common.FeeCurrencyContext{}, err
+	}
+	return common.FeeCurrencyContext{
+		ExchangeRates: rates,
+	}, nil
+}
+
 // GetBalanceERC20 returns an account's balance on a given ERC20 currency
 func GetBalanceERC20(caller bind.ContractCaller, accountOwner common.Address, contractAddress common.Address) (result *big.Int, err error) {
 	token, err := abigen.NewFeeCurrencyCaller(contractAddress, caller)

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -141,7 +141,7 @@ func GetRegisteredCurrencies(caller *abigen.FeeCurrencyDirectoryCaller) ([]commo
 	return currencies, nil
 }
 
-// GetExchangeRates returns the exchange rates for the provided gas currencies from CELO
+// GetExchangeRates returns the exchange rates for the provided gas currencies
 func GetExchangeRates(caller bind.ContractCaller) (common.ExchangeRates, error) {
 	exchangeRates := map[common.Address]*big.Rat{}
 	directory, err := abigen.NewFeeCurrencyDirectoryCaller(addresses.FeeCurrencyDirectoryAddress, caller)
@@ -150,7 +150,7 @@ func GetExchangeRates(caller bind.ContractCaller) (common.ExchangeRates, error) 
 	}
 	currencies, err := GetRegisteredCurrencies(directory)
 	if err != nil {
-		return map[common.Address]*big.Rat{}, err
+		return common.ExchangeRates{}, err
 	}
 	return getExchangeRatesForTokens(directory, currencies)
 }

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -83,7 +83,8 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		gas, _ := IntrinsicGas(data, nil, false, false, false, false, nil)
+		var feeIntrinsic common.IntrinsicGasCosts
+		gas, _ := IntrinsicGas(data, nil, false, false, false, false, nil, feeIntrinsic)
 		signer := gen.Signer()
 		gasPrice := big.NewInt(0)
 		if gen.header.BaseFee != nil {

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -83,8 +83,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		var feeIntrinsic common.IntrinsicGasCosts
-		gas, _ := IntrinsicGas(data, nil, false, false, false, false, nil, feeIntrinsic)
+		gas, _ := IntrinsicGas(data, nil, false, false, false, false, nil, common.IntrinsicGasCosts{})
 		signer := gen.Signer()
 		gasPrice := big.NewInt(0)
 		if gen.header.BaseFee != nil {

--- a/core/celo_evm.go
+++ b/core/celo_evm.go
@@ -15,9 +15,9 @@ func setCeloFieldsInBlockContext(blockContext *vm.BlockContext, header *types.He
 
 	caller := &contracts.CeloBackend{ChainConfig: config, State: statedb}
 
-	// Add fee currency exchange rates
+	// Add fee currency context
 	var err error
-	blockContext.ExchangeRates, err = contracts.GetExchangeRates(caller)
+	blockContext.FeeCurrencyContext, err = contracts.GetFeeCurrencyContext(caller)
 	if err != nil {
 		log.Error("Error fetching exchange rates!", "err", err)
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -63,7 +63,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			return
 		}
 		// Convert the transaction into an executable message and pre-cache its sender
-		msg, err := TransactionToMessage(tx, signer, header.BaseFee, blockContext.ExchangeRates)
+		msg, err := TransactionToMessage(tx, signer, header.BaseFee, blockContext.FeeCurrencyContext.ExchangeRates)
 		if err != nil {
 			return // Also invalid block, bail out
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -83,7 +83,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		msg, err := TransactionToMessage(tx, signer, header.BaseFee, context.ExchangeRates)
+		msg, err := TransactionToMessage(tx, signer, header.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
@@ -156,7 +156,7 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 	if tx.Type() == types.CeloDynamicFeeTxV2Type {
 		alternativeBaseFee := evm.Context.BaseFee
 		if msg.FeeCurrency != nil {
-			alternativeBaseFee, err = exchange.ConvertCeloToCurrency(evm.Context.ExchangeRates, msg.FeeCurrency, evm.Context.BaseFee)
+			alternativeBaseFee, err = exchange.ConvertCeloToCurrency(evm.Context.FeeCurrencyContext.ExchangeRates, msg.FeeCurrency, evm.Context.BaseFee)
 			if err != nil {
 				return nil, err
 			}
@@ -189,7 +189,7 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author, config, statedb)
-	msg, err := TransactionToMessage(tx, types.MakeSigner(config, header.Number, header.Time), header.BaseFee, blockContext.ExchangeRates)
+	msg, err := TransactionToMessage(tx, types.MakeSigner(config, header.Number, header.Time), header.BaseFee, blockContext.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -427,7 +427,7 @@ func (st *StateTransition) preCheck() error {
 		if !st.evm.ChainConfig().IsCel2(st.evm.Context.Time) {
 			return ErrCel2NotEnabled
 		} else {
-			isWhiteListed := common.IsCurrencyWhitelisted(st.evm.Context.ExchangeRates, msg.FeeCurrency)
+			isWhiteListed := common.IsCurrencyWhitelisted(st.evm.Context.FeeCurrencyContext.ExchangeRates, msg.FeeCurrency)
 			if !isWhiteListed {
 				log.Trace("fee currency not whitelisted", "fee currency address", msg.FeeCurrency)
 				return exchange.ErrNonWhitelistedFeeCurrency
@@ -455,7 +455,7 @@ func (st *StateTransition) preCheck() error {
 
 			// This will panic if baseFee is nil, but basefee presence is verified
 			// as part of header validation.
-			baseFeeInFeeCurrency, err := exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, msg.FeeCurrency, st.evm.Context.BaseFee)
+			baseFeeInFeeCurrency, err := exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, msg.FeeCurrency, st.evm.Context.BaseFee)
 			if err != nil {
 				return fmt.Errorf("preCheck: %w", err)
 			}
@@ -768,7 +768,7 @@ func (st *StateTransition) distributeTxFees() error {
 		}
 	} else {
 		if l1Cost != nil {
-			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, feeCurrency, l1Cost)
+			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, feeCurrency, l1Cost)
 		}
 		if err := contracts.CreditFees(st.evm, feeCurrency, from, st.evm.Context.Coinbase, feeHandlerAddress, params.OptimismL1FeeRecipient, refund, tipTxFee, baseTxFee, l1Cost); err != nil {
 			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "feeHandler", feeHandlerAddress, "err", err)
@@ -790,7 +790,7 @@ func (st *StateTransition) calculateBaseFee() *big.Int {
 
 	if st.msg.FeeCurrency != nil {
 		// Existence of the fee currency has been checked in `preCheck`
-		baseFee, _ = exchange.ConvertCeloToCurrency(st.evm.Context.ExchangeRates, st.msg.FeeCurrency, baseFee)
+		baseFee, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, st.msg.FeeCurrency, baseFee)
 	}
 
 	return baseFee

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -71,7 +71,7 @@ func (result *ExecutionResult) Revert() []byte {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool, isHomestead, isEIP2028, isEIP3860 bool, feeCurrency *common.Address) (uint64, error) {
+func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool, isHomestead, isEIP2028, isEIP3860 bool, feeCurrency *common.Address, feeIntrinsicGas common.IntrinsicGasCosts) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
 	if isContractCreation && isHomestead {
@@ -129,10 +129,14 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 	// In this case, however, the user always ends up paying `maxGasForDebitAndCreditTransactions`
 	// keeping it consistent.
 	if feeCurrency != nil {
-		if (math.MaxUint64 - gas) < contracts.IntrinsicGasForAlternativeFeeCurrency {
+		intrinsicGasForFeeCurrency, ok := common.CurrencyIntrinsicGasCost(feeIntrinsicGas, feeCurrency)
+		if !ok {
+			return 0, exchange.ErrNonWhitelistedFeeCurrency
+		}
+		if (math.MaxUint64 - gas) < intrinsicGasForFeeCurrency {
 			return 0, ErrGasUintOverflow
 		}
-		gas += contracts.IntrinsicGasForAlternativeFeeCurrency
+		gas += intrinsicGasForFeeCurrency
 	}
 
 	if accessList != nil {
@@ -274,6 +278,8 @@ type StateTransition struct {
 	initialGas   uint64
 	state        vm.StateDB
 	evm          *vm.EVM
+
+	feeCurrencyGasUsed uint64
 }
 
 // NewStateTransition initialises and returns a new state transition object.
@@ -379,7 +385,9 @@ func (st *StateTransition) subFees(effectiveFee *big.Int) (err error) {
 		st.state.SubBalance(st.msg.From, effectiveFeeU256)
 		return nil
 	} else {
-		return contracts.DebitFees(st.evm, st.msg.FeeCurrency, st.msg.From, effectiveFee)
+		gasUsedDebit, err := contracts.DebitFees(st.evm, st.msg.FeeCurrency, st.msg.From, effectiveFee)
+		st.feeCurrencyGasUsed += gasUsedDebit
+		return err
 	}
 }
 
@@ -586,7 +594,16 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
-	gas, err := IntrinsicGas(msg.Data, msg.AccessList, contractCreation, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai, msg.FeeCurrency)
+	gas, err := IntrinsicGas(
+		msg.Data,
+		msg.AccessList,
+		contractCreation,
+		rules.IsHomestead,
+		rules.IsIstanbul,
+		rules.IsShanghai,
+		msg.FeeCurrency,
+		st.evm.Context.FeeCurrencyContext.IntrinsicGasCosts,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +787,20 @@ func (st *StateTransition) distributeTxFees() error {
 		if l1Cost != nil {
 			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, feeCurrency, l1Cost)
 		}
-		if err := contracts.CreditFees(st.evm, feeCurrency, from, st.evm.Context.Coinbase, feeHandlerAddress, params.OptimismL1FeeRecipient, refund, tipTxFee, baseTxFee, l1Cost); err != nil {
+		if err := contracts.CreditFees(
+			st.evm,
+			feeCurrency,
+			from,
+			st.evm.Context.Coinbase,
+			feeHandlerAddress,
+			params.OptimismL1FeeRecipient,
+			refund,
+			tipTxFee,
+			baseTxFee,
+			l1Cost,
+			st.feeCurrencyGasUsed,
+		); err != nil {
+			err = fmt.Errorf("error crediting fee-currency: %w", err)
 			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "feeHandler", feeHandlerAddress, "err", err)
 			return err
 		}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -318,8 +318,8 @@ type BlobPool struct {
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
 
 	// Celo specific
-	celoBackend  *contracts.CeloBackend // For fee currency balances & exchange rate calculation
-	currentRates common.ExchangeRates   // current exchange rates for fee currencies
+	celoBackend        *contracts.CeloBackend // For fee currency balances & exchange rate calculation
+	feeCurrencyContext common.FeeCurrencyContext
 }
 
 // New creates a new blob transaction pool to gather, sort and filter inbound
@@ -1094,7 +1094,7 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 		MaxSize:   txMaxSize,
 		MinTip:    p.gasTip.ToBig(),
 	}
-	if err := txpool.CeloValidateTransaction(tx, p.head, p.signer, baseOpts, p.currentRates); err != nil {
+	if err := txpool.CeloValidateTransaction(tx, p.head, p.signer, baseOpts, p.feeCurrencyContext); err != nil {
 		return err
 	}
 	// Ensure the transaction adheres to the stateful pool filters (nonce, balance)

--- a/core/txpool/blobpool/celo_blobpool.go
+++ b/core/txpool/blobpool/celo_blobpool.go
@@ -10,9 +10,9 @@ func (pool *BlobPool) recreateCeloProperties() {
 		ChainConfig: pool.chain.Config(),
 		State:       pool.state,
 	}
-	currentRates, err := contracts.GetExchangeRates(pool.celoBackend)
+	currencyContext, err := contracts.GetFeeCurrencyContext(pool.celoBackend)
 	if err != nil {
-		log.Error("Error trying to get exchange rates in txpool.", "cause", err)
+		log.Error("Error trying to get fee currency context in txpool.", "cause", err)
 	}
-	pool.currentRates = currentRates
+	pool.feeCurrencyContext = currencyContext
 }

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -1,15 +1,13 @@
 package txpool
 
 import (
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/exchange"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
-
-var NonWhitelistedFeeCurrencyError = errors.New("Fee currency given is not whitelisted at current block")
 
 // AcceptSet is a set of accepted transaction types for a transaction subpool.
 type AcceptSet = map[uint8]struct{}

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -50,12 +50,12 @@ func (cvo *CeloValidationOptions) Accepts(txType uint8) bool {
 // This check is public to allow different transaction pools to check the basic
 // rules without duplicating code and running the risk of missed updates.
 func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
-	signer types.Signer, opts *CeloValidationOptions, rates common.ExchangeRates) error {
-	if err := ValidateTransaction(tx, head, signer, opts); err != nil {
+	signer types.Signer, opts *CeloValidationOptions, currencyCtx common.FeeCurrencyContext) error {
+	if err := ValidateTransaction(tx, head, signer, opts, currencyCtx); err != nil {
 		return err
 	}
-	if !common.IsCurrencyWhitelisted(rates, tx.FeeCurrency()) {
-		return NonWhitelistedFeeCurrencyError
+	if !common.IsCurrencyWhitelisted(currencyCtx.ExchangeRates, tx.FeeCurrency()) {
+		return exchange.ErrNonWhitelistedFeeCurrency
 	}
 
 	return nil

--- a/core/txpool/legacypool/celo_legacypool.go
+++ b/core/txpool/legacypool/celo_legacypool.go
@@ -12,7 +12,7 @@ import (
 // and gasLimit. Returns drops and invalid txs.
 func (pool *LegacyPool) filter(list *list, addr common.Address, gasLimit uint64) (types.Transactions, types.Transactions) {
 	// CELO: drop all transactions that no longer have a whitelisted currency
-	dropsWhitelist, invalidsWhitelist := list.FilterWhitelisted(pool.currentRates)
+	dropsWhitelist, invalidsWhitelist := list.FilterWhitelisted(pool.feeCurrencyContext.ExchangeRates)
 	// Check from which currencies we need to get balances
 	currenciesInList := list.FeeCurrencies()
 	drops, invalids := list.Filter(pool.getBalances(addr, currenciesInList), gasLimit)
@@ -34,9 +34,10 @@ func (pool *LegacyPool) recreateCeloProperties() {
 		ChainConfig: pool.chainconfig,
 		State:       pool.currentState,
 	}
-	currentRates, err := contracts.GetExchangeRates(pool.celoBackend)
+	feeCurrencyContext, err := contracts.GetFeeCurrencyContext(pool.celoBackend)
 	if err != nil {
-		log.Error("Error trying to get exchange rates in txpool.", "cause", err)
+		log.Error("Error trying to get fee currency context in txpool.", "cause", err)
 	}
-	pool.currentRates = currentRates
+
+	pool.feeCurrencyContext = feeCurrencyContext
 }

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -242,8 +242,8 @@ type LegacyPool struct {
 	l1CostFn txpool.L1CostFunc // To apply L1 costs as rollup, optional field, may be nil.
 
 	// Celo specific
-	celoBackend  *contracts.CeloBackend // For fee currency balances & exchange rate calculation
-	currentRates common.ExchangeRates   // current exchange rates for fee currencies
+	celoBackend        *contracts.CeloBackend    // For fee currency balances & exchange rate calculation
+	feeCurrencyContext common.FeeCurrencyContext // context for fee currencies
 }
 
 type txpoolResetRequest struct {
@@ -650,7 +650,7 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 	if local {
 		opts.MinTip = new(big.Int)
 	}
-	if err := txpool.CeloValidateTransaction(tx, pool.currentHead.Load(), pool.signer, opts, pool.currentRates); err != nil {
+	if err := txpool.CeloValidateTransaction(tx, pool.currentHead.Load(), pool.signer, opts, pool.feeCurrencyContext); err != nil {
 		return err
 	}
 	return nil
@@ -833,7 +833,7 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.currentRates)
+		inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.feeCurrencyContext.ExchangeRates)
 		if !inserted {
 			pendingDiscardMeter.Mark(1)
 			return false, txpool.ErrReplaceUnderpriced
@@ -907,7 +907,7 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 	if pool.queue[from] == nil {
 		pool.queue[from] = newList(false)
 	}
-	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.currentRates)
+	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.feeCurrencyContext.ExchangeRates)
 	if !inserted {
 		// An older transaction was better, discard this
 		queuedDiscardMeter.Mark(1)
@@ -961,7 +961,7 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	}
 	list := pool.pending[addr]
 
-	inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.currentRates)
+	inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn, pool.feeCurrencyContext.ExchangeRates)
 	if !inserted {
 		// An older transaction was better, discard this
 		pool.all.Remove(hash)
@@ -1357,7 +1357,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		if reset.newHead != nil {
 			if pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
 				pendingBaseFee := eip1559.CalcBaseFee(pool.chainconfig, reset.newHead, reset.newHead.Time+1)
-				pool.priced.SetBaseFeeAndRates(pendingBaseFee, pool.currentRates)
+				pool.priced.SetBaseFeeAndRates(pendingBaseFee, pool.feeCurrencyContext.ExchangeRates)
 			} else {
 				pool.priced.Reheap()
 			}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -713,7 +713,10 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 			log.Error("Transaction sender recovery failed", "err", err)
 			return err
 		}
-		return contracts.TryDebitFees(tx, from, pool.celoBackend)
+		//NOTE: we only test the `debitFees` call here.
+		// If the `creditFees` reverts (or runs out of gas), the transaction will
+		// not be invalidated here and will be included in the block.
+		return contracts.TryDebitFees(tx, from, pool.celoBackend, pool.feeCurrencyContext)
 	}
 	return nil
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -74,7 +74,7 @@ type ValidationOptions struct {
 // This check is public to allow different transaction pools to check the basic
 // rules without duplicating code and running the risk of missed updates.
 // ONLY TO BE CALLED FROM "CeloValidateTransaction"
-func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types.Signer, opts *CeloValidationOptions) error {
+func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types.Signer, opts *CeloValidationOptions, currencyCtx common.FeeCurrencyContext) error {
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -133,7 +133,16 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover
 	// the transaction metadata
-	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, opts.Config.IsIstanbul(head.Number), opts.Config.IsShanghai(head.Number, head.Time), tx.FeeCurrency())
+	intrGas, err := core.IntrinsicGas(
+		tx.Data(),
+		tx.AccessList(),
+		tx.To() == nil,
+		true,
+		opts.Config.IsIstanbul(head.Number),
+		opts.Config.IsShanghai(head.Number, head.Time),
+		tx.FeeCurrency(),
+		currencyCtx.IntrinsicGasCosts,
+	)
 	if err != nil {
 		return err
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -102,7 +102,6 @@ type BlockContext struct {
 	Random      *common.Hash   // Provides information for PREVRANDAO
 
 	// Celo specific information
-	GasUsedForDebit    uint64
 	FeeCurrencyContext common.FeeCurrencyContext
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -102,8 +102,8 @@ type BlockContext struct {
 	Random      *common.Hash   // Provides information for PREVRANDAO
 
 	// Celo specific information
-	ExchangeRates   common.ExchangeRates
-	GasUsedForDebit uint64
+	GasUsedForDebit    uint64
+	FeeCurrencyContext common.FeeCurrencyContext
 }
 
 // TxContext provides the EVM with information about a transaction.

--- a/e2e_test/debug-fee-currency/deploy_and_send_tx.sh
+++ b/e2e_test/debug-fee-currency/deploy_and_send_tx.sh
@@ -3,7 +3,7 @@
 set -xeo pipefail
 
 export FEE_CURRENCY=$(\
-	forge create --root . --contracts . --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 --json\
+	forge create --root . --contracts . --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 $3 --json\
 	| jq .deployedTo -r)
 
 cast send --private-key $ACC_PRIVKEY $ORACLE3 'setExchangeRate(address, uint256, uint256)' $FEE_CURRENCY 2ether 1ether

--- a/e2e_test/js-tests/test_viem_tx.mjs
+++ b/e2e_test/js-tests/test_viem_tx.mjs
@@ -263,10 +263,7 @@ describe("viem send tx", () => {
 			assert.fail("Failed to filter nonwhitelisted feeCurrency");
 		} catch (err) {
 			// TODO: find a better way to check the error type
-			if (
-				err.cause.details ==
-				"Fee currency given is not whitelisted at current block"
-			) {
+			if (err.cause.details == "non-whitelisted fee currency address") {
 				// Test success
 			} else {
 				throw err;

--- a/e2e_test/test_fee_currency_fails_intrinsic.sh
+++ b/e2e_test/test_fee_currency_fails_intrinsic.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+set -eo pipefail
+
+source shared.sh
+
+# Expect that the creditGasFees failed and is logged by geth
+tail -f -n0 geth.log >debug-fee-currency/geth.intrinsic.log & # start log capture
+(cd debug-fee-currency && ./deploy_and_send_tx.sh false false true)
+sleep 0.5
+kill %1 # stop log capture
+grep "error crediting fee-currency: surpassed maximum allowed intrinsic gas for fee currency: out of gas" debug-fee-currency/geth.intrinsic.log
+# echo $(grep "send_tx hash:" debug-fee-currency/send_tx.intrinsic.log)

--- a/e2e_test/test_fee_currency_fails_on_credit.sh
+++ b/e2e_test/test_fee_currency_fails_on_credit.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 source shared.sh
 
 # Expect that the creditGasFees failed and is logged by geth
-tail -f -n0 geth.log > debug-fee-currency/geth.partial.log &  # start log capture
-(cd debug-fee-currency && ./deploy_and_send_tx.sh false true)
-sleep 0.1
+tail -f -n0 geth.log >debug-fee-currency/geth.partial.log & # start log capture
+(cd debug-fee-currency && ./deploy_and_send_tx.sh false true false)
+sleep 0.5
 kill %1 # stop log capture
 grep "This DebugFeeCurrency always fails in (old) creditGasFees!" debug-fee-currency/geth.partial.log

--- a/e2e_test/test_fee_currency_fails_on_debit.sh
+++ b/e2e_test/test_fee_currency_fails_on_debit.sh
@@ -5,6 +5,6 @@ set -eo pipefail
 source shared.sh
 
 # Expect that the debitGasFees fails during tx submission
-(cd debug-fee-currency && ./deploy_and_send_tx.sh true false) &> debug-fee-currency/send_tx.log || true
-grep "debitGasFees reverted: This DebugFeeCurrency always fails in debitGasFees!" debug-fee-currency/send_tx.log \
-  || (cat debug-fee-currency/send_tx.log && false)
+(cd debug-fee-currency && ./deploy_and_send_tx.sh true false false) &>debug-fee-currency/send_tx.log || true
+grep "debitGasFees reverted: This DebugFeeCurrency always fails in debitGasFees!" debug-fee-currency/send_tx.log ||
+  (cat debug-fee-currency/send_tx.log && false)

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -241,7 +241,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	for idx, tx := range block.Transactions() {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil, eth.blockchain.Config(), statedb)
 		// Assemble the transaction call message and return if the requested offset
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), context.ExchangeRates)
+		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), context.FeeCurrencyContext.ExchangeRates)
 		txContext := core.NewEVMTxContext(msg)
 		if idx == txIndex {
 			return msg, context, statedb, release, nil

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -271,7 +271,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
-					msg, _ := core.TransactionToMessage(tx, signer, task.block.BaseFee(), blockCtx.ExchangeRates)
+					msg, _ := core.TransactionToMessage(tx, signer, task.block.BaseFee(), blockCtx.FeeCurrencyContext.ExchangeRates)
 					txctx := &Context{
 						BlockHash:   task.block.Hash(),
 						BlockNumber: task.block.Number(),
@@ -561,7 +561,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			return nil, err
 		}
 		var (
-			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee(), vmctx.ExchangeRates)
+			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee(), vmctx.FeeCurrencyContext.ExchangeRates)
 			txContext = core.NewEVMTxContext(msg)
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
@@ -635,7 +635,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	)
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), blockCtx.ExchangeRates)
+		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), blockCtx.FeeCurrencyContext.ExchangeRates)
 		txctx := &Context{
 			BlockHash:   blockHash,
 			BlockNumber: block.Number(),
@@ -678,7 +678,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil, api.backend.ChainConfig(), task.statedb)
-				msg, _ := core.TransactionToMessage(txs[task.index], signer, block.BaseFee(), blockCtx.ExchangeRates)
+				msg, _ := core.TransactionToMessage(txs[task.index], signer, block.BaseFee(), blockCtx.FeeCurrencyContext.ExchangeRates)
 				txctx := &Context{
 					BlockHash:   blockHash,
 					BlockNumber: block.Number(),
@@ -710,7 +710,7 @@ txloop:
 		}
 
 		// Generate the next state snapshot fast without tracing
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), blockCtx.ExchangeRates)
+		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), blockCtx.FeeCurrencyContext.ExchangeRates)
 		statedb.SetTxContext(tx.Hash(), i)
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit)); err != nil {
@@ -790,7 +790,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	for i, tx := range block.Transactions() {
 		// Prepare the transaction for un-traced execution
 		var (
-			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee(), vmctx.ExchangeRates)
+			msg, _    = core.TransactionToMessage(tx, signer, block.BaseFee(), vmctx.FeeCurrencyContext.ExchangeRates)
 			txContext = core.NewEVMTxContext(msg)
 			vmConf    vm.Config
 			dump      *os.File
@@ -966,7 +966,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		config.BlockOverrides.Apply(&vmctx)
 	}
 	// Execute the trace
-	msg, err := args.ToMessage(api.backend.RPCGasCap(), vmctx.BaseFee, vmctx.ExchangeRates)
+	msg, err := args.ToMessage(api.backend.RPCGasCap(), vmctx.BaseFee, vmctx.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -249,7 +249,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	signer := types.MakeSigner(b.chainConfig, block.Number(), block.Time())
 	for idx, tx := range block.Transactions() {
 		context := core.NewEVMBlockContext(block.Header(), b.chain, nil, b.chainConfig, statedb)
-		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), context.ExchangeRates)
+		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee(), context.FeeCurrencyContext.ExchangeRates)
 		txContext := core.NewEVMTxContext(msg)
 		if idx == txIndex {
 			return msg, context, statedb, release, nil

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -141,7 +141,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
-			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.ExchangeRates)
+			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
@@ -231,7 +231,7 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		Difficulty:  (*big.Int)(test.Context.Difficulty),
 		GasLimit:    uint64(test.Context.GasLimit),
 	}
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.ExchangeRates)
+	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -102,7 +102,7 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	if err != nil {
 		return fmt.Errorf("failed to create call tracer: %v", err)
 	}
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.ExchangeRates)
+	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for tracing: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -111,7 +111,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
-			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.ExchangeRates)
+			msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 			if err != nil {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -90,7 +90,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 		//EnableReturnData: false,
 	})
 	evm := vm.NewEVM(context, txContext, state.StateDB, params.AllEthashProtocolChanges, vm.Config{Tracer: tracer})
-	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.ExchangeRates)
+	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1187,7 +1187,7 @@ func doCall(ctx context.Context, b Backend, args TransactionArgs, state *state.S
 	if blockOverrides != nil {
 		blockOverrides.Apply(&blockCtx)
 	}
-	msg, err := args.ToMessage(globalGasCap, blockCtx.BaseFee, blockCtx.ExchangeRates)
+	msg, err := args.ToMessage(globalGasCap, blockCtx.BaseFee, blockCtx.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1137,7 +1137,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		return nil, err
 	}
 	context := core.NewEVMBlockContext(header, w.chain, nil, w.chainConfig, env.state)
-	env.feeCurrencyWhitelist = common.CurrencyWhitelist(context.ExchangeRates)
+	env.feeCurrencyWhitelist = common.CurrencyWhitelist(context.FeeCurrencyContext.ExchangeRates)
 	if header.ParentBeaconRoot != nil {
 		vmenv := vm.NewEVM(context, vm.TxContext{}, env.state, w.chainConfig, vm.Config{})
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv, env.state)

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,7 +55,8 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, nil)
+		var feeIntrinsic common.IntrinsicGasCosts
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, nil, feeIntrinsic)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,8 +55,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		var feeIntrinsic common.IntrinsicGasCosts
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, nil, feeIntrinsic)
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul, false, nil, common.IntrinsicGasCosts{})
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Closes #125 

Implements:
- refactor: now uses one combined object `FeeCurrencyContext` in block context for fee-currency related context info, storing both the exchange rates as well as the intrinsic fee currency gas costs
- refactor: `evm.Context.GasUsedForDebit` removed from Context (which should be read only after initialization) and now passed as argument directly. The value is now stored in the state-transition's `feeCurrencyGasUsed`
- read the fee-currency intrinsic gas cost from the `FeeCurrencyDirectory` on a per block context basis
- introduce e2e test for intrinsic fee currency over-usage