### PR TITLE
Add validation to ensure Cel2 chain has migrated data

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -347,12 +347,6 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// Make sure the state associated with the block is available, or log out
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
-	// Make sure Cel2 chain has migrated data from Celo1
-	if chainConfig.Cel2Time != nil && !chainConfig.IsCel2(head.Time) {
-		log.Error("Migrated data for Cel2 is missing, please ensure the migrated data from Celo1 can be properly loaded before starting the blockchain",
-			"current number", head.Number, "current hash", head.Hash())
-		return nil, fmt.Errorf("missing migrated data")
-	}
 	if !bc.HasState(head.Root) {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -347,6 +347,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// Make sure the state associated with the block is available, or log out
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
+	// Make sure Cel2 chain has migrated data from Celo1
+	if chainConfig.Cel2Time != nil && !chainConfig.IsCel2(head.Time) {
+		log.Error("Migrated data for Cel2 is missing, please ensure the migrated data from Celo1 can be properly loaded before starting the blockchain",
+			"current number", head.Number, "current hash", head.Hash())
+		return nil, fmt.Errorf("missing migrated data")
+	}
 	if !bc.HasState(head.Root) {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -255,6 +255,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Make sure Cel2 full sync node has migrated data from Celo1
+	currentBlock := eth.blockchain.CurrentBlock()
+	if config.SyncMode == downloader.FullSync && chainConfig.Cel2Time != nil && !chainConfig.IsCel2(currentBlock.Number.Uint64()) {
+		log.Error("Migrated data for Cel2 is missing, please ensure the migrated data from Celo1 can be properly loaded before starting the blockchain",
+			"current number", currentBlock.Number.Uint64(), "current hash", currentBlock.Hash())
+		return nil, fmt.Errorf("missing migrated data")
+	}
 	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1
 		config.NetworkId = chainConfig.ChainID.Uint64() // optimism defaults eth network ID to chain ID
 		eth.networkID = config.NetworkId

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -258,8 +258,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Make sure Cel2 full sync node has migrated data from Celo1
 	currentBlock := eth.blockchain.CurrentBlock()
 	if config.SyncMode == downloader.FullSync && chainConfig.Cel2Time != nil && !chainConfig.IsCel2(currentBlock.Number.Uint64()) {
-		log.Error("Migrated data for Cel2 is missing, please ensure the migrated data from Celo1 can be properly loaded before starting the blockchain",
-			"current number", currentBlock.Number.Uint64(), "current hash", currentBlock.Hash())
+		log.Error(fmt.Sprintf(
+			"Chaindata is missing blocks, Cel2 fork is at block %d, but the head block is %d. Pre Cel2 blocks must be migrated from"+
+				" Celo L1 chaindata, Celo L2 cannot generate pre Cel2 blocks. See migration instructions here - https://docs.celo.org/cel2/l2-operator-guide",
+			*chainConfig.Cel2Time, currentBlock.Number.Uint64()))
 		return nil, fmt.Errorf("missing migrated data")
 	}
 	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/871

This PR adds a validation to ensure that Cel2 chain has properly loaded the migrated data from Celo1 during bootstrapping.
If the migrated data is missing, an error log will be displayed and NewBlockChain will return an error.

While Cel2 is expected to always start with the migrated data, a node without the migrated data looks to function correctly for a certail period because `op-geth` initially syncs all headers. However, after a few hours, the node will throw an error in `ValidateBody` as `op-geth` cannot process Celo1 blocks.

This PR introduces an error so that node operators identifies missing migrated data sooner.