### PR TITLE
pin the github action in .github/workflows/pages.yaml for JamesIves/g…

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,7 +31,7 @@ jobs:
           touch tmp/pages/.nojekyll
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@920cbb300dcd3f0568dbc42700c61e2fd9e6139c
         with:
           folder: tmp/pages
           clean: true


### PR DESCRIPTION
…ithub-pages-deploy-action to a specific commit.  This will prevent the author from changing the code we rely on.  Not really necessary if you trust this person and their internal security

If you do trust the author of this action, you can ignore and close this, otherwise this will pin the action to only this commit so it can't be tampered with later.