### PR TITLE
Ensure generated types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,3 +57,22 @@ jobs:
 
         - name: Lint
           run: make lint
+
+  Generate:
+    steps:
+        - uses: actions/checkout@v4
+
+        - uses: actions/setup-go@v5
+          with:
+            go-version: '1.22'
+            cache: false
+
+        - name: Generate check
+          # Run go generate and see if anything changed.
+          run: |
+            go generate ./...
+            if [ -n "$(git status --porcelain)" ]; then
+              echo "Changes detected after running 'go generate ./...' run generate locally and commit the changes."
+              exit 1
+            fi
+          shell: sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,11 @@ jobs:
 
         - name: Generate check
           # Run go generate and see if anything changed.
+          # We need to use || true because currently we do not install protoc
+          # and protoc-gen-go which are required for genrating some files,
+          # however despite this the non protobuf related types are generated.
           run: |
-            go generate ./...
+            go generate ./... || true
             if [ -n "$(git status --porcelain)" ]; then
               echo "Changes detected after running 'go generate ./...' run generate locally and commit the changes."
               exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           run: make lint
 
   Generate:
+    runs-on: ["ubuntu-latest"]
     steps:
         - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         - name: Generate check
           # Run go generate and see if anything changed.
           # We need to use || true because currently we do not install protoc
-          # and protoc-gen-go which are required for genrating some files,
+          # and protoc-gen-go which are required for generating some files,
           # however despite this the non protobuf related types are generated.
           run: |
             go generate ./... || true

--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -72,7 +72,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		Difficulty    *math.HexOrDecimal256                      `json:"difficulty"`
 		Mixhash       *common.Hash                               `json:"mixHash"`
 		Coinbase      *common.Address                            `json:"coinbase"`
-		Alloc         map[common.UnprefixedAddress]types.Account `json:"alloc"`
+		Alloc         map[common.UnprefixedAddress]types.Account `json:"alloc"      gencodec:"required"`
 		Number        *math.HexOrDecimal64                       `json:"number"`
 		GasUsed       *math.HexOrDecimal64                       `json:"gasUsed"`
 		ParentHash    *common.Hash                               `json:"parentHash"`

--- a/core/tracing/gen_balance_change_reason_stringer.go
+++ b/core/tracing/gen_balance_change_reason_stringer.go
@@ -23,15 +23,25 @@ func _() {
 	_ = x[BalanceIncreaseSelfdestruct-12]
 	_ = x[BalanceDecreaseSelfdestruct-13]
 	_ = x[BalanceDecreaseSelfdestructBurn-14]
+	_ = x[BalanceMint-200]
 }
 
-const _BalanceChangeReason_name = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurn"
+const (
+	_BalanceChangeReason_name_0 = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurn"
+	_BalanceChangeReason_name_1 = "BalanceMint"
+)
 
-var _BalanceChangeReason_index = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400}
+var (
+	_BalanceChangeReason_index_0 = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400}
+)
 
 func (i BalanceChangeReason) String() string {
-	if i >= BalanceChangeReason(len(_BalanceChangeReason_index)-1) {
+	switch {
+	case i <= 14:
+		return _BalanceChangeReason_name_0[_BalanceChangeReason_index_0[i]:_BalanceChangeReason_index_0[i+1]]
+	case i == 200:
+		return _BalanceChangeReason_name_1
+	default:
 		return "BalanceChangeReason(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _BalanceChangeReason_name[_BalanceChangeReason_index[i]:_BalanceChangeReason_index[i+1]]
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -40,6 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
 		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
+		BaseFee               *big.Int        `json:"baseFee,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -66,6 +67,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.FeeScalar = r.FeeScalar
 	enc.L1BaseFeeScalar = (*hexutil.Uint64)(r.L1BaseFeeScalar)
 	enc.L1BlobBaseFeeScalar = (*hexutil.Uint64)(r.L1BlobBaseFeeScalar)
+	enc.BaseFee = r.BaseFee
 	return json.Marshal(&enc)
 }
 
@@ -96,6 +98,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
 		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
+		BaseFee               *big.Int        `json:"baseFee,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -177,6 +180,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.L1BlobBaseFeeScalar != nil {
 		r.L1BlobBaseFeeScalar = (*uint64)(dec.L1BlobBaseFeeScalar)
+	}
+	if dec.BaseFee != nil {
+		r.BaseFee = dec.BaseFee
 	}
 	return nil
 }

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -53,6 +53,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		OverrideCancun                            *uint64 `toml:",omitempty"`
 		OverrideVerkle                            *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon                    *uint64 `toml:",omitempty"`
+		OverrideOptimismCel2                      *uint64 `toml:",omitempty"`
 		OverrideOptimismEcotone                   *uint64 `toml:",omitempty"`
 		OverrideOptimismFjord                     *uint64 `toml:",omitempty"`
 		OverrideOptimismGranite                   *uint64 `toml:",omitempty"`
@@ -107,6 +108,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.OverrideOptimismCanyon = c.OverrideOptimismCanyon
+	enc.OverrideOptimismCel2 = c.OverrideOptimismCel2
 	enc.OverrideOptimismEcotone = c.OverrideOptimismEcotone
 	enc.OverrideOptimismFjord = c.OverrideOptimismFjord
 	enc.OverrideOptimismGranite = c.OverrideOptimismGranite
@@ -165,6 +167,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		OverrideCancun                            *uint64 `toml:",omitempty"`
 		OverrideVerkle                            *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon                    *uint64 `toml:",omitempty"`
+		OverrideOptimismCel2                      *uint64 `toml:",omitempty"`
 		OverrideOptimismEcotone                   *uint64 `toml:",omitempty"`
 		OverrideOptimismFjord                     *uint64 `toml:",omitempty"`
 		OverrideOptimismGranite                   *uint64 `toml:",omitempty"`
@@ -293,6 +296,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideOptimismCanyon != nil {
 		c.OverrideOptimismCanyon = dec.OverrideOptimismCanyon
+	}
+	if dec.OverrideOptimismCel2 != nil {
+		c.OverrideOptimismCel2 = dec.OverrideOptimismCel2
 	}
 	if dec.OverrideOptimismEcotone != nil {
 		c.OverrideOptimismEcotone = dec.OverrideOptimismEcotone


### PR DESCRIPTION
A number of generated types had become stale because we had not run go generate.

This PR updates generated types and adds a CI step to check that generated types are up to date.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/855