### PR TITLE
forkdiff: fix ref inside github action

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - celo[0-9]+
 
+  workflow_dispatch:
+
 permissions:
   contents: read
 

--- a/fork.yaml
+++ b/fork.yaml
@@ -6,7 +6,7 @@ footer: |
 base:
   name: op-geth
   url: https://github.com/celo-org/op-geth
-  ref: refs/heads/celo10-upstream
+  ref: refs/remotes/origin/celo10-upstream
 fork:
   name: Celo
   url: https://github.com/celo-org/op-geth


### PR DESCRIPTION
The checkout action fetches with `+refs/heads/*:refs/remotes/origin/*`, therefore we need to adapt the ref.