### PR TITLE
Return 0 L1 fees (not nil)

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -125,7 +125,7 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
 		if config.IsCel2(blockTime) {
-			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return nil, nil }
+			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
 		}
 		if !config.IsOptimismEcotone(blockTime) {
 			return newL1CostFuncBedrock(config, statedb, blockTime)


### PR DESCRIPTION
Returning nil works inside geth, but optimism tests expect the l1CostFunc to return non-nil values. Considering our l1CostFunc is the only one retuning nil values, it seems more pragmatic to change that rather than adapting external code to deal correctly with nil values.