### PR TITLE
Add signing support for migrated dynamic fee transactions take2

### DIFF
--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -64,6 +64,11 @@ func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 	switch {
 	case t == LegacyTxType && tx.IsCeloLegacy():
 		return deprecatedTxFuncs
+	case t == DynamicFeeTxType:
+		// We deprecate celo support of the DynamicFeeTxType in the cel2 fork
+		// since at this point it will be supported by the upstream London
+		// hardfork.
+		return deprecatedTxFuncs
 	case t == CeloDynamicFeeTxType:
 		return deprecatedTxFuncs
 	}
@@ -97,6 +102,15 @@ func (c *celoLegacy) txFuncs(tx *Transaction) *txFuncs {
 			return celoLegacyProtectedTxFuncs
 		}
 		return celoLegacyUnprotectedTxFuncs
+	case t == DynamicFeeTxType:
+		// We handle the dynamic fee tx type here because we need to handle
+		// migrated dynamic fee txs. These were enabeled in celo in the Espresso
+		// hardfork, which doesn't have any analogue in op-geth. Even though
+		// op-geth does enable support for dynamic fee txs in the London
+		// hardfork (which we set to the cel2 block) that fork contains a lot of
+		// changes that were not part of Espresso. So instead we handle
+		// DynamicFeeTxTypes ocurring before the cel2 block here.
+		return dynamicFeeTxFuncs
 	case t == CeloDynamicFeeTxV2Type:
 		return celoDynamicFeeTxV2Funcs
 	case t == CeloDynamicFeeTxType:

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -64,11 +64,6 @@ func (c *cel2) txFuncs(tx *Transaction) *txFuncs {
 	switch {
 	case t == LegacyTxType && tx.IsCeloLegacy():
 		return deprecatedTxFuncs
-	case t == DynamicFeeTxType:
-		// We deprecate celo support of the DynamicFeeTxType in the cel2 fork
-		// since at this point it will be supported by the upstream London
-		// hardfork.
-		return deprecatedTxFuncs
 	case t == CeloDynamicFeeTxType:
 		return deprecatedTxFuncs
 	}
@@ -108,8 +103,8 @@ func (c *celoLegacy) txFuncs(tx *Transaction) *txFuncs {
 		// hardfork, which doesn't have any analogue in op-geth. Even though
 		// op-geth does enable support for dynamic fee txs in the London
 		// hardfork (which we set to the cel2 block) that fork contains a lot of
-		// changes that were not part of Espresso. So instead we handle
-		// DynamicFeeTxTypes ocurring before the cel2 block here.
+		// changes that were not part of Espresso. So instead we ned to handle
+		// DynamicFeeTxTypes here.
 		return dynamicFeeTxFuncs
 	case t == CeloDynamicFeeTxV2Type:
 		return celoDynamicFeeTxV2Funcs

--- a/core/types/celo_transaction_signing_tx_funcs.go
+++ b/core/types/celo_transaction_signing_tx_funcs.go
@@ -61,6 +61,18 @@ var (
 		},
 	}
 
+	dynamicFeeTxFuncs = &txFuncs{
+		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
+			return NewLondonSigner(chainID).Hash(tx)
+		},
+		signatureValues: func(tx *Transaction, sig []byte, signerChainID *big.Int) (r *big.Int, s *big.Int, v *big.Int, err error) {
+			return NewLondonSigner(signerChainID).SignatureValues(tx, sig)
+		},
+		sender: func(tx *Transaction, hashFunc func(tx *Transaction, chainID *big.Int) common.Hash, signerChainID *big.Int) (common.Address, error) {
+			return NewLondonSigner(signerChainID).Sender(tx)
+		},
+	}
+
 	celoDynamicFeeTxFuncs = &txFuncs{
 		hash: func(tx *Transaction, chainID *big.Int) common.Hash {
 			return prefixedRlpHash(


### PR DESCRIPTION
The original PR #176 caused tests to break because it deprecated the
DynamicFeeTxType in the more recent cel2 fork. When I wrote that I was thinking
that we would hand over to the upstream signer but actually that was a logical
error on my part, since deprecating means taking away support for a transaction
you can't keep on searching for support after encountering deprecation.

The fix is to simply not deprecate support for DynamicFeeTransactions in the
cel2 fork, this should work exactly as the upstream signer since it is
delegating to the same object for signing. However if ethereum deprecates the
DynmamicFeeTransaction we will need to add our own deprecation at that point.
(assuming we want to follow ethereum's deprecation)

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/375
