### PR TITLE
Added new metrics: chain_txincluded, chain_basefee and chain_gasused

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -82,6 +82,9 @@ var (
 	blockValidationTimer = metrics.NewRegisteredResettingTimer("chain/validation", nil)
 	blockExecutionTimer  = metrics.NewRegisteredResettingTimer("chain/execution", nil)
 	blockWriteTimer      = metrics.NewRegisteredResettingTimer("chain/write", nil)
+	blockGasUsedGauge    = metrics.NewRegisteredGauge("chain/gasused", nil)
+	blockBaseFeeGauge    = metrics.NewRegisteredGauge("chain/basefee", nil)
+	blockTxIncluded      = metrics.NewRegisteredGauge("chain/txincluded", nil)
 
 	blockReorgMeter     = metrics.NewRegisteredMeter("chain/reorg/executes", nil)
 	blockReorgAddMeter  = metrics.NewRegisteredMeter("chain/reorg/add", nil)
@@ -1987,6 +1990,10 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 
 	blockWriteTimer.Update(time.Since(wstart) - max(statedb.AccountCommits, statedb.StorageCommits) /* concurrent */ - statedb.SnapshotCommits - statedb.TrieDBCommits)
 	blockInsertTimer.UpdateSince(start)
+
+	blockGasUsedGauge.Update(int64(usedGas))
+	blockBaseFeeGauge.Update(block.Header().BaseFee.Int64())
+	blockTxIncluded.Update(int64(block.Transactions().Len()))
 
 	return &blockProcessingResult{usedGas: usedGas, procTime: proctime, status: status}, nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1992,8 +1992,12 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 	blockInsertTimer.UpdateSince(start)
 
 	blockGasUsedGauge.Update(int64(usedGas))
-	blockBaseFeeGauge.Update(block.Header().BaseFee.Int64())
-	blockTxIncluded.Update(int64(block.Transactions().Len()))
+	if block.Header().BaseFee != nil {
+		blockBaseFeeGauge.Update(block.Header().BaseFee.Int64())
+	}
+	if block.Transactions() != nil {
+		blockTxIncluded.Update(int64(block.Transactions().Len()))
+	}
 
 	return &blockProcessingResult{usedGas: usedGas, procTime: proctime, status: status}, nil
 }


### PR DESCRIPTION
Added three new metrics that are updated on every block. All of them are gauges (metric that can go up or down on every record):
- `chain_gasused`: Records the block gas usage, in gas units.
- `chain_basefee`: Records the baseFee for this block, in wei.
- `chain_txincluded`: Records the number of transaction included in the block.