### PR TITLE
Reinstate l1cost function

### DIFF
--- a/compat_test/compat_test.go
+++ b/compat_test/compat_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ var (
 	celoRpcURL        string
 	opGethRpcURL      string
 	startBlock        uint64
-	gingerbreadBlocks = map[uint64]uint64{42220: 21616000, 62320: 18785000, 44787: 19814000}
+	gingerbreadBlocks = map[uint64]uint64{params.CeloMainnetChainID: 21616000, params.CeloBaklavaChainID: 18785000, params.CeloAlfajoresChainID: 19814000}
 )
 
 func init() {

--- a/contracts/addresses/addresses.go
+++ b/contracts/addresses/addresses.go
@@ -9,6 +9,4 @@ var (
 
 	CeloTokenAlfajoresAddress  = common.HexToAddress("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9")
 	FeeHandlerAlfajoresAddress = common.HexToAddress("0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38")
-
-	AlfajoresChainID uint64 = 44787
 )

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -766,7 +766,7 @@ func (st *StateTransition) distributeTxFees() error {
 
 	feeCurrency := st.msg.FeeCurrency
 	feeHandlerAddress := addresses.FeeHandlerAddress
-	if st.evm.ChainConfig().ChainID != nil && st.evm.ChainConfig().ChainID.Uint64() == addresses.AlfajoresChainID {
+	if st.evm.ChainConfig().ChainID != nil && st.evm.ChainConfig().ChainID.Uint64() == params.CeloAlfajoresChainID {
 		feeHandlerAddress = addresses.FeeHandlerAlfajoresAddress
 	}
 

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -124,7 +124,9 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	forBlock := ^uint64(0)
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
-		if config.IsCel2(blockTime) {
+		// Alfajores requires a custom cost function see link for a detailed explanation
+		// https://github.com/celo-org/op-geth/pull/271
+		if config.IsCel2(blockTime) && config.ChainID.Uint64() == params.CeloAlfajoresChainID {
 			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
 		}
 		if !config.IsOptimismEcotone(blockTime) {

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -124,6 +124,9 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	forBlock := ^uint64(0)
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
+		if config.IsCel2(blockTime) {
+			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
+		}
 		if !config.IsOptimismEcotone(blockTime) {
 			return newL1CostFuncBedrock(config, statedb, blockTime)
 		}

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -48,7 +48,7 @@ func celoPrecompileAddress(index byte) common.Address {
 
 func (ctx *celoPrecompileContext) IsCallerCeloToken() (bool, error) {
 	tokenAddress := addresses.CeloTokenAddress
-	if ctx.evm.ChainConfig().ChainID != nil && ctx.evm.ChainConfig().ChainID.Uint64() == addresses.AlfajoresChainID {
+	if ctx.evm.ChainConfig().ChainID != nil && ctx.evm.ChainConfig().ChainID.Uint64() == params.CeloAlfajoresChainID {
 		tokenAddress = addresses.CeloTokenAlfajoresAddress
 	}
 	return tokenAddress == ctx.caller, nil

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -405,7 +405,7 @@ func TestNewRPCTransactionDynamicFee(t *testing.T) {
 func allEnabledChainConfig() *params.ChainConfig {
 	zeroTime := uint64(0)
 	return &params.ChainConfig{
-		ChainID:             big.NewInt(44787),
+		ChainID:             big.NewInt(params.CeloAlfajoresChainID),
 		HomesteadBlock:      big.NewInt(0),
 		EIP150Block:         big.NewInt(0),
 		EIP155Block:         big.NewInt(0),

--- a/params/config.go
+++ b/params/config.go
@@ -36,6 +36,8 @@ const (
 	OPMainnetChainID        = 10
 	OPGoerliChainID         = 420
 	CeloMainnetChainID      = 42220
+	CeloBaklavaChainID      = 62320
+	CeloAlfajoresChainID    = 44787
 	BaseMainnetChainID      = 8453
 	BaseGoerliChainID       = 84531
 	baseSepoliaChainID      = 84532


### PR DESCRIPTION
This commit reinstates a custom l1 cost function which always returns zero.

We thought we could get rid of this by simply setting the l1 fee scalars to zero, but we missed the l1 blob fee scalars on alfajores so removing our custom l1 cost function causes a hardfork while syncing alfajores.

In order to remove our l1 cost function without introducing an unintentional hardfork, we'll need to have a hardfork so that we can switch off the use of the cost function at a certain point. But for now reinstating our custom cost function means that we can use this branch for our alfajores deployment. It will cause some tests in the optimism repo to fail but that seems like a reasonable trade off for not having to manage two separate branches (one for local development and one to be deployed on alfajores).

This reverts commit e6a34232c02327efd6de781633cea6314df43432.

This is actually reverting a commit from another branch (celo8) so don't be confused if you can't find the reverted commit in this branch.
