### PR TITLE
Fix forkdiff commit by using local commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ devtools:
 forkdiff:
 	docker run --rm \
 		--mount src=$(shell pwd),target=/host-pwd,type=bind \
+		--platform linux/amd64 \
 		protolambda/forkdiff:latest \
 		-repo /host-pwd/ -fork /host-pwd/fork.yaml -out /host-pwd/forkdiff.html
 

--- a/fork.yaml
+++ b/fork.yaml
@@ -5,8 +5,8 @@ footer: |
   a fork of [Optimism's `op-geth`](https://github.com/ethereum-optimism/op-geth).
 base:
   name: op-geth
-  url: https://github.com/ethereum-optimism/op-geth
-  hash: 110c433a2469
+  url: https://github.com/celo-org/op-geth
+  ref: refs/heads/celo10-upstream
 fork:
   name: Celo
   url: https://github.com/celo-org/op-geth


### PR DESCRIPTION
Broken forkdiff job in https://github.com/celo-org/op-geth/actions/runs/12008995126/job/33472784474, the original commit seems to be garbage collected, so let's use the same commit from our repo.

Closes https://github.com/celo-org/op-geth/pull/279