### PR TITLE
Fix wrong comparison for sanity check of migrated block in bootstrap

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -257,11 +257,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	// Make sure Cel2 full sync node has migrated data from Celo1
 	currentBlock := eth.blockchain.CurrentBlock()
-	if config.SyncMode == downloader.FullSync && chainConfig.Cel2Time != nil && !chainConfig.IsCel2(currentBlock.Number.Uint64()) {
+	if config.SyncMode == downloader.FullSync && chainConfig.Cel2Time != nil && !chainConfig.IsCel2(currentBlock.Time) {
 		log.Error(fmt.Sprintf(
-			"Chaindata is missing blocks, Cel2 fork is at block %d, but the head block is %d. Pre Cel2 blocks must be migrated from"+
+			"Chaindata is missing blocks, Cel2 fork is at %d, but the head block timestamp is %d. Pre Cel2 blocks must be migrated from"+
 				" Celo L1 chaindata, Celo L2 cannot generate pre Cel2 blocks. See migration instructions here - https://docs.celo.org/cel2/l2-operator-guide",
-			*chainConfig.Cel2Time, currentBlock.Number.Uint64()))
+			*chainConfig.Cel2Time, currentBlock.Time))
 		return nil, fmt.Errorf("missing migrated data")
 	}
 	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1


### PR DESCRIPTION
Fix the incorrect comparison for the migrating head block's sanity check for full sync node
Cel2 full sync node must have head block whose timestamp is greater than or equal to Cel2Time. Previously this check uses head block's number but this PR change it to block's timestamp