### PR TITLE
Apply TxFeeCap conversion

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -390,7 +390,7 @@ func (s *Ethereum) APIs() []rpc.API {
 	if s.config.RollupSequencerTxConditionalEnabled {
 		log.Info("Enabling eth_sendRawTransactionConditional endpoint support")
 		costRateLimit := rate.Limit(s.config.RollupSequencerTxConditionalCostRateLimit)
-		apis = append(apis, sequencerapi.GetSendRawTxConditionalAPI(s.APIBackend, s.seqRPCService, costRateLimit))
+		apis = append(apis, sequencerapi.GetSendRawTxConditionalAPI(celoBackend, s.seqRPCService, costRateLimit))
 	}
 
 	// Append all the local APIs and return

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2646,44 +2646,22 @@ func checkTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
 
 // CheckTxFee exports a helper function used to check whether the fee is reasonable
 func CheckTxFee(ctx context.Context, backend CeloBackend, gasPrice *big.Int, gas uint64, feeCurrency *common.Address) error {
-	feeCap, err := ConvertTxFeeCapToCurrency(ctx, backend, feeCurrency)
-	if err != nil {
-		return err
-	}
-
-	return checkTxFee(gasPrice, gas, feeCap)
-}
-
-// ConvertTxFeeCapToCurrency converts FeeCap in native currency into the specified currency
-// If no fee currency is specified, it returns the native currency FeeCap as is
-func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurrency *common.Address) (float64, error) {
-	txFeeCap := backend.RPCTxFeeCap()
+	// This early return prevents unnecessary API calls and ensures tests that don't involve fee currency conversion pass
 	if feeCurrency == nil {
-		return txFeeCap, nil
+		return checkTxFee(gasPrice, gas, backend.RPCTxFeeCap())
 	}
 
 	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 	if err != nil {
-		log.Warn("Failed to get exchange rates", "err", err)
-		return 0, err
-	}
-	rate, ok := rates[*feeCurrency]
-	if !ok {
-		return 0, fmt.Errorf("could not convert from native to fee currency (fee-currency=%s): %w ", feeCurrency, exchange.ErrUnregisteredFeeCurrency)
+		log.Warn("Failed to get exchange rates for latest block", "err", err)
+		return err
 	}
 
-	// NOTE: Avoiding exchange.ConvertCeloToCurrency to prevent precision loss when converting float64 to big.Int
-	// Using big.Rat instead to maintain fractional precision during conversion
-	txFeeCapInCurrency := new(big.Rat).Mul(
-		new(big.Rat).SetFloat64(txFeeCap),
-		rate,
-	)
-
-	result, exact := txFeeCapInCurrency.Float64()
-	if !exact {
-		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String())
-		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
+	gasPriceInCelo, err := exchange.ConvertCurrencyToCelo(rates, feeCurrency, gasPrice)
+	if err != nil {
+		log.Warn("Failed to convert gas price", "err", err, "currency", feeCurrency)
+		return err
 	}
 
-	return result, nil
+	return checkTxFee(gasPriceInCelo, gas, backend.RPCTxFeeCap())
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2662,28 +2662,28 @@ func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurr
 		return txFeeCap, nil
 	}
 
+	// NOTE:
 	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 	if err != nil {
 		log.Warn("Failed to get exchange rates", "err", err)
 		return 0, err
 	}
-
-	// Convert txFeeCap (float64) to big.Int with proper precision
-	// Since ConvertCeloToCurrency expects big.Int, directly converting to big.Int would lose decimal precision
-	scaledTxFeeCap := big.NewInt(int64(txFeeCap * 1e18))
-	scaledTxFeeCapInCurrency, err := exchange.ConvertCeloToCurrency(rates, feeCurrency, scaledTxFeeCap)
-	if err != nil {
-		log.Warn("Failed to convert RPCTxFeeCap to the specified currency", "currency", feeCurrency, "err", err)
-		return 0, err
+	rate, ok := rates[*feeCurrency]
+	if !ok {
+		return 0, fmt.Errorf("could not convert from native to fee currency (fee-currency=%s): %w ", feeCurrency, exchange.ErrUnregisteredFeeCurrency)
 	}
-	txFeeCapInCurrency := new(big.Float).Quo(
-		new(big.Float).SetInt(scaledTxFeeCapInCurrency),
-		new(big.Float).SetInt64(1e18),
+
+	// NOTE: Avoiding exchange.ConvertCeloToCurrency to prevent precision loss when converting float64 to big.Int
+	// Using big.Rat instead to maintain fractional precision during conversion
+	txFeeCapInCurrencyRat := new(big.Rat).Mul(
+		new(big.Rat).SetFloat64(txFeeCap),
+		rate,
 	)
 
-	result, accuracy := txFeeCapInCurrency.Float64()
-	if accuracy != big.Exact {
-		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String(), "accuracy", accuracy.String())
+	result, exact := txFeeCapInCurrencyRat.Float64()
+	fmt.Printf("result %f\n", result)
+	if !exact {
+		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrencyRat.String())
 		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -528,11 +528,7 @@ func (api *PersonalAccountAPI) SignTransaction(ctx context.Context, args Transac
 	}
 	// Before actually signing the transaction, ensure the transaction fee is reasonable.
 	tx := args.ToTransaction(types.LegacyTxType)
-	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, tx.FeeCurrency())
-	if err != nil {
-		return nil, err
-	}
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
+	if err := CheckTxFee(ctx, api.b, tx.GasPrice(), tx.Gas(), tx.FeeCurrency()); err != nil {
 		return nil, err
 	}
 	signed, err := api.signTransaction(ctx, &args, passwd)
@@ -2226,11 +2222,7 @@ func (api *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*ty
 func SubmitTransaction(ctx context.Context, b CeloBackend, tx *types.Transaction) (common.Hash, error) {
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
-	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, b, tx.FeeCurrency())
-	if err != nil {
-		return common.Hash{}, err
-	}
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
+	if err := CheckTxFee(ctx, b, tx.GasPrice(), tx.Gas(), tx.FeeCurrency()); err != nil {
 		return common.Hash{}, err
 	}
 	if !b.UnprotectedAllowed() && !tx.Protected() {
@@ -2375,11 +2367,7 @@ func (api *TransactionAPI) SignTransaction(ctx context.Context, args Transaction
 	}
 	// Before actually sign the transaction, ensure the transaction fee is reasonable.
 	tx := args.ToTransaction(types.LegacyTxType)
-	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, tx.FeeCurrency())
-	if err != nil {
-		return nil, err
-	}
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
+	if err := CheckTxFee(ctx, api.b, tx.GasPrice(), tx.Gas(), tx.FeeCurrency()); err != nil {
 		return nil, err
 	}
 	signed, err := api.sign(args.from(), tx)
@@ -2447,11 +2435,7 @@ func (api *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs,
 	if gasLimit != nil {
 		gas = uint64(*gasLimit)
 	}
-	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, matchTx.FeeCurrency())
-	if err != nil {
-		return common.Hash{}, err
-	}
-	if err := checkTxFee(price, gas, txFeeCap); err != nil {
+	if err := CheckTxFee(ctx, api.b, price, gas, matchTx.FeeCurrency()); err != nil {
 		return common.Hash{}, err
 	}
 	// Iterate the pending list for replacement
@@ -2481,39 +2465,6 @@ func (api *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs,
 		}
 	}
 	return common.Hash{}, fmt.Errorf("transaction %#x not found", matchTx.Hash())
-}
-
-// ConvertTxFeeCapToCurrency converts FeeCap in native currency into the specified currency
-// If no fee currency is specified, it returns the native currency FeeCap as is
-func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurrency *common.Address) (float64, error) {
-	txFeeCap := backend.RPCTxFeeCap()
-	if feeCurrency == nil {
-		return txFeeCap, nil
-	}
-
-	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
-	if err != nil {
-		log.Warn("Failed to get exchange rates", "current", backend.CurrentBlock().Number, "err", err)
-		return 0, err
-	}
-
-	// Convert txFeeCap (float64) to big.Int with proper precision
-	// Since ConvertCeloToCurrency expects big.Int, directly converting to big.Int would lose decimal precision
-	scaledTxFeeCap := big.NewInt(int64(txFeeCap * 1e18))
-	scaledTxFeeCapInCurrency, err := exchange.ConvertCeloToCurrency(rates, feeCurrency, scaledTxFeeCap)
-	if err != nil {
-		log.Warn("Failed to convert RPCTxFeeCap to the specified currency", "current", backend.CurrentBlock().Number, "currency", feeCurrency, "err", err)
-		return 0, err
-	}
-	txFeeCapInCurrency := scaledTxFeeCapInCurrency.Div(scaledTxFeeCapInCurrency, big.NewInt(1e18))
-
-	result, accuracy := txFeeCapInCurrency.Float64()
-	if accuracy != big.Exact {
-		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String(), "accuracy", accuracy.String())
-		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
-	}
-
-	return result, nil
 }
 
 // DebugAPI is the collection of Ethereum APIs exposed over the debugging
@@ -2694,6 +2645,47 @@ func checkTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
 }
 
 // CheckTxFee exports a helper function used to check whether the fee is reasonable
-func CheckTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
-	return checkTxFee(gasPrice, gas, cap)
+func CheckTxFee(ctx context.Context, backend CeloBackend, gasPrice *big.Int, gas uint64, feeCurrency *common.Address) error {
+	feeCap, err := ConvertTxFeeCapToCurrency(ctx, backend, feeCurrency)
+	if err != nil {
+		return err
+	}
+
+	return checkTxFee(gasPrice, gas, feeCap)
+}
+
+// ConvertTxFeeCapToCurrency converts FeeCap in native currency into the specified currency
+// If no fee currency is specified, it returns the native currency FeeCap as is
+func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurrency *common.Address) (float64, error) {
+	txFeeCap := backend.RPCTxFeeCap()
+	if feeCurrency == nil {
+		return txFeeCap, nil
+	}
+
+	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		log.Warn("Failed to get exchange rates", "err", err)
+		return 0, err
+	}
+
+	// Convert txFeeCap (float64) to big.Int with proper precision
+	// Since ConvertCeloToCurrency expects big.Int, directly converting to big.Int would lose decimal precision
+	scaledTxFeeCap := big.NewInt(int64(txFeeCap * 1e18))
+	scaledTxFeeCapInCurrency, err := exchange.ConvertCeloToCurrency(rates, feeCurrency, scaledTxFeeCap)
+	if err != nil {
+		log.Warn("Failed to convert RPCTxFeeCap to the specified currency", "currency", feeCurrency, "err", err)
+		return 0, err
+	}
+	txFeeCapInCurrency := new(big.Float).Quo(
+		new(big.Float).SetInt(scaledTxFeeCapInCurrency),
+		new(big.Float).SetInt64(1e18),
+	)
+
+	result, accuracy := txFeeCapInCurrency.Float64()
+	if accuracy != big.Exact {
+		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String(), "accuracy", accuracy.String())
+		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
+	}
+
+	return result, nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2674,14 +2674,14 @@ func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurr
 
 	// NOTE: Avoiding exchange.ConvertCeloToCurrency to prevent precision loss when converting float64 to big.Int
 	// Using big.Rat instead to maintain fractional precision during conversion
-	txFeeCapInCurrencyRat := new(big.Rat).Mul(
+	txFeeCapInCurrency := new(big.Rat).Mul(
 		new(big.Rat).SetFloat64(txFeeCap),
 		rate,
 	)
 
-	result, exact := txFeeCapInCurrencyRat.Float64()
+	result, exact := txFeeCapInCurrency.Float64()
 	if !exact {
-		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrencyRat.String())
+		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String())
 		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/exchange"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -527,7 +528,11 @@ func (api *PersonalAccountAPI) SignTransaction(ctx context.Context, args Transac
 	}
 	// Before actually signing the transaction, ensure the transaction fee is reasonable.
 	tx := args.ToTransaction(types.LegacyTxType)
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), api.b.RPCTxFeeCap()); err != nil {
+	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, tx.FeeCurrency())
+	if err != nil {
+		return nil, err
+	}
+	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
 		return nil, err
 	}
 	signed, err := api.signTransaction(ctx, &args, passwd)
@@ -2218,10 +2223,14 @@ func (api *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*ty
 }
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
-func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
+func SubmitTransaction(ctx context.Context, b CeloBackend, tx *types.Transaction) (common.Hash, error) {
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
+	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, b, tx.FeeCurrency())
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
 		return common.Hash{}, err
 	}
 	if !b.UnprotectedAllowed() && !tx.Protected() {
@@ -2366,7 +2375,11 @@ func (api *TransactionAPI) SignTransaction(ctx context.Context, args Transaction
 	}
 	// Before actually sign the transaction, ensure the transaction fee is reasonable.
 	tx := args.ToTransaction(types.LegacyTxType)
-	if err := checkTxFee(tx.GasPrice(), tx.Gas(), api.b.RPCTxFeeCap()); err != nil {
+	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, tx.FeeCurrency())
+	if err != nil {
+		return nil, err
+	}
+	if err := checkTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
 		return nil, err
 	}
 	signed, err := api.sign(args.from(), tx)
@@ -2434,7 +2447,11 @@ func (api *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs,
 	if gasLimit != nil {
 		gas = uint64(*gasLimit)
 	}
-	if err := checkTxFee(price, gas, api.b.RPCTxFeeCap()); err != nil {
+	txFeeCap, err := ConvertTxFeeCapToCurrency(ctx, api.b, matchTx.FeeCurrency())
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if err := checkTxFee(price, gas, txFeeCap); err != nil {
 		return common.Hash{}, err
 	}
 	// Iterate the pending list for replacement
@@ -2464,6 +2481,39 @@ func (api *TransactionAPI) Resend(ctx context.Context, sendArgs TransactionArgs,
 		}
 	}
 	return common.Hash{}, fmt.Errorf("transaction %#x not found", matchTx.Hash())
+}
+
+// ConvertTxFeeCapToCurrency converts FeeCap in native currency into the specified currency
+// If no fee currency is specified, it returns the native currency FeeCap as is
+func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurrency *common.Address) (float64, error) {
+	txFeeCap := backend.RPCTxFeeCap()
+	if feeCurrency == nil {
+		return txFeeCap, nil
+	}
+
+	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		log.Warn("Failed to get exchange rates", "current", backend.CurrentBlock().Number, "err", err)
+		return 0, err
+	}
+
+	// Convert txFeeCap (float64) to big.Int with proper precision
+	// Since ConvertCeloToCurrency expects big.Int, directly converting to big.Int would lose decimal precision
+	scaledTxFeeCap := big.NewInt(int64(txFeeCap * 1e18))
+	scaledTxFeeCapInCurrency, err := exchange.ConvertCeloToCurrency(rates, feeCurrency, scaledTxFeeCap)
+	if err != nil {
+		log.Warn("Failed to convert RPCTxFeeCap to the specified currency", "current", backend.CurrentBlock().Number, "currency", feeCurrency, "err", err)
+		return 0, err
+	}
+	txFeeCapInCurrency := scaledTxFeeCapInCurrency.Div(scaledTxFeeCapInCurrency, big.NewInt(1e18))
+
+	result, accuracy := txFeeCapInCurrency.Float64()
+	if accuracy != big.Exact {
+		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrency.String(), "accuracy", accuracy.String())
+		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")
+	}
+
+	return result, nil
 }
 
 // DebugAPI is the collection of Ethereum APIs exposed over the debugging

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2662,7 +2662,6 @@ func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurr
 		return txFeeCap, nil
 	}
 
-	// NOTE:
 	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 	if err != nil {
 		log.Warn("Failed to get exchange rates", "err", err)
@@ -2681,7 +2680,6 @@ func ConvertTxFeeCapToCurrency(ctx context.Context, backend CeloBackend, feeCurr
 	)
 
 	result, exact := txFeeCapInCurrencyRat.Float64()
-	fmt.Printf("result %f\n", result)
 	if !exact {
 		log.Warn("Failed to accurately convert fee currency to float64", "fee cap", txFeeCapInCurrencyRat.String())
 		return 0, fmt.Errorf("failed to accurately convert fee currency to float64")

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2653,13 +2653,11 @@ func CheckTxFee(ctx context.Context, backend CeloBackend, gasPrice *big.Int, gas
 
 	rates, err := backend.GetExchangeRates(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 	if err != nil {
-		log.Warn("Failed to get exchange rates for latest block", "err", err)
 		return err
 	}
 
 	gasPriceInCelo, err := exchange.ConvertCurrencyToCelo(rates, feeCurrency, gasPrice)
 	if err != nil {
-		log.Warn("Failed to convert gas price", "err", err, "currency", feeCurrency)
 		return err
 	}
 

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -2,6 +2,7 @@ package ethapi
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -616,15 +617,17 @@ func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
 	})
 }
 
-// TestConvertTxFeeCapToCurrency verifies the output is accurate for each currency
-func TestConvertTxFeeCapToCurrency(t *testing.T) {
+// TestCheckTxFee ensures CheckTxFee validates whether the product of GasPrice and Gas
+// does not exceed a predefined cap. Additionally, if FeeCurrency
+// is provided, it ensures that GasPrice is correctly converted to
+// the native currency before validation
+func TestCheckTxFee(t *testing.T) {
 	t.Parallel()
 
 	var (
 		txFeeCap = float64(1.5)
 		rates    = common.ExchangeRates{
-			core.DevFeeCurrencyAddr:  big.NewRat(2, 1),
-			core.DevFeeCurrencyAddr2: big.NewRat(1, 2),
+			core.DevFeeCurrencyAddr: big.NewRat(2, 1),
 		}
 		config = allEnabledChainConfig()
 	)
@@ -633,27 +636,30 @@ func TestConvertTxFeeCapToCurrency(t *testing.T) {
 	backend.SetExchangeRates(rates)
 	backend.SetRPCTxFeeCap(txFeeCap)
 
-	t.Run("should return given fee cap when fee currency is not specified", func(t *testing.T) {
-		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, nil)
-		require.NoError(t, err)
-		assert.Equal(t, txFeeCap, res)
+	t.Run("should allow transaction if fee does not exceed 1.5 Ether", func(t *testing.T) {
+		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 1, nil) // 1 Ether
+		assert.NoError(t, err)
 	})
 
-	t.Run("should return the twice of given fee cap when a fee currency is specified", func(t *testing.T) {
-		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevFeeCurrencyAddr)
-		require.NoError(t, err)
-		assert.Equal(t, 2*txFeeCap, res)
+	t.Run("should reject transaction if fee exceeds 1.5 Ether", func(t *testing.T) {
+		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 2, nil) // 2 Ether
+		expected := fmt.Sprintf("tx fee (%.2f ether) exceeds the configured cap (%.2f ether)", 2.0, 1.5)
+		assert.ErrorContains(t, err, expected)
 	})
 
-	t.Run("should return the half of given fee cap when a fee currency is specified", func(t *testing.T) {
-		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevFeeCurrencyAddr2)
-		require.NoError(t, err)
-		assert.Equal(t, txFeeCap/2, res)
+	t.Run("should allow transaction if fee currency is given and converted fee does not exceed 1.5 Ether", func(t *testing.T) {
+		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 2, &core.DevFeeCurrencyAddr) // 1 Ether
+		assert.NoError(t, err)
 	})
 
-	t.Run("should return error when fee currency is not found in exchange rates", func(t *testing.T) {
-		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevAddr)
-		require.Zero(t, res)
+	t.Run("should reject transaction if fee currency is given and converted fee exceeds 1.5 Ether", func(t *testing.T) {
+		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 4, &core.DevFeeCurrencyAddr) // 2 Ether
+		expected := fmt.Sprintf("tx fee (%.2f ether) exceeds the configured cap (%.2f ether)", 2.0, 1.5)
+		assert.ErrorContains(t, err, expected)
+	})
+
+	t.Run("should reject transaction if fee currency is not registered", func(t *testing.T) {
+		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 4, &core.DevFeeCurrencyAddr2)
 		assert.ErrorIs(t, err, exchange.ErrUnregisteredFeeCurrency)
 	})
 }

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/exchange"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/blocktest"
@@ -611,5 +613,47 @@ func TestRPCMarshalBlock_Celo1TotalDifficulty(t *testing.T) {
 		res := marshalBlock(t, &config)
 
 		assert.Equal(t, nil, res["totalDifficulty"])
+	})
+}
+
+// TestConvertTxFeeCapToCurrency verifies the output is accurate for each currency
+func TestConvertTxFeeCapToCurrency(t *testing.T) {
+	t.Parallel()
+
+	var (
+		txFeeCap = float64(1.5)
+		rates    = common.ExchangeRates{
+			core.DevFeeCurrencyAddr:  big.NewRat(2, 1),
+			core.DevFeeCurrencyAddr2: big.NewRat(1, 2),
+		}
+		config = allEnabledChainConfig()
+	)
+
+	backend := newCeloBackendMock(config)
+	backend.SetExchangeRates(rates)
+	backend.SetRPCTxFeeCap(txFeeCap)
+
+	t.Run("should return given fee cap when fee currency is not specified", func(t *testing.T) {
+		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, nil)
+		require.NoError(t, err)
+		assert.Equal(t, txFeeCap, res)
+	})
+
+	t.Run("should return the twice of given fee cap when a fee currency is specified", func(t *testing.T) {
+		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevFeeCurrencyAddr)
+		require.NoError(t, err)
+		assert.Equal(t, 2*txFeeCap, res)
+	})
+
+	t.Run("should return the half of given fee cap when a fee currency is specified", func(t *testing.T) {
+		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevFeeCurrencyAddr2)
+		require.NoError(t, err)
+		assert.Equal(t, txFeeCap/2, res)
+	})
+
+	t.Run("should return error when fee currency is not found in exchange rates", func(t *testing.T) {
+		res, err := ConvertTxFeeCapToCurrency(context.Background(), backend, &core.DevAddr)
+		require.Zero(t, res)
+		assert.ErrorIs(t, err, exchange.ErrUnregisteredFeeCurrency)
 	})
 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -318,6 +318,8 @@ type celoBackendMock struct {
 	chainDb        ethdb.Database
 	blockByNumber  map[int64]*types.Block
 	receiptsByHash map[common.Hash]types.Receipts
+	rates          common.ExchangeRates
+	rpcTxFeeCap    float64
 }
 
 func newCeloBackendMock(config *params.ChainConfig) *celoBackendMock {
@@ -329,15 +331,21 @@ func newCeloBackendMock(config *params.ChainConfig) *celoBackendMock {
 	}
 }
 
+func (c *celoBackendMock) SetExchangeRates(rates common.ExchangeRates) {
+	c.rates = rates
+}
+
+func (c *celoBackendMock) SetRPCTxFeeCap(txFeeCap float64) {
+	c.rpcTxFeeCap = txFeeCap
+}
+
 func (c *celoBackendMock) GetFeeBalance(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, account common.Address, feeCurrency *common.Address) (*big.Int, error) {
 	// Celo specific backend features are currently not tested
 	return nil, errCeloNotImplemented
 }
 
 func (c *celoBackendMock) GetExchangeRates(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash) (common.ExchangeRates, error) {
-	var er common.ExchangeRates
-	// This Celo specific backend features are currently not tested
-	return er, errCeloNotImplemented
+	return c.rates, nil
 }
 
 func (c *celoBackendMock) ConvertToCurrency(ctx context.Context, blockNumOrHash rpc.BlockNumberOrHash, value *big.Int, fromFeeCurrency *common.Address) (*big.Int, error) {
@@ -373,6 +381,8 @@ func (c *celoBackendMock) setBlock(number int64, block *types.Block) {
 func (c *celoBackendMock) setReceipts(hash common.Hash, receipts types.Receipts) {
 	c.receiptsByHash[hash] = receipts
 }
+
+func (c *celoBackendMock) RPCTxFeeCap() float64 { return c.rpcTxFeeCap }
 
 type backendMock struct {
 	current *types.Header

--- a/internal/sequencerapi/api.go
+++ b/internal/sequencerapi/api.go
@@ -104,11 +104,7 @@ func (s *sendRawTxCond) SendRawTransactionConditional(ctx context.Context, txByt
 	// forward if seqRPC is set, otherwise submit the tx
 	if s.seqRPC != nil {
 		// Some precondition checks done by `ethapi.SubmitTransaction` that are good to also check here
-		txFeeCap, err := ethapi.ConvertTxFeeCapToCurrency(ctx, s.b, tx.FeeCurrency())
-		if err != nil {
-			return common.Hash{}, err
-		}
-		if err := ethapi.CheckTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
+		if err := ethapi.CheckTxFee(ctx, s.b, tx.GasPrice(), tx.Gas(), tx.FeeCurrency()); err != nil {
 			return common.Hash{}, err
 		}
 		if !s.b.UnprotectedAllowed() && !tx.Protected() {

--- a/internal/sequencerapi/api.go
+++ b/internal/sequencerapi/api.go
@@ -23,12 +23,12 @@ var (
 )
 
 type sendRawTxCond struct {
-	b           ethapi.Backend
+	b           ethapi.CeloBackend
 	seqRPC      *rpc.Client
 	costLimiter *rate.Limiter
 }
 
-func GetSendRawTxConditionalAPI(b ethapi.Backend, seqRPC *rpc.Client, costRateLimit rate.Limit) rpc.API {
+func GetSendRawTxConditionalAPI(b ethapi.CeloBackend, seqRPC *rpc.Client, costRateLimit rate.Limit) rpc.API {
 	// Applying a manual bump to the burst to allow conditional txs to queue. Metrics will
 	// will inform of adjustments that may need to be made here.
 	costLimiter := rate.NewLimiter(costRateLimit, 3*params.TransactionConditionalMaxCost)
@@ -104,7 +104,11 @@ func (s *sendRawTxCond) SendRawTransactionConditional(ctx context.Context, txByt
 	// forward if seqRPC is set, otherwise submit the tx
 	if s.seqRPC != nil {
 		// Some precondition checks done by `ethapi.SubmitTransaction` that are good to also check here
-		if err := ethapi.CheckTxFee(tx.GasPrice(), tx.Gas(), s.b.RPCTxFeeCap()); err != nil {
+		txFeeCap, err := ethapi.ConvertTxFeeCapToCurrency(ctx, s.b, tx.FeeCurrency())
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if err := ethapi.CheckTxFee(tx.GasPrice(), tx.Gas(), txFeeCap); err != nil {
 			return common.Hash{}, err
 		}
 		if !s.b.UnprotectedAllowed() && !tx.Protected() {
@@ -113,7 +117,7 @@ func (s *sendRawTxCond) SendRawTransactionConditional(ctx context.Context, txByt
 		}
 
 		var hash common.Hash
-		err := s.seqRPC.CallContext(ctx, &hash, "eth_sendRawTransactionConditional", txBytes, cond)
+		err = s.seqRPC.CallContext(ctx, &hash, "eth_sendRawTransactionConditional", txBytes, cond)
 		return hash, err
 	} else {
 		// Set out-of-consensus internal tx fields


### PR DESCRIPTION
Closes https://github.com/celo-org/op-geth/issues/313

This PR adds fee cap conversion in `CheckTxFee`.  `ConvertTxFeeCapToCurrency` fetches TxFeeCap from backend and convert it to a tx fee currency.