### PR TITLE
Update scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '42 12 * * 4'
   push:
-    branches: [ "master" ]
+    branches: [ "celo8" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Changing this to be the proper branch instead of master.  I know there was a celo5 as the default branch before, should we change this to celo* instead of celo8 in case the default branch increments again?