### PR TITLE
Enabling Cel2 does not need special base fee case

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -66,14 +66,8 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, time uint64) 
 		}
 	}()
 
-	// If this is the cel2 transition block and the parent block has a base fee
-	// then use that.
-	if config.Cel2Time != nil && *config.Cel2Time == time && parent.BaseFee != nil {
-		return parent.BaseFee
-	}
-
 	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
-	if !config.IsLondon(parent.Number) {
+	if !config.IsLondon(parent.Number) && !config.IsGingerbread(parent.Number) {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}
 

--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -67,6 +67,10 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, time uint64) 
 	}()
 
 	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
+	// For cel2 the london hardfork is enabled at the transition block, but we want to smoothly continue
+	// using our existing base fee and simply transition the calculation logic across to the real eip1559 logic
+	// I.E. stop using original celo logic defined in a smart contract. So if gingerbread was active for the parent
+	// block we don't set the base fee to the InitialBaseFee, and instead use the normal calculation logic.
 	if !config.IsLondon(parent.Number) && !config.IsGingerbread(parent.Number) {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -212,20 +212,3 @@ func TestCalcBaseFeeCeloFloor(t *testing.T) {
 		}
 	}
 }
-
-// TestCalcBaseFeeCeloBlockActivation tests the base fee calculation for the celo block activation, mantaining the same base fee as the parent block
-func TestCalcBaseFeeCeloBlockActivation(t *testing.T) {
-	config := celoConfig()
-	// Before activation
-	// usage above target
-	parent := &types.Header{
-		Number:   common.Big32,
-		GasLimit: 20000000,
-		GasUsed:  15000000,
-		BaseFee:  big.NewInt(params.InitialBaseFee * 3),
-		Time:     *config.Cel2Time - 2,
-	}
-	if have, want := CalcBaseFee(config, parent, parent.Time+2), big.NewInt(params.InitialBaseFee*3); have.Cmp(want) != 0 {
-		t.Errorf("have %d  want %d, ", have, want)
-	}
-}

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -146,6 +146,7 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, cancunBlock *big.Int, pe
 		emptyBlobVHash     = kzg4844.CalcBlobHashV1(sha256.New(), &emptyBlobCommit)
 	)
 	config.LondonBlock = londonBlock
+	config.GingerbreadBlock = londonBlock
 	config.ArrowGlacierBlock = londonBlock
 	config.GrayGlacierBlock = londonBlock
 	var engine consensus.Engine = beacon.New(ethash.NewFaker())


### PR DESCRIPTION
We can just continue calculating base fees with the normal EIP-1559 formula. There is not need to special case this block. Without the special case, we also don't need the test for the special case.

Removing the special case makes it easier to enable Cel2 in other tests without breaking the tests by unintentionally modifying the base fee.

This change might require a corresponding change in our migration script for consistency.