### PR TITLE
Revert "Add method to statedb to move an account (#146)"

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1484,16 +1484,3 @@ func (s *StateDB) PointCache() *utils.PointCache {
 func (s *StateDB) Witness() *stateless.Witness {
 	return s.witness
 }
-
-func (s *StateDB) MoveAccount(from, to common.Address) error {
-	fromObj := s.getStateObject(from)
-	if fromObj == nil {
-		return fmt.Errorf("account %s not found", from.Hex())
-	}
-
-	fromObj.address = to
-	fromObj.addrHash = crypto.Keccak256Hash(to[:])
-
-	s.setStateObject(fromObj)
-	return nil
-}


### PR DESCRIPTION
This reverts commit 0ec50cc52583709d267a93a70e0fdb34243e83dd.

No need for this in the migration any more, so let's reduce the diff.