### PR TITLE
Avoid concurrent use of statedb

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -677,6 +677,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 	if threads > len(txs) {
 		threads = len(txs)
 	}
+	exchangeRates := core.GetExchangeRates(block.Header(), api.backend.ChainConfig(), statedb)
 	jobs := make(chan *txTraceTask, threads)
 	for th := 0; th < threads; th++ {
 		pend.Add(1)
@@ -684,7 +685,6 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 			defer pend.Done()
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
-				exchangeRates := core.GetExchangeRates(block.Header(), api.backend.ChainConfig(), statedb)
 				msg, _ := core.TransactionToMessage(txs[task.index], signer, block.BaseFee(), exchangeRates)
 				txctx := &Context{
 					BlockHash:   blockHash,


### PR DESCRIPTION
The call to get exchange rates was sharing a statedb instance between many goroutines. Now we make the call once up front and share the exchange rates between goroutines, this is ok since we use the same set of exchange rates for the entire block.