### PR TITLE
Add gingerbread hardfork block to chain config

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -432,7 +432,8 @@ type ChainConfig struct {
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 
-	Cel2Time *uint64 `json:"cel2Time,omitempty"` // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
+	Cel2Time         *uint64  `json:"cel2Time,omitempty"`         // Cel2 switch time (nil = no fork, 0 = already on optimism cel2)
+	GingerbreadBlock *big.Int `json:"gingerbreadBlock,omitempty"` // Gingerbread switch block (nil = no fork, 0 = already activated)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -721,6 +722,11 @@ func (c *ChainConfig) IsInterop(time uint64) bool {
 
 func (c *ChainConfig) IsCel2(time uint64) bool {
 	return isTimestampForked(c.Cel2Time, time)
+}
+
+// IsGingerbread returns whether num represents a block number after the Gingerbread fork
+func (c *ChainConfig) IsGingerbread(num *big.Int) bool {
+	return isBlockForked(c.GingerbreadBlock, num)
 }
 
 // IsOptimism returns whether the node is an optimism node or not.


### PR DESCRIPTION
We need this hardfork to be able to determine how we should calculate
gas price for transactions and receipts returned over the RPC API.
Specifically we want to treat the pre gingerbread occurrences differently. 

In L1 celo for pre gingerbread transactions when the associated state was
not available we would return null for the gas price, because we had no
way of knowing what the gas price was. Currently op-geth is returning the
gasFeeCap, which is misleading.