### PR TITLE
Increase default RPCTxFeeCap to 1000 (celos)

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -66,7 +66,7 @@ var Defaults = Config{
 	RPCGasCap:          50000000,
 	RPCEVMTimeout:      5 * time.Second,
 	GPO:                FullNodeGPO,
-	RPCTxFeeCap:        1, // 1 ether
+	RPCTxFeeCap:        1000, // 1000 celo
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go


### PR DESCRIPTION
With default configuration, we enforce txfeelimit to 1 celo, which can be not enough for high-gas transactions.
Increasing the default value to 1000 Celos, that in terms of dollar costs is closer to upstream limit of 1 ETH.