### PR TITLE
Add totalDifficulty field to JSON-RPC schema of Celo1 block

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -844,7 +844,7 @@ func (api *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.Bloc
 	header, err := api.b.HeaderByNumber(ctx, number)
 	if header != nil && err == nil {
 		header := PopulatePreGingerbreadHeaderFields(ctx, api.b, header)
-		response := RPCMarshalHeader(header)
+		response := RPCMarshalHeader(header, isCelo1Block(api.b.ChainConfig(), header.Time))
 		if number == rpc.PendingBlockNumber && api.b.ChainConfig().Optimism == nil {
 			// Pending header need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
@@ -861,7 +861,7 @@ func (api *BlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.Hash)
 	header, _ := api.b.HeaderByHash(ctx, hash)
 	if header != nil {
 		header := PopulatePreGingerbreadHeaderFields(ctx, api.b, header)
-		return RPCMarshalHeader(header)
+		return RPCMarshalHeader(header, isCelo1Block(api.b.ChainConfig(), header.Time))
 	}
 	return nil
 }
@@ -1520,7 +1520,7 @@ func (api *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs,
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header) map[string]interface{} {
+func RPCMarshalHeader(head *types.Header, isCelo1 bool) map[string]interface{} {
 	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
@@ -1557,14 +1557,23 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.RequestsHash != nil {
 		result["requestsRoot"] = head.RequestsHash
 	}
+	if isCelo1 {
+		result["totalDifficulty"] = (*hexutil.Big)(new(big.Int).Add(head.Number, common.Big1))
+	}
 	return result
+}
+
+// isCelo1Block determines whether the given block is a Celo1 block
+// based on the chain config and the provided block time
+func isCelo1Block(config *params.ChainConfig, blockTime uint64) bool {
+	return config.Cel2Time != nil && !config.IsCel2(blockTime)
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func RPCMarshalBlock(ctx context.Context, block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig, backend Backend) (map[string]interface{}, error) {
-	fields := RPCMarshalHeader(block.Header())
+	fields := RPCMarshalHeader(block.Header(), isCelo1Block(config, block.Header().Time))
 	fields["size"] = hexutil.Uint64(block.Size())
 
 	if inclTx {

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -1,6 +1,8 @@
 package ethapi
 
 import (
+	"context"
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/blocktest"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -530,4 +533,122 @@ func checkTxFields(
 	}
 	assert.Equal(t, (*hexutil.Big)(tx.GatewayFee()), rpcTx.GatewayFee)
 	assert.Equal(t, tx.GatewayFeeRecipient(), rpcTx.GatewayFeeRecipient)
+}
+
+// Test_isCelo1Block tests isCelo1Block function to determine whether the given block time
+// corresponds to Celo1 chain based on the provided chain configuration
+func Test_isCelo1Block(t *testing.T) {
+	cel2Time := uint64(1000)
+
+	t.Run("Non-Celo", func(t *testing.T) {
+		res := isCelo1Block(&params.ChainConfig{
+			Cel2Time: nil,
+		}, 1000)
+
+		assert.False(t, res)
+	})
+
+	t.Run("Celo1", func(t *testing.T) {
+		res := isCelo1Block(&params.ChainConfig{
+			Cel2Time: &cel2Time,
+		}, 500)
+
+		assert.True(t, res)
+	})
+
+	t.Run("Celo2", func(t *testing.T) {
+		res := isCelo1Block(&params.ChainConfig{
+			Cel2Time: &cel2Time,
+		}, 1000)
+
+		assert.False(t, res)
+	})
+}
+
+// TestRPCMarshalBlock_Celo1TotalDifficulty tests the RPCMarshalBlock function, specifically for totalDifficulty field
+// It validates the result has `totalDifficulty` field only if it's Celo1 block
+func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
+	t.Parallel()
+
+	blockTime := uint64(1000)
+	block := types.NewBlock(&types.Header{Number: big.NewInt(100), Time: blockTime}, &types.Body{Transactions: []*types.Transaction{}}, nil, blocktest.NewHasher())
+
+	getExpectedJson := func(t *testing.T, expectedTd string) string {
+		data := map[string]interface{}{
+			"difficulty":       "0x0",
+			"extraData":        "0x",
+			"gasLimit":         "0x0",
+			"gasUsed":          "0x0",
+			"hash":             "0xd8371db7c48c7538a9cdf3e9211510e423039c0af3e1aa61d0a40960214d2101",
+			"logsBloom":        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			"miner":            "0x0000000000000000000000000000000000000000",
+			"mixHash":          "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"nonce":            "0x0000000000000000",
+			"number":           "0x64",
+			"parentHash":       "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"receiptsRoot":     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+			"sha3Uncles":       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+			"size":             "0x1f7",
+			"stateRoot":        "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp":        "0x3e8",
+			"transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+			"uncles":           []interface{}{},
+		}
+
+		if expectedTd != "" {
+			data["totalDifficulty"] = expectedTd
+		}
+
+		marshaled, err := json.Marshal(&data)
+		require.NoError(t, err)
+
+		return string(marshaled)
+	}
+
+	marshalBlock := func(t *testing.T, config *params.ChainConfig) string {
+		t.Helper()
+
+		resp, err := RPCMarshalBlock(context.Background(), block, false, false, config, testBackend{})
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		out, err := json.Marshal(resp)
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		return string(out)
+	}
+
+	t.Run("Non-Celo", func(t *testing.T) {
+		expected := getExpectedJson(t, "")
+
+		config := *params.MainnetChainConfig
+
+		res := marshalBlock(t, &config)
+		assert.JSONEq(t, expected, res)
+	})
+
+	t.Run("Celo1", func(t *testing.T) {
+		expected := getExpectedJson(t, "0x65")
+
+		cel2Time := blockTime + 500
+		config := *params.MainnetChainConfig
+		config.Cel2Time = &cel2Time
+
+		res := marshalBlock(t, &config)
+		assert.JSONEq(t, expected, res)
+	})
+
+	t.Run("Celo2", func(t *testing.T) {
+		expected := getExpectedJson(t, "")
+
+		cel2Time := blockTime - 500
+		config := *params.MainnetChainConfig
+		config.Cel2Time = &cel2Time
+
+		res := marshalBlock(t, &config)
+		assert.JSONEq(t, expected, res)
+	})
 }

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -604,7 +604,6 @@ func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
 	})
 
 	t.Run("Celo2", func(t *testing.T) {
-
 		cel2Time := blockTime - 500
 		config := *params.MainnetChainConfig
 		config.Cel2Time = &cel2Time

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -2,7 +2,6 @@ package ethapi
 
 import (
 	"context"
-	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -573,39 +572,7 @@ func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
 	blockTime := uint64(1000)
 	block := types.NewBlock(&types.Header{Number: big.NewInt(100), Time: blockTime}, &types.Body{Transactions: []*types.Transaction{}}, nil, blocktest.NewHasher())
 
-	getExpectedJson := func(t *testing.T, expectedTd string) string {
-		data := map[string]interface{}{
-			"difficulty":       "0x0",
-			"extraData":        "0x",
-			"gasLimit":         "0x0",
-			"gasUsed":          "0x0",
-			"hash":             "0xd8371db7c48c7538a9cdf3e9211510e423039c0af3e1aa61d0a40960214d2101",
-			"logsBloom":        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-			"miner":            "0x0000000000000000000000000000000000000000",
-			"mixHash":          "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"nonce":            "0x0000000000000000",
-			"number":           "0x64",
-			"parentHash":       "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"receiptsRoot":     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-			"sha3Uncles":       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-			"size":             "0x1f7",
-			"stateRoot":        "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"timestamp":        "0x3e8",
-			"transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-			"uncles":           []interface{}{},
-		}
-
-		if expectedTd != "" {
-			data["totalDifficulty"] = expectedTd
-		}
-
-		marshaled, err := json.Marshal(&data)
-		require.NoError(t, err)
-
-		return string(marshaled)
-	}
-
-	marshalBlock := func(t *testing.T, config *params.ChainConfig) string {
+	marshalBlock := func(t *testing.T, config *params.ChainConfig) map[string]interface{} {
 		t.Helper()
 
 		resp, err := RPCMarshalBlock(context.Background(), block, false, false, config, testBackend{})
@@ -613,42 +580,37 @@ func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		out, err := json.Marshal(resp)
-		if err != nil {
-			require.NoError(t, err)
-		}
-
-		return string(out)
+		return resp
 	}
 
 	t.Run("Non-Celo", func(t *testing.T) {
-		expected := getExpectedJson(t, "")
-
 		config := *params.MainnetChainConfig
 
 		res := marshalBlock(t, &config)
-		assert.JSONEq(t, expected, res)
+
+		assert.Equal(t, nil, res["totalDifficulty"])
 	})
 
 	t.Run("Celo1", func(t *testing.T) {
-		expected := getExpectedJson(t, "0x65")
+		expected := (*hexutil.Big)(new(big.Int).Add(block.Number(), common.Big1))
 
 		cel2Time := blockTime + 500
 		config := *params.MainnetChainConfig
 		config.Cel2Time = &cel2Time
 
 		res := marshalBlock(t, &config)
-		assert.JSONEq(t, expected, res)
+
+		assert.Equal(t, expected, res["totalDifficulty"])
 	})
 
 	t.Run("Celo2", func(t *testing.T) {
-		expected := getExpectedJson(t, "")
 
 		cel2Time := blockTime - 500
 		config := *params.MainnetChainConfig
 		config.Cel2Time = &cel2Time
 
 		res := marshalBlock(t, &config)
-		assert.JSONEq(t, expected, res)
+
+		assert.Equal(t, nil, res["totalDifficulty"])
 	})
 }


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/849

This PR adds the `totalDifficulty` field to the JSON-RPC response for Celo1 blocks.
The `totalDifficulty` is no longer present in `geth` and `op-geth`, as described in the following references:
- https://github.com/ethereum/go-ethereum/pull/30386
- https://github.com/ethereum-optimism/op-geth/commit/40fd887df6812033f96941181549693d2cd5444d

However, Celo2 requires RPC compatibility support for Celo1 blocks. Therefore, this PR adds `totalDifficulty` field specifically for Celo1 blocks.

During my investigation, I discovered that snap sync does not store total difficulty into local database. As a result, the `totalDifficulty` value in the RPC response is derived from the block height

