### PR TITLE
Go back to original L1 fee handling

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -124,9 +124,6 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	forBlock := ^uint64(0)
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
-		if config.IsCel2(blockTime) {
-			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
-		}
 		if !config.IsOptimismEcotone(blockTime) {
 			return newL1CostFuncBedrock(config, statedb, blockTime)
 		}


### PR DESCRIPTION
We initially set the L1 fee to a fixed value of zero for Cel2. This is not necessary because we configure those fees to be zero by setting the fee scalars to zero that are applied to L1 base fees.

This reduces our changes to upstream, allows changing these values if we ever want to and allows us to keep tests with non-zero scalars.