### PR TITLE
Add more verbosity to contract-address getter defaults

### DIFF
--- a/contracts/addresses/addresses.go
+++ b/contracts/addresses/addresses.go
@@ -33,19 +33,31 @@ var (
 	}
 )
 
-// GetAddresses returns the addresses for the given chainID.
+// GetAddresses returns the addresses for the given chainID or
+// nil if not found.
 func GetAddresses(chainID *big.Int) *CeloAddresses {
 	// ChainID can be uninitialized in some tests
 	if chainID == nil {
-		return MainnetAddresses
+		return nil
 	}
-
 	switch chainID.Uint64() {
 	case params.CeloAlfajoresChainID:
 		return AlfajoresAddresses
 	case params.CeloBaklavaChainID:
 		return BaklavaAddresses
-	default:
+	case params.CeloMainnetChainID:
 		return MainnetAddresses
+	default:
+		return nil
 	}
+}
+
+// GetAddressesOrDefault returns the addresses for the given chainID or
+// the Mainnet addresses if none are found.
+func GetAddressesOrDefault(chainID *big.Int, defaultValue *CeloAddresses) *CeloAddresses {
+	addresses := GetAddresses(chainID)
+	if addresses == nil {
+		return defaultValue
+	}
+	return addresses
 }

--- a/contracts/fee_currencies.go
+++ b/contracts/fee_currencies.go
@@ -189,7 +189,10 @@ func GetRegisteredCurrencies(caller *abigen.FeeCurrencyDirectoryCaller) ([]commo
 
 // GetExchangeRates returns the exchange rates for the provided gas currencies
 func GetExchangeRates(caller *CeloBackend) (common.ExchangeRates, error) {
-	directory, err := abigen.NewFeeCurrencyDirectoryCaller(addresses.GetAddresses(caller.ChainConfig.ChainID).FeeCurrencyDirectory, caller)
+	directory, err := abigen.NewFeeCurrencyDirectoryCaller(
+		addresses.GetAddressesOrDefault(caller.ChainConfig.ChainID, addresses.MainnetAddresses).FeeCurrencyDirectory,
+		caller,
+	)
 	if err != nil {
 		return common.ExchangeRates{}, fmt.Errorf("failed to access FeeCurrencyDirectory: %w", err)
 	}
@@ -203,7 +206,10 @@ func GetExchangeRates(caller *CeloBackend) (common.ExchangeRates, error) {
 // GetFeeCurrencyContext returns the fee currency block context for all registered gas currencies from CELO
 func GetFeeCurrencyContext(caller *CeloBackend) (common.FeeCurrencyContext, error) {
 	var feeContext common.FeeCurrencyContext
-	directory, err := abigen.NewFeeCurrencyDirectoryCaller(addresses.GetAddresses(caller.ChainConfig.ChainID).FeeCurrencyDirectory, caller)
+	directory, err := abigen.NewFeeCurrencyDirectoryCaller(
+		addresses.GetAddressesOrDefault(caller.ChainConfig.ChainID, addresses.MainnetAddresses).FeeCurrencyDirectory,
+		caller,
+	)
 	if err != nil {
 		return feeContext, fmt.Errorf("failed to access FeeCurrencyDirectory: %w", err)
 	}

--- a/core/celo_state_transition.go
+++ b/core/celo_state_transition.go
@@ -94,7 +94,7 @@ func (st *StateTransition) distributeTxFees() error {
 	tipTxFee := new(big.Int).Sub(totalTxFee, baseTxFee)
 
 	feeCurrency := st.msg.FeeCurrency
-	feeHandlerAddress := addresses.GetAddresses(st.evm.ChainConfig().ChainID).FeeHandler
+	feeHandlerAddress := addresses.GetAddressesOrDefault(st.evm.ChainConfig().ChainID, addresses.MainnetAddresses).FeeHandler
 
 	log.Trace("distributeTxFees", "from", from, "refund", refund, "feeCurrency", feeCurrency,
 		"coinbaseFeeRecipient", st.evm.Context.Coinbase, "coinbaseFee", tipTxFee,

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -47,7 +47,7 @@ func celoPrecompileAddress(index byte) common.Address {
 }
 
 func (ctx *celoPrecompileContext) IsCallerCeloToken() (bool, error) {
-	tokenAddress := addresses.GetAddresses(ctx.evm.ChainConfig().ChainID).CeloToken
+	tokenAddress := addresses.GetAddressesOrDefault(ctx.evm.ChainConfig().ChainID, addresses.MainnetAddresses).CeloToken
 
 	return tokenAddress == ctx.caller, nil
 }


### PR DESCRIPTION
Before the `GetAddresses` function silently returned the mainnet addresses as a default value, without the caller being made aware of this.

Now, the `GetAddresses` function will return `nil` whenever it does not explicitly map the passed in chain-id to a set of addresses.

The newly added `GetAddressesOrDefault` function allows for retrieving the addresses with a default fallback for easier use in inline calls. This replicates the behavior of the old `GetAddresses` functionality with more verbosity.