### PR TITLE
Add txpool metrics for TxType and FeeCurrency

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -102,6 +102,16 @@ var (
 	slotsGauge   = metrics.NewRegisteredGauge("txpool/slots", nil)
 
 	reheapTimer = metrics.NewRegisteredTimer("txpool/reheap", nil)
+
+	// Celo specific metrics
+	validTxMeterByTxType = map[byte]metrics.Meter{
+		types.LegacyTxType:           metrics.NewRegisteredMeter("txpool/txtype/legacy", nil),
+		types.AccessListTxType:       metrics.NewRegisteredMeter("txpool/txtype/accesslist", nil),
+		types.DynamicFeeTxType:       metrics.NewRegisteredMeter("txpool/txtype/dynamicfee", nil),
+		types.BlobTxType:             metrics.NewRegisteredMeter("txpool/txtype/blob", nil),
+		types.CeloDynamicFeeTxV2Type: metrics.NewRegisteredMeter("txpool/txtype/cip64", nil),
+	}
+	validTxMeterByFeeCurrency = map[common.Address]metrics.Meter{}
 )
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
@@ -1097,6 +1107,19 @@ func (pool *LegacyPool) addTxsLocked(txs []*types.Transaction, local bool) ([]er
 		errs[i] = err
 		if err == nil && !replaced {
 			dirty.addTx(tx)
+			if tx.FeeCurrency() != nil {
+				feeCurrencyMeter, ok := validTxMeterByFeeCurrency[*tx.FeeCurrency()]
+				if !ok {
+					feeCurrencyMeter = metrics.NewRegisteredMeter(
+						"txpool/feecurrency/"+tx.FeeCurrency().Hex(),
+						nil)
+					validTxMeterByFeeCurrency[*tx.FeeCurrency()] = feeCurrencyMeter
+				}
+				feeCurrencyMeter.Mark(1)
+			}
+			if txTypeMeter, ok := validTxMeterByTxType[tx.Type()]; ok {
+				txTypeMeter.Mark(1)
+			}
 		}
 	}
 	validTxMeter.Mark(int64(len(dirty.accounts)))


### PR DESCRIPTION
These are helpful to track the usage of our fee currency feature.

Adding gauges to track the exact amount of fee currency txs in the tx pool would be possible, but cause a larger diff that is spread out across multiple functions.

I also refrained from adding tracking to the state transition, since no metrics are collected inside the state transition at the moment. I wanted to stay close to the upstream code and correctly tracking the values when changes can be reverted at any time is not straightforward.

See https://github.com/celo-org/op-geth/issues/74.

Example output for the new metrics after running the viem e2e tests:

```
"txpool/feecurrency/0x000000000000000000000000000000000000cE16.count": 4,
"txpool/feecurrency/0x000000000000000000000000000000000000cE16.fifteen-minute": 0.7567675751254122,
"txpool/feecurrency/0x000000000000000000000000000000000000cE16.five-minute": 0.6771853799124913,
"txpool/feecurrency/0x000000000000000000000000000000000000cE16.mean": 0.07459095132259183,
"txpool/feecurrency/0x000000000000000000000000000000000000cE16.one-minute": 0.3476785668056627,
"txpool/txtype/accesslist.count": 0,
"txpool/txtype/accesslist.fifteen-minute": 0,
"txpool/txtype/accesslist.five-minute": 0,
"txpool/txtype/accesslist.mean": 0,
"txpool/txtype/accesslist.one-minute": 0,
"txpool/txtype/blob.count": 0,
"txpool/txtype/blob.fifteen-minute": 0,
"txpool/txtype/blob.five-minute": 0,
"txpool/txtype/blob.mean": 0,
"txpool/txtype/blob.one-minute": 0,
"txpool/txtype/cip64.count": 4,
"txpool/txtype/cip64.fifteen-minute": 0.7567675751254122,
"txpool/txtype/cip64.five-minute": 0.6771853799124913,
"txpool/txtype/cip64.mean": 0.07272912131376315,
"txpool/txtype/cip64.one-minute": 0.3476785668056627,
"txpool/txtype/dynamicfee.count": 9,
"txpool/txtype/dynamicfee.fifteen-minute": 1.7027270440321776,
"txpool/txtype/dynamicfee.five-minute": 1.5236671048031056,
"txpool/txtype/dynamicfee.mean": 0.16364100744682356,
"txpool/txtype/dynamicfee.one-minute": 0.7822767753127412,
"txpool/txtype/legacy.count": 0,
"txpool/txtype/legacy.fifteen-minute": 0,
"txpool/txtype/legacy.five-minute": 0,
"txpool/txtype/legacy.mean": 0,
"txpool/txtype/legacy.one-minute": 0,
```