### PR TITLE
Backport commits from upstream

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie/triestate"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
-	"golang.org/x/sync/errgroup"
 )
 
 // TriesInMemory represents the number of layers that are kept in RAM.
@@ -851,9 +850,9 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	// method will internally call a blocking trie fetch from the prefetcher,
 	// so there's no need to explicitly wait for the prefetchers to finish.
 	var (
-		start   = time.Now()
-		workers errgroup.Group
+		start = time.Now()
 	)
+	workers := newWorkerGroup()
 	if s.db.TrieDB().IsVerkle() {
 		// Whilst MPT storage tries are independent, Verkle has one single trie
 		// for all the accounts and all the storage slots merged together. The
@@ -1225,10 +1224,10 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// off some milliseconds from the commit operation. Also accumulate the code
 	// writes to run in parallel with the computations.
 	var (
-		start   = time.Now()
-		root    common.Hash
-		workers errgroup.Group
+		start = time.Now()
+		root  common.Hash
 	)
+	workers := newWorkerGroup()
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
 	//

--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"errors"
+	"runtime"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type workerGroup interface {
+	Go(func() error)
+	SetLimit(int)
+	Wait() error
+}
+
+func newWorkerGroup() workerGroup {
+	if runtime.NumCPU() <= 1 {
+		return &inlineWorkerGroup{}
+	} else {
+		var grp errgroup.Group
+		return &grp
+	}
+}
+
+type inlineWorkerGroup struct {
+	err error
+}
+
+func (i *inlineWorkerGroup) Go(action func() error) {
+	i.err = errors.Join(i.err, action())
+}
+
+func (i *inlineWorkerGroup) SetLimit(_ int) {
+}
+
+func (i *inlineWorkerGroup) Wait() error {
+	return i.err
+}

--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"errors"
-	"runtime"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -13,8 +12,8 @@ type workerGroup interface {
 	Wait() error
 }
 
-func newWorkerGroup() workerGroup {
-	if runtime.NumCPU() <= 1 {
+func newWorkerGroup(singlethreaded bool) workerGroup {
+	if singlethreaded {
 		return &inlineWorkerGroup{}
 	} else {
 		var grp errgroup.Group

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -210,11 +210,19 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 	return evm.interpreter
 }
 
+func (evm *EVM) maybeOverrideCaller(caller ContractRef) ContractRef {
+	if evm.Config.CallerOverride != nil {
+		return evm.Config.CallerOverride(caller)
+	}
+	return caller
+}
+
 // Call executes the contract associated with the addr with the given input as
 // parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	// Capture the tracer start/end events in debug mode
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALL, caller.Address(), addr, input, gas, value.ToBig())
@@ -300,6 +308,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALLCODE, caller.Address(), addr, input, gas, value.ToBig())
@@ -354,13 +363,14 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		// NOTE: caller must, at all times be a contract. It should never happen
 		// that caller is something other than a Contract.
-		parent := caller.(*Contract)
+		parent := caller.(interface{ Value() *uint256.Int })
 		// DELEGATECALL inherits value from parent call
-		evm.captureBegin(evm.depth, DELEGATECALL, caller.Address(), addr, input, gas, parent.value.ToBig())
+		evm.captureBegin(evm.depth, DELEGATECALL, caller.Address(), addr, input, gas, parent.Value().ToBig())
 		defer func(startGas uint64) {
 			evm.captureEnd(evm.depth, startGas, leftOverGas, ret, err)
 		}(gas)
@@ -402,6 +412,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, STATICCALL, caller.Address(), addr, input, gas, nil)
@@ -549,7 +560,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 
 	// Check whether the max code size has been exceeded, assign err if the case.
-	if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
+	if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize && !evm.Config.NoMaxCodeSize {
 		err = ErrMaxCodeSizeExceeded
 	}
 
@@ -599,6 +610,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
@@ -608,6 +620,7 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint2
 // The different between Create2 with Create is Create2 uses keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]
 // instead of the usual sender-and-nonce-hash as the address where the contract is initialized at.
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	caller = evm.maybeOverrideCaller(caller)
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
 	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -314,7 +314,7 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if size > params.MaxInitCodeSize && !evm.Config.NoMaxCodeSize {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
@@ -333,7 +333,7 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if size > params.MaxInitCodeSize && !evm.Config.NoMaxCodeSize {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -40,7 +40,9 @@ type Config struct {
 	ExtraEips               []int // Additional EIPS that are to be enabled
 	EnableWitnessCollection bool  // true if witness collection is enabled
 
-	PrecompileOverrides PrecompileOverrides // Precompiles can be swapped / changed / wrapped as needed
+	PrecompileOverrides PrecompileOverrides             // Precompiles can be swapped / changed / wrapped as needed
+	NoMaxCodeSize       bool                            // Ignore Max code size and max init code size limits
+	CallerOverride      func(v ContractRef) ContractRef // Swap the caller as needed, for VM prank functionality.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"runtime"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -45,7 +46,7 @@ var hasherPool = sync.Pool{
 
 func newHasher(parallel bool) *hasher {
 	h := hasherPool.Get().(*hasher)
-	h.parallel = parallel
+	h.parallel = parallel && runtime.NumCPU() > 1
 	return h
 }
 


### PR DESCRIPTION
These commits are required to make the optimism rebase work for version 1.9.1.

I expected the op-geth release that goes with op-stack 1.9.1 to be the same version that is used by the optimism repo internally. However, this is not the case and therefore we need these commits to make op-stack 1.9.1's optimism repo (and our rebase based on it) compile.