### PR TITLE
Fix `effectiveGasPrice` JSON marshalling

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1979,7 +1979,11 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
 		"type":              hexutil.Uint(tx.Type()),
-		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
+	}
+
+	// omit the effectiveGasPrice when it is nil, for Celo L1 backwards compatibility.
+	if receipt.EffectiveGasPrice != nil || chainConfig.IsGingerbread(new(big.Int).SetUint64(blockNumber)) {
+		fields["effectiveGasPrice"] = (*hexutil.Big)(receipt.EffectiveGasPrice)
 	}
 
 	if chainConfig.Optimism != nil && !tx.IsDepositTx() {

--- a/params/config.go
+++ b/params/config.go
@@ -211,6 +211,7 @@ var (
 		GrayGlacierBlock:              big.NewInt(0),
 		ShanghaiTime:                  newUint64(0),
 		Cel2Time:                      newUint64(0),
+		GingerbreadBlock:              big.NewInt(0),
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 	}


### PR DESCRIPTION
Fixes #204 - the **Solution B** was chosen here

- Now the Receipt JSON marshaling will omit the `effectiveGasPrice` when it is `nil` and the blockchain is pre-Gingerbread
- The `--dev` mode was running in pre-Gingerbread configuration and caused issues with `cast` and `forge` (see #204 )