### PR TITLE
Refactor: segregate celo changes

### DIFF
--- a/core/celo_state_transition.go
+++ b/core/celo_state_transition.go
@@ -1,0 +1,193 @@
+package core
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/exchange"
+	"github.com/ethereum/go-ethereum/contracts"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// IsFeeCurrencyDenominated returns whether the gas-price related
+// fields are denominated in a given fee currency or in the native token.
+// This effectively is only true for CIP-64 transactions.
+func (msg *Message) IsFeeCurrencyDenominated() bool {
+	return msg.FeeCurrency != nil && msg.MaxFeeInFeeCurrency == nil
+}
+
+// canPayFee checks whether accountOwner's balance can cover transaction fee.
+func (st *StateTransition) canPayFee(checkAmountForGas *big.Int) error {
+	var checkAmountInCelo, checkAmountInAlternativeCurrency *big.Int
+	if st.msg.FeeCurrency == nil {
+		checkAmountInCelo = new(big.Int).Add(checkAmountForGas, st.msg.Value)
+		checkAmountInAlternativeCurrency = common.Big0
+	} else {
+		checkAmountInCelo = st.msg.Value
+		checkAmountInAlternativeCurrency = checkAmountForGas
+	}
+
+	if checkAmountInCelo.Cmp(common.Big0) > 0 {
+		balanceInCeloU256, overflow := uint256.FromBig(checkAmountInCelo)
+		if overflow {
+			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+		}
+
+		balance := st.state.GetBalance(st.msg.From)
+
+		if balance.Cmp(balanceInCeloU256) < 0 {
+			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmountInCelo)
+		}
+	}
+	if checkAmountInAlternativeCurrency.Cmp(common.Big0) > 0 {
+		_, overflow := uint256.FromBig(checkAmountInAlternativeCurrency)
+		if overflow {
+			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+		}
+		backend := &contracts.CeloBackend{
+			ChainConfig: st.evm.ChainConfig(),
+			State:       st.state,
+		}
+		balance, err := contracts.GetBalanceERC20(backend, st.msg.From, *st.msg.FeeCurrency)
+		if err != nil {
+			return err
+		}
+
+		if balance.Cmp(checkAmountInAlternativeCurrency) < 0 {
+			return fmt.Errorf("%w: address %v have %v want %v, fee currency: %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmountInAlternativeCurrency, st.msg.FeeCurrency.Hex())
+		}
+	}
+	return nil
+}
+
+func (st *StateTransition) subFees(effectiveFee *big.Int) (err error) {
+	log.Trace("Debiting fee", "from", st.msg.From, "amount", effectiveFee, "feeCurrency", st.msg.FeeCurrency)
+
+	// native currency
+	if st.msg.FeeCurrency == nil {
+		effectiveFeeU256, _ := uint256.FromBig(effectiveFee)
+		st.state.SubBalance(st.msg.From, effectiveFeeU256, tracing.BalanceDecreaseGasBuy)
+		return nil
+	} else {
+		gasUsedDebit, err := contracts.DebitFees(st.evm, st.msg.FeeCurrency, st.msg.From, effectiveFee)
+		st.feeCurrencyGasUsed += gasUsedDebit
+		return err
+	}
+}
+
+// distributeTxFees calculates the amounts and recipients of transaction fees and credits the accounts.
+func (st *StateTransition) distributeTxFees() error {
+	if st.evm.Config.NoBaseFee && st.msg.GasFeeCap.Sign() == 0 && st.msg.GasTipCap.Sign() == 0 {
+		// Skip fee payment when NoBaseFee is set and the fee fields
+		// are 0. This avoids a negative effectiveTip being applied to
+		// the coinbase when simulating calls.
+		return nil
+	}
+
+	// Determine the refund and transaction fee to be distributed.
+	refund := new(big.Int).Mul(new(big.Int).SetUint64(st.gasRemaining), st.msg.GasPrice)
+	gasUsed := new(big.Int).SetUint64(st.gasUsed())
+	totalTxFee := new(big.Int).Mul(gasUsed, st.msg.GasPrice)
+	from := st.msg.From
+
+	// Divide the transaction into a base (the minimum transaction fee) and tip (any extra, or min(max tip, feecap - GPM) if espresso).
+	baseTxFee := new(big.Int).Mul(gasUsed, st.calculateBaseFee())
+	// No need to do effectiveTip calculation, because st.gasPrice == effectiveGasPrice, and effectiveTip = effectiveGasPrice - baseTxFee
+	tipTxFee := new(big.Int).Sub(totalTxFee, baseTxFee)
+
+	feeCurrency := st.msg.FeeCurrency
+	feeHandlerAddress := addresses.GetAddresses(st.evm.ChainConfig().ChainID).FeeHandler
+
+	log.Trace("distributeTxFees", "from", from, "refund", refund, "feeCurrency", feeCurrency,
+		"coinbaseFeeRecipient", st.evm.Context.Coinbase, "coinbaseFee", tipTxFee,
+		"feeHandler", feeHandlerAddress, "communityFundFee", baseTxFee)
+
+	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber, st.evm.Context.Random != nil, st.evm.Context.Time)
+	var l1Cost *big.Int
+	// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
+	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
+	if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil &&
+		rules.IsOptimismBedrock && !st.msg.IsDepositTx {
+		l1Cost = st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time)
+	}
+
+	if feeCurrency == nil {
+		tipTxFeeU256, overflow := uint256.FromBig(tipTxFee)
+		if overflow {
+			return fmt.Errorf("celo tip overflows U256: %d", tipTxFee)
+		}
+		st.state.AddBalance(st.evm.Context.Coinbase, tipTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
+
+		refundU256, overflow := uint256.FromBig(refund)
+		if overflow {
+			return fmt.Errorf("celo refund overflows U256: %d", refund)
+		}
+		st.state.AddBalance(from, refundU256, tracing.BalanceIncreaseGasReturn)
+
+		baseTxFeeU256, overflow := uint256.FromBig(baseTxFee)
+		if overflow {
+			return fmt.Errorf("celo base fee overflows U256: %d", baseTxFee)
+		}
+		if rules.IsCel2 {
+			st.state.AddBalance(feeHandlerAddress, baseTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
+		} else if st.evm.ChainConfig().Optimism != nil {
+			st.state.AddBalance(params.OptimismBaseFeeRecipient, baseTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
+		}
+
+		l1CostU256, overflow := uint256.FromBig(l1Cost)
+		if overflow {
+			return fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
+		}
+		if l1Cost != nil {
+			st.state.AddBalance(params.OptimismL1FeeRecipient, l1CostU256, tracing.BalanceIncreaseRewardTransactionFee)
+		}
+	} else {
+		if l1Cost != nil {
+			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, feeCurrency, l1Cost)
+		}
+		if err := contracts.CreditFees(
+			st.evm,
+			feeCurrency,
+			from,
+			st.evm.Context.Coinbase,
+			feeHandlerAddress,
+			params.OptimismL1FeeRecipient,
+			refund,
+			tipTxFee,
+			baseTxFee,
+			l1Cost,
+			st.feeCurrencyGasUsed,
+		); err != nil {
+			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "feeHandler", feeHandlerAddress, "err", err)
+			return err
+		}
+	}
+
+	if st.evm.Config.Tracer != nil && st.evm.Config.Tracer.OnGasChange != nil && st.gasRemaining > 0 {
+		st.evm.Config.Tracer.OnGasChange(st.gasRemaining, 0, tracing.GasChangeTxLeftOverReturned)
+	}
+	return nil
+}
+
+// calculateBaseFee returns the correct base fee to use during fee calculations
+// This is the base fee from the header if no fee currency is used, but the
+// base fee converted to fee currency when a fee currency is used.
+func (st *StateTransition) calculateBaseFee() *big.Int {
+	baseFee := st.evm.Context.BaseFee
+	if baseFee == nil {
+		// This can happen in pre EIP-1559 environments
+		baseFee = big.NewInt(0)
+	}
+
+	if st.msg.FeeCurrency != nil {
+		// Existence of the fee currency has been checked in `preCheck`
+		baseFee, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, st.msg.FeeCurrency, baseFee)
+	}
+
+	return baseFee
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -24,8 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/exchange"
 	cmath "github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/contracts"
-	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -231,13 +229,6 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 	return msg, err
 }
 
-// IsFeeCurrencyDenominated returns whether the gas-price related
-// fields are denominated in a given fee currency or in the native token.
-// This effectively is only true for CIP-64 transactions.
-func (msg *Message) IsFeeCurrencyDenominated() bool {
-	return msg.FeeCurrency != nil && msg.MaxFeeInFeeCurrency == nil
-}
-
 // ApplyMessage computes the new state by applying the given message
 // against the old state within the environment.
 //
@@ -349,65 +340,6 @@ func (st *StateTransition) buyGas() error {
 	st.initialGas = st.msg.GasLimit
 
 	return st.subFees(mgval)
-}
-
-// canPayFee checks whether accountOwner's balance can cover transaction fee.
-func (st *StateTransition) canPayFee(checkAmountForGas *big.Int) error {
-	var checkAmountInCelo, checkAmountInAlternativeCurrency *big.Int
-	if st.msg.FeeCurrency == nil {
-		checkAmountInCelo = new(big.Int).Add(checkAmountForGas, st.msg.Value)
-		checkAmountInAlternativeCurrency = common.Big0
-	} else {
-		checkAmountInCelo = st.msg.Value
-		checkAmountInAlternativeCurrency = checkAmountForGas
-	}
-
-	if checkAmountInCelo.Cmp(common.Big0) > 0 {
-		balanceInCeloU256, overflow := uint256.FromBig(checkAmountInCelo)
-		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
-		}
-
-		balance := st.state.GetBalance(st.msg.From)
-
-		if balance.Cmp(balanceInCeloU256) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmountInCelo)
-		}
-	}
-	if checkAmountInAlternativeCurrency.Cmp(common.Big0) > 0 {
-		_, overflow := uint256.FromBig(checkAmountInAlternativeCurrency)
-		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
-		}
-		backend := &contracts.CeloBackend{
-			ChainConfig: st.evm.ChainConfig(),
-			State:       st.state,
-		}
-		balance, err := contracts.GetBalanceERC20(backend, st.msg.From, *st.msg.FeeCurrency)
-		if err != nil {
-			return err
-		}
-
-		if balance.Cmp(checkAmountInAlternativeCurrency) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v, fee currency: %v", ErrInsufficientFunds, st.msg.From.Hex(), balance, checkAmountInAlternativeCurrency, st.msg.FeeCurrency.Hex())
-		}
-	}
-	return nil
-}
-
-func (st *StateTransition) subFees(effectiveFee *big.Int) (err error) {
-	log.Trace("Debiting fee", "from", st.msg.From, "amount", effectiveFee, "feeCurrency", st.msg.FeeCurrency)
-
-	// native currency
-	if st.msg.FeeCurrency == nil {
-		effectiveFeeU256, _ := uint256.FromBig(effectiveFee)
-		st.state.SubBalance(st.msg.From, effectiveFeeU256, tracing.BalanceDecreaseGasBuy)
-		return nil
-	} else {
-		gasUsedDebit, err := contracts.DebitFees(st.evm, st.msg.FeeCurrency, st.msg.From, effectiveFee)
-		st.feeCurrencyGasUsed += gasUsedDebit
-		return err
-	}
 }
 
 func (st *StateTransition) preCheck() error {
@@ -742,116 +674,4 @@ func (st *StateTransition) gasUsed() uint64 {
 // blobGasUsed returns the amount of blob gas used by the message.
 func (st *StateTransition) blobGasUsed() uint64 {
 	return uint64(len(st.msg.BlobHashes) * params.BlobTxBlobGasPerBlob)
-}
-
-// distributeTxFees calculates the amounts and recipients of transaction fees and credits the accounts.
-func (st *StateTransition) distributeTxFees() error {
-	if st.evm.Config.NoBaseFee && st.msg.GasFeeCap.Sign() == 0 && st.msg.GasTipCap.Sign() == 0 {
-		// Skip fee payment when NoBaseFee is set and the fee fields
-		// are 0. This avoids a negative effectiveTip being applied to
-		// the coinbase when simulating calls.
-		return nil
-	}
-
-	// Determine the refund and transaction fee to be distributed.
-	refund := new(big.Int).Mul(new(big.Int).SetUint64(st.gasRemaining), st.msg.GasPrice)
-	gasUsed := new(big.Int).SetUint64(st.gasUsed())
-	totalTxFee := new(big.Int).Mul(gasUsed, st.msg.GasPrice)
-	from := st.msg.From
-
-	// Divide the transaction into a base (the minimum transaction fee) and tip (any extra, or min(max tip, feecap - GPM) if espresso).
-	baseTxFee := new(big.Int).Mul(gasUsed, st.calculateBaseFee())
-	// No need to do effectiveTip calculation, because st.gasPrice == effectiveGasPrice, and effectiveTip = effectiveGasPrice - baseTxFee
-	tipTxFee := new(big.Int).Sub(totalTxFee, baseTxFee)
-
-	feeCurrency := st.msg.FeeCurrency
-	feeHandlerAddress := addresses.GetAddresses(st.evm.ChainConfig().ChainID).FeeHandler
-
-	log.Trace("distributeTxFees", "from", from, "refund", refund, "feeCurrency", feeCurrency,
-		"coinbaseFeeRecipient", st.evm.Context.Coinbase, "coinbaseFee", tipTxFee,
-		"feeHandler", feeHandlerAddress, "communityFundFee", baseTxFee)
-
-	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber, st.evm.Context.Random != nil, st.evm.Context.Time)
-	var l1Cost *big.Int
-	// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
-	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
-	if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil &&
-		rules.IsOptimismBedrock && !st.msg.IsDepositTx {
-		l1Cost = st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time)
-	}
-
-	if feeCurrency == nil {
-		tipTxFeeU256, overflow := uint256.FromBig(tipTxFee)
-		if overflow {
-			return fmt.Errorf("celo tip overflows U256: %d", tipTxFee)
-		}
-		st.state.AddBalance(st.evm.Context.Coinbase, tipTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
-
-		refundU256, overflow := uint256.FromBig(refund)
-		if overflow {
-			return fmt.Errorf("celo refund overflows U256: %d", refund)
-		}
-		st.state.AddBalance(from, refundU256, tracing.BalanceIncreaseGasReturn)
-
-		baseTxFeeU256, overflow := uint256.FromBig(baseTxFee)
-		if overflow {
-			return fmt.Errorf("celo base fee overflows U256: %d", baseTxFee)
-		}
-		if rules.IsCel2 {
-			st.state.AddBalance(feeHandlerAddress, baseTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
-		} else if st.evm.ChainConfig().Optimism != nil {
-			st.state.AddBalance(params.OptimismBaseFeeRecipient, baseTxFeeU256, tracing.BalanceIncreaseRewardTransactionFee)
-		}
-
-		l1CostU256, overflow := uint256.FromBig(l1Cost)
-		if overflow {
-			return fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
-		}
-		if l1Cost != nil {
-			st.state.AddBalance(params.OptimismL1FeeRecipient, l1CostU256, tracing.BalanceIncreaseRewardTransactionFee)
-		}
-	} else {
-		if l1Cost != nil {
-			l1Cost, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, feeCurrency, l1Cost)
-		}
-		if err := contracts.CreditFees(
-			st.evm,
-			feeCurrency,
-			from,
-			st.evm.Context.Coinbase,
-			feeHandlerAddress,
-			params.OptimismL1FeeRecipient,
-			refund,
-			tipTxFee,
-			baseTxFee,
-			l1Cost,
-			st.feeCurrencyGasUsed,
-		); err != nil {
-			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "feeHandler", feeHandlerAddress, "err", err)
-			return err
-		}
-	}
-
-	if st.evm.Config.Tracer != nil && st.evm.Config.Tracer.OnGasChange != nil && st.gasRemaining > 0 {
-		st.evm.Config.Tracer.OnGasChange(st.gasRemaining, 0, tracing.GasChangeTxLeftOverReturned)
-	}
-	return nil
-}
-
-// calculateBaseFee returns the correct base fee to use during fee calculations
-// This is the base fee from the header if no fee currency is used, but the
-// base fee converted to fee currency when a fee currency is used.
-func (st *StateTransition) calculateBaseFee() *big.Int {
-	baseFee := st.evm.Context.BaseFee
-	if baseFee == nil {
-		// This can happen in pre EIP-1559 environments
-		baseFee = big.NewInt(0)
-	}
-
-	if st.msg.FeeCurrency != nil {
-		// Existence of the fee currency has been checked in `preCheck`
-		baseFee, _ = exchange.ConvertCeloToCurrency(st.evm.Context.FeeCurrencyContext.ExchangeRates, st.msg.FeeCurrency, baseFee)
-	}
-
-	return baseFee
 }

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -587,14 +587,16 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 			lazies := make([]*txpool.LazyTransaction, len(txs))
 			for i := 0; i < len(txs); i++ {
 				lazies[i] = &txpool.LazyTransaction{
-					Pool:        pool,
-					Hash:        txs[i].Hash(),
-					Tx:          txs[i],
-					Time:        txs[i].Time(),
-					GasFeeCap:   uint256.MustFromBig(txs[i].GasFeeCap()),
-					GasTipCap:   uint256.MustFromBig(txs[i].GasTipCap()),
-					Gas:         txs[i].Gas(),
-					BlobGas:     txs[i].BlobGas(),
+					Pool:      pool,
+					Hash:      txs[i].Hash(),
+					Tx:        txs[i],
+					Time:      txs[i].Time(),
+					GasFeeCap: uint256.MustFromBig(txs[i].GasFeeCap()),
+					GasTipCap: uint256.MustFromBig(txs[i].GasTipCap()),
+					Gas:       txs[i].Gas(),
+					BlobGas:   txs[i].BlobGas(),
+
+					// Celo specific
 					FeeCurrency: txs[i].FeeCurrency(),
 				}
 			}

--- a/core/types/celo_receipt.go
+++ b/core/types/celo_receipt.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type celoDynamicReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             Bloom
+	Logs              []*Log
+	// BaseFee was introduced as mandatory in Cel2 ONLY for the CeloDynamicFeeTxs
+	BaseFee *big.Int `rlp:"optional"`
+}
+
+type CeloDynamicFeeStoredReceiptRLP struct {
+	CeloDynamicReceiptMarker []interface{} // Marker to distinguish this from storedReceiptRLP
+	PostStateOrStatus        []byte
+	CumulativeGasUsed        uint64
+	Logs                     []*Log
+	BaseFee                  *big.Int `rlp:"optional"`
+}
+
+// Detect CeloDynamicFee receipts by looking at the first list element
+// To distinguish these receipts from the very similar normal receipts, an
+// empty list is added as the first element of the RLP-serialized struct.
+func IsCeloDynamicFeeReceipt(blob []byte) bool {
+	listHeaderSize := 1 // Length of the list header representing the struct in bytes
+	if blob[0] > 0xf7 {
+		listHeaderSize += int(blob[0]) - 0xf7
+	}
+	firstListElement := blob[listHeaderSize] // First byte of first list element
+	return firstListElement == 0xc0
+}
+
+func decodeStoredCeloDynamicFeeReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored CeloDynamicFeeStoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.Logs = stored.Logs
+	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+	r.BaseFee = stored.BaseFee
+	return nil
+}

--- a/miner/ordering.go
+++ b/miner/ordering.go
@@ -107,10 +107,12 @@ func (s *txByPriceAndTime) Pop() interface{} {
 // transactions in a profit-maximizing sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
 type transactionsByPriceAndNonce struct {
-	txs           map[common.Address][]*txpool.LazyTransaction // Per account nonce-sorted list of transactions
-	heads         txByPriceAndTime                             // Next transaction for each unique account (price heap)
-	signer        types.Signer                                 // Signer for the set of transactions
-	baseFee       *uint256.Int                                 // Current base fee
+	txs     map[common.Address][]*txpool.LazyTransaction // Per account nonce-sorted list of transactions
+	heads   txByPriceAndTime                             // Next transaction for each unique account (price heap)
+	signer  types.Signer                                 // Signer for the set of transactions
+	baseFee *uint256.Int                                 // Current base fee
+
+	// Celo specific
 	exchangeRates common.ExchangeRates
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -56,20 +56,22 @@ var (
 // environment is the worker's current environment and holds all
 // information of the sealing block generation.
 type environment struct {
-	signer               types.Signer
-	state                *state.StateDB     // apply state changes here
-	tcount               int                // tx count in cycle
-	gasPool              *core.GasPool      // available gas used to pack transactions
-	multiGasPool         *core.MultiGasPool // available per-fee-currency gas used to pack transactions
-	feeCurrencyAllowlist common.AddressSet
-	coinbase             common.Address
-	feeCurrencyContext   *common.FeeCurrencyContext
+	signer   types.Signer
+	state    *state.StateDB // apply state changes here
+	tcount   int            // tx count in cycle
+	gasPool  *core.GasPool  // available gas used to pack transactions
+	coinbase common.Address
 
 	header   *types.Header
 	txs      []*types.Transaction
 	receipts []*types.Receipt
 	sidecars []*types.BlobTxSidecar
 	blobs    int
+
+	// Celo specific
+	multiGasPool         *core.MultiGasPool // available per-fee-currency gas used to pack transactions
+	feeCurrencyAllowlist common.AddressSet
+	feeCurrencyContext   *common.FeeCurrencyContext
 }
 
 const (


### PR DESCRIPTION
Basic refactorings to make the celo changes to upstream stand out more clearly and reduce the diff size and chances of merge conflicts when using non-syntax-aware tools.