### PR TITLE
Configure docker workflow to cancel previously running builds

### DIFF
--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -3,6 +3,9 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 


### PR DESCRIPTION
Currently if a docker workflow is triggered, and then another event that triggers the workflow comes in, it will build the container twice.  This should cancel the previous run so we're not burning through github actions minutes for no reason