### PR TITLE
Add overflow checks for addition of AccessList cost in IntrinsicGas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -141,8 +141,17 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation, 
 	}
 
 	if accessList != nil {
-		gas += uint64(len(accessList)) * params.TxAccessListAddressGas
-		gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
+		numItems := uint64(len(accessList))
+		if (math.MaxUint64-gas)/params.TxAccessListAddressGas < numItems {
+			return 0, ErrGasUintOverflow
+		}
+		gas += numItems * params.TxAccessListAddressGas
+
+		numStorageKeys := uint64(accessList.StorageKeys())
+		if (math.MaxUint64-gas)/params.TxAccessListStorageKeyGas < numStorageKeys {
+			return 0, ErrGasUintOverflow
+		}
+		gas += numStorageKeys * params.TxAccessListStorageKeyGas
 	}
 	return gas, nil
 }


### PR DESCRIPTION
Fixes https://github.com/celo-org/celo-blockchain-planning/issues/805

This PR adds overflow check before adding AccessList cost in `IntrinsicGas` function