### PR TITLE
ethclient allow empty uncles

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -150,7 +150,10 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	if head.UncleHash == types.EmptyUncleHash && len(body.UncleHashes) > 0 {
 		return nil, errors.New("server returned non-empty uncle list but block header indicates no uncles")
 	}
-	if head.UncleHash != types.EmptyUncleHash && len(body.UncleHashes) == 0 {
+	// In celo before the ginerbread hardfork, blocks had no uncles hash and no
+	// uncles, so in those cases it is legitimate to have an empty uncles hash.
+	var emptyHash common.Hash
+	if head.UncleHash != emptyHash && head.UncleHash != types.EmptyUncleHash && len(body.UncleHashes) == 0 {
 		return nil, errors.New("server returned empty uncle list but block header indicates uncles")
 	}
 	if head.TxHash == types.EmptyTxsHash && len(body.Transactions) > 0 {


### PR DESCRIPTION
The first blocks of the celo chain (till gingerbread) lacked the uncles field, so to support
retrieving them with the ethclient.Client this modification is required.

Discovered through https://github.com/celo-org/celo-blockchain-planning/issues/363