### PR TITLE
Fix genesis init for migrated chains

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -230,6 +230,9 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
+	// Set ignore defaults here so that our genesis is not inited with default
+	// values for gasLimit, difficulty or uncleHash which celo did not historically set.
+	genesis.SetInitingGenesis()
 	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -230,8 +230,6 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
-	// Set initing genesis here, to signal that we are in an initGenesis flow.
-	genesis.SetInitingGenesis()
 	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -230,6 +230,8 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
+	// Set initing genesis here, to signal that we are in an initGenesis flow.
+	genesis.SetInitingGenesis()
 	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -230,8 +230,7 @@ func initGenesis(ctx *cli.Context) error {
 	triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 	defer triedb.Close()
 
-	// Set ignore defaults here so that our genesis is not inited with default
-	// values for gasLimit, difficulty or uncleHash which celo did not historically set.
+	// Set initing genesis here, to signal that we are in an initGenesis flow.
 	genesis.SetInitingGenesis()
 	_, hash, _, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 	if err != nil {

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -167,3 +167,13 @@ func addFeeCurrencyToStorage(feeCurrencyAddr common.Address, oracleAddr common.A
 	storage[structStart] = common.BytesToHash(oracleAddr.Bytes())                                   // oracle
 	storage[incHash(structStart, 1)] = common.BigToHash(big.NewInt(int64(FeeCurrencyIntrinsicGas))) // intrinsicGas
 }
+
+// SetInitingGenesis sets marks this genesis as one that is being used in the initGenesis operation.
+func (g *Genesis) SetInitingGenesis() {
+	g.initingGenesis = true
+}
+
+// InitingGenesis returns true if this genesis is being used in the initGenesis operation.
+func (g *Genesis) InitingGenesis() bool {
+	return g.initingGenesis
+}

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -168,7 +168,7 @@ func addFeeCurrencyToStorage(feeCurrencyAddr common.Address, oracleAddr common.A
 	storage[incHash(structStart, 1)] = common.BigToHash(big.NewInt(int64(FeeCurrencyIntrinsicGas))) // intrinsicGas
 }
 
-// SetInitingGenesis sets marks this genesis as one that is being used in the initGenesis operation.
+// SetInitingGenesis marks this genesis as one that is being used in the initGenesis operation.
 func (g *Genesis) SetInitingGenesis() {
 	g.initingGenesis = true
 }

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -167,3 +167,13 @@ func addFeeCurrencyToStorage(feeCurrencyAddr common.Address, oracleAddr common.A
 	storage[structStart] = common.BytesToHash(oracleAddr.Bytes())                                   // oracle
 	storage[incHash(structStart, 1)] = common.BigToHash(big.NewInt(int64(FeeCurrencyIntrinsicGas))) // intrinsicGas
 }
+
+// SetInitingGenesis marks this genesis as one that is being used in the initGenesis operation.
+func (g *Genesis) SetInitingGenesis() {
+	g.initingGenesis = true
+}
+
+// InitingGenesis returns true if this genesis is being used in the initGenesis operation.
+func (g *Genesis) InitingGenesis() bool {
+	return g.initingGenesis
+}

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -167,13 +167,3 @@ func addFeeCurrencyToStorage(feeCurrencyAddr common.Address, oracleAddr common.A
 	storage[structStart] = common.BytesToHash(oracleAddr.Bytes())                                   // oracle
 	storage[incHash(structStart, 1)] = common.BigToHash(big.NewInt(int64(FeeCurrencyIntrinsicGas))) // intrinsicGas
 }
-
-// SetInitingGenesis marks this genesis as one that is being used in the initGenesis operation.
-func (g *Genesis) SetInitingGenesis() {
-	g.initingGenesis = true
-}
-
-// InitingGenesis returns true if this genesis is being used in the initGenesis operation.
-func (g *Genesis) InitingGenesis() bool {
-	return g.initingGenesis
-}

--- a/core/celo_genesis_test.go
+++ b/core/celo_genesis_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToBlockWithRoot(t *testing.T) {
+	nonMigrated := &Genesis{Config: &params.ChainConfig{}}
+	var cel2Time uint64 = 1
+	migrated := &Genesis{
+		Config: &params.ChainConfig{
+			Cel2Time: &cel2Time,
+		},
+	}
+
+	t.Run("PreGingerbreadBlocksProducedWhenInitingGenesis", func(t *testing.T) {
+		g := &Genesis{
+			Config: &params.ChainConfig{
+				GingerbreadBlock: big.NewInt(1),
+			},
+			initingGenesis: true,
+		}
+		b := g.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.True(t, b.Header().IsPreGingerbread())
+	})
+	t.Run("PreGingerbreadBlocksNotProducedWhenNotInitingGenesis", func(t *testing.T) {
+		g := &Genesis{
+			Config: &params.ChainConfig{
+				GingerbreadBlock: big.NewInt(1),
+			},
+			initingGenesis: false,
+		}
+		b := g.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.False(t, b.Header().IsPreGingerbread())
+	})
+	t.Run("PreGingerbreadBlocksNotProducedWhenNotPreGingerbread", func(t *testing.T) {
+		g := &Genesis{
+			Config: &params.ChainConfig{
+				GingerbreadBlock: big.NewInt(0),
+			},
+		}
+		g.initingGenesis = false
+		b := g.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.False(t, b.Header().IsPreGingerbread())
+		g.initingGenesis = true
+		b = g.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.False(t, b.Header().IsPreGingerbread())
+	})
+	t.Run("NonMigratedChainHasDefaultGasLimit&DifficultySet", func(t *testing.T) {
+		b := nonMigrated.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.Equal(t, params.GenesisGasLimit, b.Header().GasLimit)
+		assert.Equal(t, params.GenesisDifficulty, b.Header().Difficulty)
+	})
+	t.Run("MigratedChainGasLimitNotSet", func(t *testing.T) {
+		b := migrated.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.Equal(t, uint64(0), b.Header().GasLimit)
+	})
+	t.Run("MigratedChainNilDifficultyInitialisedToZero", func(t *testing.T) {
+		b := migrated.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.Equal(t, big.NewInt(0), b.Header().Difficulty)
+	})
+	t.Run("NonMigratedChainHasEmptyUncleHashSet", func(t *testing.T) {
+		b := nonMigrated.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.Equal(t, types.EmptyUncleHash, b.Header().UncleHash)
+	})
+	t.Run("PreGingerbreadBlocksOnMigratedChainsDoNotHaveEmptyUncleHashSet", func(t *testing.T) {
+		g := &Genesis{
+			Config: &params.ChainConfig{
+				Cel2Time:         &cel2Time,
+				GingerbreadBlock: big.NewInt(1),
+			},
+		}
+		b := g.toBlockWithRoot(common.Hash{}, common.Hash{})
+		assert.Equal(t, common.Hash{}, b.Header().UncleHash)
+	})
+}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -589,33 +589,47 @@ func (g *Genesis) ToBlock() *types.Block {
 
 // toBlockWithRoot constructs the genesis block with the given genesis state root.
 func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Hash) *types.Block {
-	head := &types.Header{
-		Number:     new(big.Int).SetUint64(g.Number),
-		Nonce:      types.EncodeNonce(g.Nonce),
-		Time:       g.Timestamp,
-		ParentHash: g.ParentHash,
-		Extra:      g.ExtraData,
-		GasLimit:   g.GasLimit,
-		GasUsed:    g.GasUsed,
-		BaseFee:    g.BaseFee,
-		Difficulty: g.Difficulty,
-		MixDigest:  g.Mixhash,
-		Coinbase:   g.Coinbase,
-		Root:       stateRoot,
+	number := new(big.Int).SetUint64(g.Number)
+	head := &types.Header{}
+	// If this is a pre gingerbread block,then set the block to be
+	// pre-gingerbread. This affects the way it is encoded, which affects it's
+	// hash.
+	if g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
+		head = types.NewPreGingerbreadHeader()
 	}
-	if g.GasLimit == 0 {
-		head.GasLimit = params.GenesisGasLimit
-	}
-	if g.Difficulty == nil && g.Mixhash == (common.Hash{}) {
-		head.Difficulty = params.GenesisDifficulty
+
+	head.Number = number
+	head.Nonce = types.EncodeNonce(g.Nonce)
+	head.Time = g.Timestamp
+	head.ParentHash = g.ParentHash
+	head.Extra = g.ExtraData
+	head.GasLimit = g.GasLimit
+	head.GasUsed = g.GasUsed
+	head.BaseFee = g.BaseFee
+	head.Difficulty = g.Difficulty
+	head.MixDigest = g.Mixhash
+	head.Coinbase = g.Coinbase
+	head.Root = stateRoot
+
+	// When initialising the genesis we don't want to override unset gasLimit or
+	// difficulty fields since these fields were not present at the celo chain genesis.
+	if !g.Config.IsMigratedChain() {
+		if g.GasLimit == 0 {
+			head.GasLimit = params.GenesisGasLimit
+		}
+		if g.Difficulty == nil && g.Mixhash == (common.Hash{}) {
+			head.Difficulty = params.GenesisDifficulty
+		}
 	} else if g.Difficulty == nil {
 		// In the case of migrated chains we ensure a zero rather than nil difficulty.
 		head.Difficulty = new(big.Int)
 	}
+
 	if g.Config != nil && g.Config.IsLondon(common.Big0) {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
 		} else {
+			// If defaults are not ignored, set default values for base fee.
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		}
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -597,7 +597,7 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 	head := &types.Header{}
 	// If we are in an initGenesis flow and this is a pre-gingerbread block, then
 	// set the block to be pre-gingerbread. This affects the way it is encoded,
-	// which affects it's hash. Ideally we could do without the InitingGenesis
+	// which affects its hash. Ideally we could do without the InitingGenesis
 	// condition, but TestFeeHistory, makes use of chains with pre-gingerbread
 	// genesis blocks without actually accounting for the different structure of
 	// the pre-gingerbread block.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -80,6 +79,10 @@ type Genesis struct {
 	// Chains with history pruning, or extraordinarily large genesis allocation (e.g. after a regenesis event)
 	// may utilize this to get started, and then state-sync the latest state, while still verifying the header chain.
 	StateHash *common.Hash `json:"stateHash,omitempty"`
+
+	// initingGenesis is used to indicate whether this genesis config is being
+	// used in the initGenesis operation.
+	initingGenesis bool
 }
 
 func ReadGenesis(db ethdb.Database) (*Genesis, error) {
@@ -595,10 +598,10 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 	// If we are in a context where ginerbread is configured but not active for
 	// the genesis block we set the block to be pre-gingerbread. This affects
 	// the way it is encoded, which affects its hash. Ideally we could do
-	// without the testing.Testing condition, but TestFeeHistory, makes use of
+	// without the InitGenesis condition, but TestFeeHistory, makes use of
 	// chains with pre-gingerbread genesis blocks without actually accounting
 	// for the different structure of the pre-gingerbread block.
-	if !testing.Testing() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
+	if g.InitingGenesis() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
 		head = types.NewPreGingerbreadHeader()
 	}
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -79,10 +80,6 @@ type Genesis struct {
 	// Chains with history pruning, or extraordinarily large genesis allocation (e.g. after a regenesis event)
 	// may utilize this to get started, and then state-sync the latest state, while still verifying the header chain.
 	StateHash *common.Hash `json:"stateHash,omitempty"`
-
-	// initingGenesis is used to indicate whether this genesis config is being
-	// used in the initGenesis operation.
-	initingGenesis bool
 }
 
 func ReadGenesis(db ethdb.Database) (*Genesis, error) {
@@ -601,7 +598,7 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 	// condition, but TestFeeHistory, makes use of chains with pre-gingerbread
 	// genesis blocks without actually accounting for the different structure of
 	// the pre-gingerbread block.
-	if g.InitingGenesis() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
+	if !testing.Testing() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
 		head = types.NewPreGingerbreadHeader()
 	}
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -592,12 +592,12 @@ func (g *Genesis) ToBlock() *types.Block {
 func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Hash) *types.Block {
 	number := new(big.Int).SetUint64(g.Number)
 	head := &types.Header{}
-	// If we are in an initGenesis flow and this is a pre-gingerbread block, then
-	// set the block to be pre-gingerbread. This affects the way it is encoded,
-	// which affects its hash. Ideally we could do without the InitingGenesis
-	// condition, but TestFeeHistory, makes use of chains with pre-gingerbread
-	// genesis blocks without actually accounting for the different structure of
-	// the pre-gingerbread block.
+	// If we are in a context where ginerbread is configured but not active for
+	// the genesis block we set the block to be pre-gingerbread. This affects
+	// the way it is encoded, which affects its hash. Ideally we could do
+	// without the testing.Testing condition, but TestFeeHistory, makes use of
+	// chains with pre-gingerbread genesis blocks without actually accounting
+	// for the different structure of the pre-gingerbread block.
 	if !testing.Testing() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
 		head = types.NewPreGingerbreadHeader()
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -595,7 +595,7 @@ func (g *Genesis) ToBlock() *types.Block {
 func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Hash) *types.Block {
 	number := new(big.Int).SetUint64(g.Number)
 	head := &types.Header{}
-	// If we are in an initGenesis flow and this is a pre gingerbread block,then
+	// If we are in an initGenesis flow and this is a pre-gingerbread block, then
 	// set the block to be pre-gingerbread. This affects the way it is encoded,
 	// which affects it's hash. Ideally we could do without the InitingGenesis
 	// condition, but TestFeeHistory, makes use of chains with pre-gingerbread

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -79,6 +79,10 @@ type Genesis struct {
 	// Chains with history pruning, or extraordinarily large genesis allocation (e.g. after a regenesis event)
 	// may utilize this to get started, and then state-sync the latest state, while still verifying the header chain.
 	StateHash *common.Hash `json:"stateHash,omitempty"`
+
+	// initingGenesis is used to indicate whether this genesis config is being
+	// used in the initGenesis operation.
+	initingGenesis bool
 }
 
 func ReadGenesis(db ethdb.Database) (*Genesis, error) {
@@ -591,10 +595,13 @@ func (g *Genesis) ToBlock() *types.Block {
 func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Hash) *types.Block {
 	number := new(big.Int).SetUint64(g.Number)
 	head := &types.Header{}
-	// If this is a pre gingerbread block,then set the block to be
-	// pre-gingerbread. This affects the way it is encoded, which affects it's
-	// hash.
-	if g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
+	// If we are in an initGenesis flow and this is a pre gingerbread block,then
+	// set the block to be pre-gingerbread. This affects the way it is encoded,
+	// which affects it's hash. Ideally we could do without the InitingGenesis
+	// condition, but TestFeeHistory, makes use of chains with pre-gingerbread
+	// genesis blocks without actually accounting for the different structure of
+	// the pre-gingerbread block.
+	if g.InitingGenesis() && g.Config.GingerbreadBlock != nil && !g.Config.IsGingerbread(number) {
 		head = types.NewPreGingerbreadHeader()
 	}
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -618,8 +618,8 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 	head.Coinbase = g.Coinbase
 	head.Root = stateRoot
 
-	// When initialising the genesis we don't want to override unset gasLimit or
-	// difficulty fields since these fields were not present at the celo chain genesis.
+	// Avoid setting default values for gasLimit and difficulty on migrated
+	// chains.
 	if !g.Config.IsMigratedChain() {
 		if g.GasLimit == 0 {
 			head.GasLimit = params.GenesisGasLimit
@@ -636,7 +636,6 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
 		} else {
-			// If defaults are not ignored, set default values for base fee.
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		}
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -254,6 +254,7 @@ type extblock struct {
 type BlockType interface {
 	HasOptimismWithdrawalsRoot(blkTime uint64) bool
 	IsIsthmus(blkTime uint64) bool
+	IsMigratedChain() bool
 }
 
 // NewBlock creates a new block. The input data is copied, changes to header and to the
@@ -287,7 +288,7 @@ func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher
 		b.header.Bloom = CreateBloom(receipts)
 	}
 
-	if len(uncles) == 0 {
+	if len(uncles) == 0 && !bType.IsMigratedChain() {
 		b.header.UncleHash = EmptyUncleHash
 	} else {
 		b.header.UncleHash = CalcUncleHash(uncles)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -254,6 +254,7 @@ type extblock struct {
 type BlockType interface {
 	HasOptimismWithdrawalsRoot(blkTime uint64) bool
 	IsIsthmus(blkTime uint64) bool
+	IsGingerbread(blockNumber *big.Int) bool
 	IsMigratedChain() bool
 }
 
@@ -288,7 +289,9 @@ func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher
 		b.header.Bloom = CreateBloom(receipts)
 	}
 
-	if len(uncles) == 0 && !bType.IsMigratedChain() {
+	// We prevent setting the EmptyUncleHash only when we are on a migrated
+	// chain and the block is pre-gingerbread.
+	if len(uncles) == 0 && !(bType.IsMigratedChain() && !bType.IsGingerbread(header.Number)) {
 		b.header.UncleHash = EmptyUncleHash
 	} else {
 		b.header.UncleHash = CalcUncleHash(uncles)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -289,15 +289,17 @@ func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher
 		b.header.Bloom = CreateBloom(receipts)
 	}
 
-	// We prevent setting the EmptyUncleHash only when we are on a migrated
-	// chain and the block is pre-gingerbread.
-	if len(uncles) == 0 && !(bType.IsMigratedChain() && !bType.IsGingerbread(header.Number)) {
-		b.header.UncleHash = EmptyUncleHash
-	} else {
-		b.header.UncleHash = CalcUncleHash(uncles)
-		b.uncles = make([]*Header, len(uncles))
-		for i := range uncles {
-			b.uncles[i] = CopyHeader(uncles[i])
+	// We prevent setting the unclehash when we are on a migrated chain and the
+	// block is pre-gingerbread.
+	if !(bType.IsMigratedChain() && !bType.IsGingerbread(header.Number)) {
+		if len(uncles) == 0 {
+			b.header.UncleHash = EmptyUncleHash
+		} else {
+			b.header.UncleHash = CalcUncleHash(uncles)
+			b.uncles = make([]*Header, len(uncles))
+			for i := range uncles {
+				b.uncles[i] = CopyHeader(uncles[i])
+			}
 		}
 	}
 

--- a/core/types/block_config.go
+++ b/core/types/block_config.go
@@ -1,5 +1,7 @@
 package types
 
+import "math/big"
+
 type BlockConfig struct {
 	IsIsthmusEnabled bool
 }
@@ -14,6 +16,10 @@ func (bc *BlockConfig) IsIsthmus(blockTime uint64) bool {
 
 func (bc *BlockConfig) IsMigratedChain() bool {
 	return false
+}
+
+func (bc *BlockConfig) IsGingerbread(blockNumber *big.Int) bool {
+	return true
 }
 
 var (

--- a/core/types/block_config.go
+++ b/core/types/block_config.go
@@ -12,6 +12,10 @@ func (bc *BlockConfig) IsIsthmus(blockTime uint64) bool {
 	return bc.IsIsthmusEnabled
 }
 
+func (bc *BlockConfig) IsMigratedChain() bool {
+	return false
+}
+
 var (
 	DefaultBlockConfig = &BlockConfig{IsIsthmusEnabled: false}
 	IsthmusBlockConfig = &BlockConfig{IsIsthmusEnabled: true}

--- a/core/types/celo_block.go
+++ b/core/types/celo_block.go
@@ -109,6 +109,10 @@ func isPreGingerbreadHeader(buf []byte) (bool, error) {
 	return contentSize == common.AddressLength, nil
 }
 
+func NewPreGingerbreadHeader() *Header {
+	return &Header{preGingerbread: true}
+}
+
 func (h *Header) IsPreGingerbread() bool {
 	return h.preGingerbread
 }

--- a/params/config.go
+++ b/params/config.go
@@ -730,6 +730,11 @@ func (c *ChainConfig) IsGingerbread(num *big.Int) bool {
 	return isBlockForked(c.GingerbreadBlock, num)
 }
 
+// Returns whether this is config for a chain that has been migrated to cel2.
+func (c *ChainConfig) IsMigratedChain() bool {
+	return c.Cel2Time != nil && *c.Cel2Time > 0
+}
+
 // IsOptimism returns whether the node is an optimism node or not.
 func (c *ChainConfig) IsOptimism() bool {
 	return c.Optimism != nil

--- a/params/config.go
+++ b/params/config.go
@@ -731,6 +731,7 @@ func (c *ChainConfig) IsGingerbread(num *big.Int) bool {
 }
 
 // Returns whether this is config for a chain that has been migrated to cel2.
+// (I.E. cel2 is configured but non zero)
 func (c *ChainConfig) IsMigratedChain() bool {
 	return c.Cel2Time != nil && *c.Cel2Time > 0
 }


### PR DESCRIPTION
When the celo blockchain launched it did so without `gasLimit`, `difficulty`
and `uncleHash` fields on the celo block.

In the gingerbread hardfork these fields were added to the block, to improve
celo's compatibility with ethereum, and a zero (or not) `uncleHash` was used to
distinguish the old and new block formats.

When transitioning to the op-stack we discovered that these fields are set to
default values during genesis init if they are unset. This broke our approach
to encoding, so to prevent this happening we would only set defaults in a
migrated chain context (where cel2 time is set an non zero), this allowed us to
skip setting defaults for migrated chains but retain the defaults for tests
which rely heavily on them.

In the op-stack we were using a zero gas limit as an indication of what type of
block encoding to use, but this presented it's own problems for some tests that
used blocks without a gas limit set, so we subsequently switched (#300) to
having an explicit flag set inside headers to specify which encoding to use.
When loading blocks from leveldb the RLP structure could be introspected to
determine the type of block that was being loaded, our thinking was that for
all migrated blocks we could rely on this approach to setting the encoding, and
for any new blocks they would all be being created after the cel2 fork and so
would use the most recent encoding. We removed the special casing of default
setting in `toBlockWithRoot` and relied on the explicit flag.

Unfortunately we forgot about what happens at genesis init, where `NewBlock` is
called to create the genesis block. With the special casing removed, the
defaults being set and `NewBlock` always producing blocks that use the new
encoding we discovered that initing the genesis on a migrated chain resulted in
a different genesis block.

To fix this the special casing has been re-introduced in `toBlockWithRoot` and
extended to prevent default setting of `uncleHash` inside `NewBlock` when
operating in the context of a migrated chain. Also if the genesis block is a
pre-gingerbread block it is marked as such so that it is encoded correctly.

There's was one remaining issue which is that `TestFeeHistory`, initialises a
pre-gingerbread genesis but expects it to have the new block format, so to
account for that an extra condition was added to only use the old format for
pre-gingerbread blocks that are being initialised as a result of executing the
initGenesis command.

# Tested
Locally and got the same 0 block as returned by https://baklava-forno.baklava.celo-testnet.org/ also saw a snap sync node get past syncing beacon headers stage.

Also added unit tests to verify the genesis block created under different conditions.

Resolves https://github.com/celo-org/celo-blockchain-planning/issues/900
