### PR TITLE
Increase txpool inclusion

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -166,7 +166,7 @@ var DefaultConfig = Config{
 	PriceLimit: 1,
 	PriceBump:  10,
 
-	AccountSlots: 16,
+	AccountSlots: 4,
 	GlobalSlots:  4096 + 1024, // urgent + floating queue capacity with 4:1 ratio
 	AccountQueue: 64,
 	GlobalQueue:  1024,


### PR DESCRIPTION
Given the one second block time of the celo chain, there is
significantly reduced need, compared to ethereum's twelve seconds, for
individual accounts to be able to include multiple transactions a single
block.

To account for this we can reduce the AccontSlots default. This makes
for a more inclusive txpool, capable of accepting transactions from a
more diverse range of accounts.

Even though it might make sense to divide the AccountSlots default by a
factor of 12, to match the account slots per second offered by ethereum,
doing so would reduce the Account slots below the max tx size of 4
slots. So we set the AccontSlots default at 4, to inrease inclusion
whilst still supporting large transactions.
