### PR TITLE
Note that the bedrock block is the cel2 block

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -427,6 +427,8 @@ type ChainConfig struct {
 	PragueTime   *uint64 `json:"pragueTime,omitempty"`   // Prague switch time (nil = no fork, 0 = already on prague)
 	VerkleTime   *uint64 `json:"verkleTime,omitempty"`   // Verkle switch time (nil = no fork, 0 = already on verkle)
 
+	// Note that the bedrock block is also the first block of the celo L2, because it must be set for the celo l2 to
+	// function correctly and it can't be set before we migrate to the L2.
 	BedrockBlock *big.Int `json:"bedrockBlock,omitempty"` // Bedrock switch block (nil = no fork, 0 = already on optimism bedrock)
 	RegolithTime *uint64  `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 	CanyonTime   *uint64  `json:"canyonTime,omitempty"`   // Canyon switch time (nil = no fork, 0 = already on optimism canyon)


### PR DESCRIPTION
This PR adds a comment, to clarify this, since it is not immediately obvious and we are using the bedrock block to decide whether RPC requests require proxying to a historical RPC service.