### PR TITLE
Simplify precompile address

### DIFF
--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -11,6 +11,10 @@ import (
 	"github.com/holiman/uint256"
 )
 
+var (
+	TransferPrecompileAddress = common.HexToAddress("0x00000000000000000000000000000000000000fd")
+)
+
 type CeloPrecompiledContract interface {
 	RequiredGas(input []byte) uint64                              // RequiredGas calculates the contract gas use
 	Run(input []byte, ctx *celoPrecompileContext) ([]byte, error) // Run runs the precompiled contract
@@ -39,11 +43,6 @@ func NewContext(caller common.Address, evm *EVM) *celoPrecompileContext {
 		caller:       caller,
 		evm:          evm,
 	}
-}
-
-func celoPrecompileAddress(index byte) common.Address {
-	celoPrecompiledContractsAddressOffset := byte(0xff)
-	return common.BytesToAddress(append([]byte{0}, (celoPrecompiledContractsAddressOffset - index)))
 }
 
 func (ctx *celoPrecompileContext) IsCallerCeloToken() (bool, error) {

--- a/core/vm/celo_contracts.go
+++ b/core/vm/celo_contracts.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	TransferPrecompileAddress = common.HexToAddress("0x00000000000000000000000000000000000000fd")
+	transferPrecompileAddress = common.HexToAddress("0x00000000000000000000000000000000000000fd")
 )
 
 type CeloPrecompiledContract interface {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -201,7 +201,7 @@ var PrecompiledContractsIsthmus = map[common.Address]PrecompiledContract{
 // multiple Ethereum/Optimism hardforks and therefore does not fit into the
 // linear history of normal hardforks.
 var PrecompiledCeloContractsCel2 = map[common.Address]CeloPrecompiledContract{
-	celoPrecompileAddress(2): &transfer{},
+	TransferPrecompileAddress: &transfer{},
 }
 
 var (

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -201,7 +201,7 @@ var PrecompiledContractsIsthmus = map[common.Address]PrecompiledContract{
 // multiple Ethereum/Optimism hardforks and therefore does not fit into the
 // linear history of normal hardforks.
 var PrecompiledCeloContractsCel2 = map[common.Address]CeloPrecompiledContract{
-	TransferPrecompileAddress: &transfer{},
+	transferPrecompileAddress: &transfer{},
 }
 
 var (


### PR DESCRIPTION
Hardcode the remaining single precompile address and remove `celoPrecompileAddress`