### PR TITLE
api: Correct error message

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -80,7 +80,7 @@ type NoHistoricalFallbackError struct{}
 func (e NoHistoricalFallbackError) ErrorCode() int { return -32801 }
 
 func (e NoHistoricalFallbackError) Error() string {
-	return "no historical RPC is available for this historical (pre-bedrock) execution request"
+	return "no historical RPC is available for this historical (pre-L2) execution request"
 }
 
 type methodNotFoundError struct{ method string }


### PR DESCRIPTION
Don't mention bedrock, but the L2 migration