### PR TITLE
Proxy to HistoricalRPCService

### DIFF
--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -546,6 +546,15 @@ func TestTraceTransactionHistorical(t *testing.T) {
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
 		},
 	}
+
+	// Set Cel2Time so that we are in the pre-migration case
+	var cel2Time uint64 = 10000
+	genesis.Config.Cel2Time = &cel2Time
+	// These two changes are a workaround to compensate for the Cel2Time
+	// check in Genesis.ToBlock(). Ideally we remove this and fix it there.
+	genesis.GasLimit = params.GenesisGasLimit
+	genesis.Difficulty = params.GenesisDifficulty
+
 	target := common.Hash{}
 	signer := types.HomesteadSigner{}
 	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
@@ -691,6 +700,15 @@ func TestTraceBlockHistorical(t *testing.T) {
 			accounts[2].addr: {Balance: big.NewInt(params.Ether)},
 		},
 	}
+
+	// Set Cel2Time so that we are in the pre-migration case
+	var cel2Time uint64 = 10000
+	genesis.Config.Cel2Time = &cel2Time
+	// These two changes are a workaround to compensate for the Cel2Time
+	// check in Genesis.ToBlock(). Ideally we remove this and fix it there.
+	genesis.GasLimit = params.GenesisGasLimit
+	genesis.Difficulty = params.GenesisDifficulty
+
 	genBlocks := 10
 	signer := types.HomesteadSigner{}
 	backend := newTestBackend(t, genBlocks, genesis, func(i int, b *core.BlockGen) {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -295,6 +295,14 @@ func newTestBackend(t *testing.T, enableHistoricalState bool) (*node.Node, []*ty
 		actualGenesis = genesisForHistorical
 		consensusEngine = beacon.New(ethash.NewFaker())
 		chainLength = 10
+
+		// Set Cel2Time so that we are in the pre-migration case
+		var cel2Time uint64 = 10000
+		actualGenesis.Config.Cel2Time = &cel2Time
+		// These two changes are a workaround to compensate for the Cel2Time
+		// check in Genesis.ToBlock(). Ideally we remove this and fix it there.
+		actualGenesis.GasLimit = params.GenesisGasLimit
+		actualGenesis.Difficulty = params.GenesisDifficulty
 	} else {
 		actualGenesis = genesis
 		consensusEngine = ethash.NewFaker()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -671,7 +671,7 @@ func (api *BlockChainAPI) GetBalance(ctx context.Context, address common.Address
 		return nil, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Big
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getBalance", address, blockNrOrHash)
@@ -728,7 +728,7 @@ func (api *BlockChainAPI) GetProof(ctx context.Context, address common.Address, 
 	if err != nil {
 		return nil, err
 	}
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res AccountResult
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getProof", address, storageKeys, blockNrOrHash)
@@ -950,7 +950,7 @@ func (api *BlockChainAPI) GetCode(ctx context.Context, address common.Address, b
 		return nil, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getCode", address, blockNrOrHash)
@@ -981,7 +981,7 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Addre
 		return nil, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getStorageAt", address, hexKey, blockNrOrHash)
@@ -1262,7 +1262,7 @@ func (api *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockN
 		return nil, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_call", args, blockNrOrHash, overrides)
@@ -1363,7 +1363,7 @@ func (api *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs,
 		return 0, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Uint64
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_estimateGas", args, blockNrOrHash)
@@ -1725,7 +1725,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 	}
 
 	header, err := headerByNumberOrHash(ctx, api.b, bNrOrHash)
-	if err == nil && header != nil && api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if err == nil && header != nil && api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res accessListResult
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_createAccessList", args, blockNrOrHash)
@@ -1898,7 +1898,7 @@ func (api *TransactionAPI) GetTransactionCount(ctx context.Context, address comm
 		return nil, err
 	}
 
-	if api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if api.b.ChainConfig().IsPreCel2(header.Time) {
 		if api.b.HistoricalRPCService() != nil {
 			var res hexutil.Uint64
 			err := api.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getTransactionCount", address, blockNrOrHash)

--- a/params/config.go
+++ b/params/config.go
@@ -770,7 +770,7 @@ func (c *ChainConfig) IsCel2(time uint64) bool {
 }
 
 func (c *ChainConfig) IsPreCel2(time uint64) bool {
-	return !c.IsCel2(time)
+	return c.Cel2Time != nil && !c.IsCel2(time)
 }
 
 // IsGingerbread returns whether num represents a block number after the Gingerbread fork

--- a/params/config.go
+++ b/params/config.go
@@ -769,6 +769,10 @@ func (c *ChainConfig) IsCel2(time uint64) bool {
 	return isTimestampForked(c.Cel2Time, time)
 }
 
+func (c *ChainConfig) IsPreCel2(time uint64) bool {
+	return !c.IsCel2(time)
+}
+
 // IsGingerbread returns whether num represents a block number after the Gingerbread fork
 func (c *ChainConfig) IsGingerbread(num *big.Int) bool {
 	return isBlockForked(c.GingerbreadBlock, num)

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -80,7 +80,7 @@ type NoHistoricalFallbackError struct{}
 func (e NoHistoricalFallbackError) ErrorCode() int { return -32801 }
 
 func (e NoHistoricalFallbackError) Error() string {
-	return "no historical RPC is available for this historical (pre-bedrock) execution request"
+	return "no historical RPC is available for this historical (pre-cel2) execution request"
 }
 
 type methodNotFoundError struct{ method string }


### PR DESCRIPTION
- Minor edits to proxy out to the HistoricalRPCService based on cel2 time rather than bedrock block. 
- Adds support for TraceCall proxying to HistoricalRPCService

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/386

Testing:
- Manually tested all rpc endpoints (see doc here https://www.notion.so/clabsco/HistoricalRPCService-Testing-Scratchpad-10aea6297b89809789bde885503a6210?showMoveTo=true&saveParent=true) 
- Working on adding unit tests, but have gotten stuck. See https://github.com/celo-org/op-geth/pull/238