### PR TITLE
Updating workflows to give the default github token read only permiss…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Test:
     runs-on: ["8-cpu","self-hosted","org"]

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -3,6 +3,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-scan-container:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@main

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - celo[0-9]+
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     concurrency: ci-${{ github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,9 @@ on:
       - master
       - celo*
 
+permissions:
+  contents: read
+
 jobs:
   dependencies:
     concurrency: ci-${{ github.ref }}


### PR DESCRIPTION
…ions unless more permissions are specified in a job.  This shouldn't affect the workflow at all since the token isn't used, but its following best practices and if the repo github token is still somehow leaked (shouldn't be possible anyways) then it only has contents read.