### PR TITLE
Fix mempool order with different currency tip

### DIFF
--- a/miner/ordering.go
+++ b/miner/ordering.go
@@ -52,7 +52,7 @@ func newTxWithMinerFee(tx *txpool.LazyTransaction, from common.Address, baseFee 
 		if tx.GasFeeCap.Cmp(baseFeeConverted) < 0 {
 			return nil, types.ErrGasFeeCapTooLow
 		}
-		tip = new(uint256.Int).Sub(tx.GasFeeCap, baseFee)
+		tip = new(uint256.Int).Sub(tx.GasFeeCap, baseFeeConverted)
 		if tip.Gt(tx.GasTipCap) {
 			tip = tx.GasTipCap
 		}

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -194,3 +194,50 @@ func TestTransactionTimeSort(t *testing.T) {
 		}
 	}
 }
+
+func TestCorrectTransactionSortWithFeeCurrency(t *testing.T) {
+	t.Parallel()
+
+	user1, _ := crypto.GenerateKey()
+	user2, _ := crypto.GenerateKey()
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	rates := make(common.ExchangeRates)
+	feeCurrency := common.BigToAddress(common.Big1)
+	rates[feeCurrency] = big.NewRat(10, 1)
+
+	groups := map[common.Address][]*txpool.LazyTransaction{}
+
+	addr1 := crypto.PubkeyToAddress(user1.PublicKey)
+	// user1 pays 950 feeCurrency, rate is 10/1, baseFee is 10 in feeCurrency is 100,
+	// 950 - 100 = 850 feeCurrency tip => 85 celo tip
+	// without converting the tip (error fixed): 950 - 10 = 940 feeCurrency tip => 94 celo tip (this test fails)
+	groups[addr1] = append(groups[addr1], &txpool.LazyTransaction{
+		GasFeeCap:   uint256.NewInt(950),
+		GasTipCap:   uint256.NewInt(950),
+		Gas:         100,
+		FeeCurrency: &feeCurrency,
+	})
+
+	addr2 := crypto.PubkeyToAddress(user2.PublicKey)
+	// user2 pays 100 celos, baseFee is 10, tip is 90
+	groups[addr2] = append(groups[addr2], &txpool.LazyTransaction{
+		GasFeeCap: uint256.NewInt(100),
+		GasTipCap: uint256.NewInt(100),
+		Gas:       100,
+	})
+
+	// Sort the transactions and cross check the nonce ordering
+	txset := newTransactionsByPriceAndNonce(signer, groups, big.NewInt(10), rates)
+
+	var auxTx *txpool.LazyTransaction
+	auxTx, _ = txset.Peek()
+	if auxTx.FeeCurrency != nil {
+		t.Error("expected tx from user2, got the tx from user1")
+	}
+	txset.Shift()
+	auxTx, _ = txset.Peek()
+	if auxTx.FeeCurrency == nil || *auxTx.FeeCurrency != feeCurrency {
+		t.Error("expected tx from user1, got the tx from user2")
+	}
+}

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -208,36 +208,41 @@ func TestCorrectTransactionSortWithFeeCurrency(t *testing.T) {
 
 	groups := map[common.Address][]*txpool.LazyTransaction{}
 
+	baseFee := big.NewInt(10)
+
 	addr1 := crypto.PubkeyToAddress(user1.PublicKey)
+	user1GasFeeCap := uint256.NewInt(950)
 	// user1 pays 950 feeCurrency, rate is 10/1, baseFee is 10 in feeCurrency is 100,
 	// 950 - 100 = 850 feeCurrency tip => 85 celo tip
 	// without converting the tip (error fixed): 950 - 10 = 940 feeCurrency tip => 94 celo tip (this test fails)
 	groups[addr1] = append(groups[addr1], &txpool.LazyTransaction{
-		GasFeeCap:   uint256.NewInt(950),
-		GasTipCap:   uint256.NewInt(950),
+		GasFeeCap:   user1GasFeeCap,
+		GasTipCap:   user1GasFeeCap,
 		Gas:         100,
 		FeeCurrency: &feeCurrency,
 	})
 
 	addr2 := crypto.PubkeyToAddress(user2.PublicKey)
+	user2GasFeeCap := uint256.NewInt(100)
 	// user2 pays 100 celos, baseFee is 10, tip is 90
 	groups[addr2] = append(groups[addr2], &txpool.LazyTransaction{
-		GasFeeCap: uint256.NewInt(100),
-		GasTipCap: uint256.NewInt(100),
+		GasFeeCap: user2GasFeeCap,
+		GasTipCap: user2GasFeeCap,
 		Gas:       100,
 	})
 
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, big.NewInt(10), rates)
+	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee, rates)
 
 	var auxTx *txpool.LazyTransaction
-	auxTx, _ = txset.Peek()
-	if auxTx.FeeCurrency != nil {
+	var fees *uint256.Int
+	auxTx, fees = txset.Peek()
+	if auxTx.FeeCurrency != nil || auxTx.GasFeeCap.Cmp(user2GasFeeCap) != 0 || fees.Cmp(uint256.NewInt(90)) != 0 {
 		t.Error("expected tx from user2, got the tx from user1")
 	}
 	txset.Shift()
-	auxTx, _ = txset.Peek()
-	if auxTx.FeeCurrency == nil || *auxTx.FeeCurrency != feeCurrency {
+	auxTx, fees = txset.Peek()
+	if auxTx.FeeCurrency == nil || *auxTx.FeeCurrency != feeCurrency || auxTx.GasFeeCap.Cmp(user1GasFeeCap) != 0 || fees.Cmp(uint256.NewInt(85)) != 0 {
 		t.Error("expected tx from user1, got the tx from user2")
 	}
 }


### PR DESCRIPTION
We were calculating the tip of the cip64 txs for ordering with an arithmetic miscalculation.
Instead of getting the Tip as `GasFeeCap - BaseFeeInCurrency`, we were using `GasFeeCap - BaseFee`

Adding a test to avoid this scenario in the future

Fixes [765](https://github.com/celo-org/celo-blockchain-planning/issues/765)