### PR TITLE
Ensure l1 gas fields not added to legacy receipt

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1945,7 +1945,7 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
-	if chainConfig.Optimism != nil && !tx.IsDepositTx() && chainConfig.IsCel2Block(new(big.Int).SetUint64(blockNumber)) {
+	if chainConfig.Optimism != nil && !tx.IsDepositTx() {
 		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1946,9 +1946,16 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 	}
 
 	if chainConfig.Optimism != nil && !tx.IsDepositTx() {
-		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
-		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
-		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
+		// These three fields are not present receipts migrated from l1 Celo
+		if receipt.L1GasPrice != nil {
+			fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
+		}
+		if receipt.L1GasUsed != nil {
+			fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
+		}
+		if receipt.L1Fee != nil {
+			fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
+		}
 		// Fields removed with Ecotone
 		if receipt.FeeScalar != nil {
 			fields["l1FeeScalar"] = receipt.FeeScalar.String()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1945,7 +1945,7 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
-	if chainConfig.Optimism != nil && !tx.IsDepositTx() {
+	if chainConfig.Optimism != nil && !tx.IsDepositTx() && chainConfig.IsCel2Block(new(big.Int).SetUint64(blockNumber)) {
 		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)

--- a/params/config.go
+++ b/params/config.go
@@ -432,9 +432,7 @@ type ChainConfig struct {
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 
-	// These fields must both be set or both be nil.
-	Cel2Time  *uint64  `json:"cel2Time,omitempty"`  // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
-	Cel2Block *big.Int `json:"cel2Block,omitempty"` // Cel2 switch block (nil = no fork, 0 = already on optimism cel2)
+	Cel2Time *uint64 `json:"cel2Time,omitempty"` // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -723,10 +721,6 @@ func (c *ChainConfig) IsInterop(time uint64) bool {
 
 func (c *ChainConfig) IsCel2(time uint64) bool {
 	return isTimestampForked(c.Cel2Time, time)
-}
-
-func (c *ChainConfig) IsCel2Block(num *big.Int) bool {
-	return isBlockForked(c.Cel2Block, num)
 }
 
 // IsOptimism returns whether the node is an optimism node or not.

--- a/params/config.go
+++ b/params/config.go
@@ -432,7 +432,9 @@ type ChainConfig struct {
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 
-	Cel2Time *uint64 `json:"cel2Time,omitempty"` // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
+	// These fields must both be set or both be nil.
+	Cel2Time  *uint64  `json:"cel2Time,omitempty"`  // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
+	Cel2Block *big.Int `json:"cel2Block,omitempty"` // Cel2 switch block (nil = no fork, 0 = already on optimism cel2)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -721,6 +723,10 @@ func (c *ChainConfig) IsInterop(time uint64) bool {
 
 func (c *ChainConfig) IsCel2(time uint64) bool {
 	return isTimestampForked(c.Cel2Time, time)
+}
+
+func (c *ChainConfig) IsCel2Block(num *big.Int) bool {
+	return isBlockForked(c.Cel2Block, num)
 }
 
 // IsOptimism returns whether the node is an optimism node or not.


### PR DESCRIPTION
The l1 gas fields are specific to L2 operation, so they should not be
returned for legacy receipts generated when celo was an L1.