### PR TITLE
Includes baseFee in receipt of RPC response

### DIFF
--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -180,7 +180,6 @@ func TestHashConsistency(t *testing.T) {
 	// Wait for all fetching jobs to complete and then close the result channel
 	if err := fetchingEg.Wait(); err != nil {
 		t.Logf("failed to complete fetching block elements job: %v", err)
-		outerCancel()
 		t.Fail()
 	}
 	close(resultCh)
@@ -188,7 +187,6 @@ func TestHashConsistency(t *testing.T) {
 	// Wait for all testing jobs to complete
 	if err := testingEg.Wait(); err != nil {
 		t.Logf("failed to complete testing block elements job: %v", err)
-		outerCancel()
 		t.Fail()
 	}
 }

--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -95,7 +95,7 @@ func TestHashConsistency(t *testing.T) {
 
 	endBlock := latestBlock.NumberU64()
 
-	t.Logf("Starting Hash Compatibility Test")
+	t.Logf("Starting RPC Hash Consistency Test")
 	t.Logf("\tChainID: %s", chainId.String())
 	t.Logf("\tStart Block: %d", startBlock)
 	t.Logf("\tEnd Block: %d", endBlock)
@@ -184,8 +184,7 @@ func TestHashConsistency(t *testing.T) {
 		return nil
 	})
 
-	loggingEg, jobCtx := errgroup.WithContext(outerCtx)
-	loggingEg.Go(func() error {
+	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
@@ -196,13 +195,9 @@ func TestHashConsistency(t *testing.T) {
 
 		for {
 			select {
-			case <-jobCtx.Done():
-				return nil
-			case req, ok := <-jobStatusUpdateReqCh:
-				if !ok {
-					return nil
-				}
-
+			case <-outerCtx.Done():
+				return
+			case req := <-jobStatusUpdateReqCh:
 				switch req.jobTypeId {
 				case JobTypeFetchBlock:
 					lastFetchHeight = req.lastHeight
@@ -210,10 +205,10 @@ func TestHashConsistency(t *testing.T) {
 					lastVerifyHeight = req.lastHeight
 				}
 			case <-ticker.C:
-				t.Logf("Progress: Fetching Blocks: %.2f%%, Verifying Blocks: %.2f%%", calcPercentage(startBlock, endBlock, lastFetchHeight), calcPercentage(startBlock, endBlock, lastVerifyHeight))
+				t.Logf("Progress: Fetched Blocks: %.2f%%, Verified Blocks: %.2f%%", calcPercentage(startBlock, endBlock, lastFetchHeight), calcPercentage(startBlock, endBlock, lastVerifyHeight))
 			}
 		}
-	})
+	}()
 
 	// Wait for all fetching jobs to complete and then close the result channel
 	if err := fetchingEg.Wait(); err != nil {
@@ -228,6 +223,7 @@ func TestHashConsistency(t *testing.T) {
 		t.Fail()
 	}
 
+	outerCancel()
 	close(jobStatusUpdateReqCh)
 }
 

--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -7,17 +7,18 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math/big"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/sync/errgroup"
-	"math/big"
-	"math/rand"
-	"net/http"
-	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -29,7 +30,7 @@ var (
 )
 
 func TestHashConsistency(t *testing.T) {
-	// TestHashCompatTest validates that the hashes obtained from RPC endpoint are consistent with the values calculated locally
+	// TestHashConsistency validates that the hashes obtained from RPC endpoint are consistent with the values calculated locally
 	// It retrieves and compares the following hashes:
 	// 1. TxHash
 	// 2. TxRoot

--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -107,9 +107,10 @@ func TestHashConsistency(t *testing.T) {
 	t.Cleanup(outerCancel)
 
 	resultCh := make(chan *blockAndReceipts, 100)
+	jobStatusUpdateReqCh := make(chan *jobStatusUpdateReq, 10)
 
 	fetchingEg, jobCtx := errgroup.WithContext(outerCtx)
-	fetchingEg.SetLimit(5)
+	fetchingEg.SetLimit(10)
 	fetchingEg.Go(func() error {
 		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
@@ -138,12 +139,15 @@ func TestHashConsistency(t *testing.T) {
 					return err
 				}
 
-				t.Logf("Fetched data at height %d", res.height)
-
 				select {
 				case <-jobCtx.Done():
 					return jobCtx.Err()
 				case resultCh <- res:
+				}
+
+				select {
+				case jobStatusUpdateReqCh <- &jobStatusUpdateReq{jobTypeId: JobTypeFetchBlock, lastHeight: res.height}:
+				default:
 				}
 
 				return nil
@@ -154,7 +158,7 @@ func TestHashConsistency(t *testing.T) {
 	})
 
 	testingEg, jobCtx := errgroup.WithContext(outerCtx)
-	testingEg.SetLimit(10)
+	testingEg.SetLimit(20)
 	testingEg.Go(func() error {
 		for result := range resultCh {
 			if isContextCanceled(jobCtx) {
@@ -168,13 +172,47 @@ func TestHashConsistency(t *testing.T) {
 					return fmt.Errorf("failed to verify data at height %d: %w", result.header.Number.Uint64(), err)
 				}
 
-				t.Logf("Verified data at height %d", result.header.Number.Uint64())
+				select {
+				case jobStatusUpdateReqCh <- &jobStatusUpdateReq{jobTypeId: JobTypeVerifyBlock, lastHeight: result.height}:
+				default:
+				}
 
 				return nil
 			})
 		}
 
 		return nil
+	})
+
+	loggingEg, jobCtx := errgroup.WithContext(outerCtx)
+	loggingEg.Go(func() error {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		var (
+			lastFetchHeight  uint64
+			lastVerifyHeight uint64
+		)
+
+		for {
+			select {
+			case <-jobCtx.Done():
+				return nil
+			case req, ok := <-jobStatusUpdateReqCh:
+				if !ok {
+					return nil
+				}
+
+				switch req.jobTypeId {
+				case JobTypeFetchBlock:
+					lastFetchHeight = req.lastHeight
+				case JobTypeVerifyBlock:
+					lastVerifyHeight = req.lastHeight
+				}
+			case <-ticker.C:
+				t.Logf("Progress: Fetching Blocks: %.2f%%, Verifying Blocks: %.2f%%", calcPercentage(startBlock, endBlock, lastFetchHeight), calcPercentage(startBlock, endBlock, lastVerifyHeight))
+			}
+		}
 	})
 
 	// Wait for all fetching jobs to complete and then close the result channel
@@ -189,6 +227,22 @@ func TestHashConsistency(t *testing.T) {
 		t.Logf("failed to complete testing block elements job: %v", err)
 		t.Fail()
 	}
+
+	close(jobStatusUpdateReqCh)
+}
+
+func calcPercentage(start, end, current uint64) float64 {
+	return float64((current-start)*100) / float64(end-start)
+}
+
+const (
+	JobTypeFetchBlock uint8 = iota
+	JobTypeVerifyBlock
+)
+
+type jobStatusUpdateReq struct {
+	jobTypeId  uint8
+	lastHeight uint64
 }
 
 type blockAndReceipts struct {

--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -9,23 +9,25 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
+	cel2Times = map[uint64]uint64{
+		params.CeloMainnetChainID:   1742957258,
+		params.CeloAlfajoresChainID: 1727339320,
+		params.CeloBaklavaChainID:   1740081460,
+	}
 	sha3Uncles = common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
 )
 
@@ -59,18 +61,6 @@ func TestHashConsistency(t *testing.T) {
 		t.Fatalf("failed to get chain id: %v", err)
 	}
 
-	// Fetch chain config
-	chainConfig, err := fetchChainConfig(t, int(chainId.Int64()))
-	if err != nil {
-		t.Fatalf("failed to fetch chain config: %v", err)
-	}
-	if chainConfig.Cel2Time == nil {
-		t.Fatalf("Cel2Time is not set in chain config")
-	}
-	if chainConfig.ChainID.Cmp(chainId) != 0 {
-		t.Fatalf("fetched chain ID (%s) and the chain ID in ChainConfig (%s) do not match", chainId.String(), chainConfig.ChainID.String())
-	}
-
 	// Fetch start and latest blocks
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -80,8 +70,12 @@ func TestHashConsistency(t *testing.T) {
 	} else if startBlockObj == nil {
 		t.Fatal("first block is nil")
 	}
-	if startBlockObj.Time() < *chainConfig.Cel2Time {
-		t.Fatalf("start block time (%d) is less than Cel2Time (%d)", startBlockObj.Time(), *chainConfig.Cel2Time)
+	cel2Times, ok := cel2Times[chainId.Uint64()]
+	if !ok {
+		t.Fatalf("celo2 time not found for chain %d", chainId.Uint64())
+	}
+	if startBlockObj.Time() < cel2Times {
+		t.Fatalf("start block time (%d) is less than Cel2Time (%d)", startBlockObj.Time(), cel2Times)
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
@@ -246,6 +240,7 @@ type blockAndReceipts struct {
 	rpcBlockHash       common.Hash
 	rpcTxRoot          common.Hash
 	rpcReceiptRoot     common.Hash
+	rpcLogsBoom        types.Bloom
 	rpcSha3Uncles      common.Hash
 	rpcWithdrawalsRoot common.Hash
 	rpcTxs             []interface{}
@@ -278,6 +273,11 @@ func fetchBlockAndReceipts(ctx context.Context, cel2Client *rpc.Client, cel2EthC
 	rpcReceiptRoot, ok := blockObj["receiptsRoot"].(string)
 	if !ok {
 		return nil, fmt.Errorf("failed to cast receiptsRoot from block at height %d", height)
+	}
+
+	rpcLogsBoom, ok := blockObj["logsBloom"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast logsBloom from block at height %d", height)
 	}
 
 	rpcSha3Uncles, ok := blockObj["sha3Uncles"].(string)
@@ -314,6 +314,7 @@ func fetchBlockAndReceipts(ctx context.Context, cel2Client *rpc.Client, cel2EthC
 		rpcBlockHash:       rpcBlockHash,
 		rpcTxRoot:          common.HexToHash(rpcTxRoot),
 		rpcReceiptRoot:     common.HexToHash(rpcReceiptRoot),
+		rpcLogsBoom:        types.BytesToBloom(common.FromHex(rpcLogsBoom)),
 		rpcSha3Uncles:      common.HexToHash(rpcSha3Uncles),
 		rpcWithdrawalsRoot: common.HexToHash(rpcWithdrawalsRoot),
 		rpcTxs:             txsObj,
@@ -336,7 +337,7 @@ func (b *blockAndReceipts) Verify(t *testing.T) error {
 		failed = true
 	}
 
-	// Transactions Hash Test
+	// Transaction Hashes Test
 	txs := make(types.Transactions, 0, len(b.rpcTxs))
 	for idx, rawTxObj := range b.rpcTxs {
 		txObj, ok := rawTxObj.(map[string]interface{})
@@ -363,7 +364,7 @@ func (b *blockAndReceipts) Verify(t *testing.T) error {
 		}
 	}
 
-	// Tx Root Test
+	// Transaction Root Test
 	calculatedTxRoot := types.DeriveSha(txs, trie.NewStackTrie(nil))
 	if calculatedTxRoot != b.rpcTxRoot {
 		t.Logf("Tx Root Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, calculatedTxRoot, b.rpcTxRoot)
@@ -377,6 +378,22 @@ func (b *blockAndReceipts) Verify(t *testing.T) error {
 		failed = true
 	}
 
+	// Transaction Logs Bloom Test
+	for idx, receipt := range b.receipts {
+		calculatedLogsBloom := types.CreateBloom(types.Receipts{receipt})
+		if calculatedLogsBloom != receipt.Bloom {
+			t.Logf("Transaction Logs Bloom Mismatch, block height=%d, block hash=%s, receipt index=%d => calculated=%s, rpc=%s", b.height, b.rpcBlockHash, idx, calculatedLogsBloom, receipt.Bloom)
+			failed = true
+		}
+	}
+
+	// Block Logs Bloom Test
+	calculatedLogsBloom := types.CreateBloom(b.receipts)
+	if calculatedLogsBloom != b.rpcLogsBoom {
+		t.Logf("Block Logs Bloom Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, calculatedLogsBloom, b.rpcLogsBoom)
+		failed = true
+	}
+
 	// Withdrawal Root Test
 	calculatedWithdrawalsRoot := types.DeriveSha(b.withdrawals, trie.NewStackTrie(nil))
 	if calculatedWithdrawalsRoot != b.rpcWithdrawalsRoot {
@@ -384,6 +401,7 @@ func (b *blockAndReceipts) Verify(t *testing.T) error {
 		failed = true
 	}
 
+	// Sha3 Uncles Test
 	if b.rpcSha3Uncles != sha3Uncles {
 		t.Logf("Sha3 Uncles Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, sha3Uncles, b.rpcSha3Uncles)
 		failed = true
@@ -420,44 +438,4 @@ func getTxTypeName(txType uint8) string {
 	default:
 		return "Unknown"
 	}
-}
-
-// fetchChainConfig fetches the chain config for the given chain ID from server
-func fetchChainConfig(t *testing.T, chainId int) (cfg *params.ChainConfig, err error) {
-	t.Helper()
-
-	var url string
-	switch chainId {
-	case params.CeloMainnetChainID:
-		url = "https://storage.googleapis.com/cel2-rollup-files/celo/genesis.json"
-	case params.CeloAlfajoresChainID:
-		url = "https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json"
-	case params.CeloBaklavaChainID:
-		url = "https://storage.googleapis.com/cel2-rollup-files/baklava/genesis.json"
-	default:
-		return nil, fmt.Errorf("unsupported chain id: %d", chainId)
-	}
-
-	genesis := new(core.Genesis)
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download genesis file: %v", err)
-	}
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			t.Logf("[WARN] failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code when fetching genesis file: %d", resp.StatusCode)
-	}
-
-	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(genesis); err != nil {
-		return nil, fmt.Errorf("failed to decode genesis file: %v", err)
-	}
-
-	return genesis.Config, nil
 }

--- a/compat_test/hash_consistency_test.go
+++ b/compat_test/hash_consistency_test.go
@@ -1,0 +1,414 @@
+//go:build compat_test
+
+package compat_tests
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
+	"golang.org/x/sync/errgroup"
+	"math/big"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	sha3Uncles = common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+)
+
+func TestHashConsistency(t *testing.T) {
+	// TestHashCompatTest validates that the hashes obtained from RPC endpoint are consistent with the values calculated locally
+	// It retrieves and compares the following hashes:
+	// 1. TxHash
+	// 2. TxRoot
+	// 3. BlockHash
+	// 4. ReceiptRoot
+	// 5. WithdrawalsRoot
+	flag.Parse()
+
+	if opGethRpcURL == "" {
+		t.Fatal("op-geth rpc url not set example usage:\n go test -v ./compat_test -tags compat_test -run TestHashCompatTest -op-geth-url ws://localhost:9994")
+	}
+	if blockInterval == 0 {
+		t.Fatal("block interval must be positive integer:\n go test -v ./compat_test -tags compat_test -run TestHashCompatTest -op-geth-url ws://localhost:9994 -block-interval 1000000")
+	}
+
+	// Setup RPC clients for Celo2
+	cel2Client, err := rpc.DialOptions(context.Background(), opGethRpcURL, clientOpts...)
+	require.NoError(t, err)
+	cel2EthClient := ethclient.NewClient(cel2Client)
+
+	// Fetch Chain ID
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	chainId, err := cel2EthClient.ChainID(ctx)
+	if err != nil {
+		t.Fatalf("failed to get chain id: %v", err)
+	}
+
+	// Fetch chain config
+	chainConfig, err := fetchChainConfig(t, int(chainId.Int64()))
+	if err != nil {
+		t.Fatalf("failed to fetch chain config: %v", err)
+	}
+	if chainConfig.Cel2Time == nil {
+		t.Fatalf("Cel2Time is not set in chain config")
+	}
+	if chainConfig.ChainID.Cmp(chainId) != 0 {
+		t.Fatalf("fetched chain ID (%s) and the chain ID in ChainConfig (%s) do not match", chainId.String(), chainConfig.ChainID.String())
+	}
+
+	// Fetch start and latest blocks
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	startBlockObj, err := cel2EthClient.BlockByNumber(ctx, big.NewInt(int64(startBlock)))
+	if err != nil {
+		t.Fatalf("failed to get the first block: %v", err)
+	} else if startBlockObj == nil {
+		t.Fatal("first block is nil")
+	}
+	if startBlockObj.Time() < *chainConfig.Cel2Time {
+		t.Fatalf("start block time (%d) is less than Cel2Time (%d)", startBlockObj.Time(), *chainConfig.Cel2Time)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	latestBlock, err := cel2EthClient.BlockByNumber(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to get latest block: %v", err)
+	} else if latestBlock == nil {
+		t.Fatal("latest block is nil")
+	}
+
+	endBlock := latestBlock.NumberU64()
+
+	t.Logf("Starting Hash Compatibility Test")
+	t.Logf("\tChainID: %s", chainId.String())
+	t.Logf("\tStart Block: %d", startBlock)
+	t.Logf("\tEnd Block: %d", endBlock)
+	t.Logf("\tBlock Count in Range: %d", endBlock-startBlock+1)
+	t.Logf("\tBlock Interval: %d", blockInterval)
+	t.Logf("\tEnable Random Block Test: %t\n", enableRandomBlockTest)
+
+	outerCtx, outerCancel := context.WithCancel(context.Background())
+	t.Cleanup(outerCancel)
+
+	resultCh := make(chan *blockAndReceipts, 100)
+
+	fetchingEg, jobCtx := errgroup.WithContext(outerCtx)
+	fetchingEg.SetLimit(5)
+	fetchingEg.Go(func() error {
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		for height := startBlock; height <= endBlock; height += blockInterval {
+			if isContextCanceled(jobCtx) {
+				t.Logf("Context canceled, exiting fetching loop at height %d", height)
+				return nil
+			}
+
+			fetchingEg.Go(func() error {
+				var blockHeight uint64
+				if enableRandomBlockTest {
+					blockHeight = height + rng.Uint64()%blockInterval
+					if blockHeight > endBlock {
+						blockHeight = endBlock
+					}
+				} else {
+					blockHeight = height
+				}
+
+				ctx, cancel := context.WithTimeout(jobCtx, 10*time.Second)
+				defer cancel()
+
+				res, err := fetchBlockAndReceipts(ctx, cel2Client, cel2EthClient, blockHeight)
+				if err != nil {
+					return err
+				}
+
+				t.Logf("Fetched data at height %d", res.height)
+
+				select {
+				case <-jobCtx.Done():
+					return jobCtx.Err()
+				case resultCh <- res:
+				}
+
+				return nil
+			})
+		}
+
+		return nil
+	})
+
+	testingEg, jobCtx := errgroup.WithContext(outerCtx)
+	testingEg.SetLimit(10)
+	testingEg.Go(func() error {
+		for result := range resultCh {
+			if isContextCanceled(jobCtx) {
+				t.Logf("Context canceled, exiting testing loop at height %d", result.header.Number.Uint64())
+				return nil
+			}
+
+			testingEg.Go(func() error {
+				err := result.Verify(t)
+				if err != nil {
+					return fmt.Errorf("failed to verify data at height %d: %w", result.header.Number.Uint64(), err)
+				}
+
+				t.Logf("Verified data at height %d", result.header.Number.Uint64())
+
+				return nil
+			})
+		}
+
+		return nil
+	})
+
+	// Wait for all fetching jobs to complete and then close the result channel
+	if err := fetchingEg.Wait(); err != nil {
+		t.Logf("failed to complete fetching block elements job: %v", err)
+		outerCancel()
+		t.Fail()
+	}
+	close(resultCh)
+
+	// Wait for all testing jobs to complete
+	if err := testingEg.Wait(); err != nil {
+		t.Logf("failed to complete testing block elements job: %v", err)
+		outerCancel()
+		t.Fail()
+	}
+}
+
+type blockAndReceipts struct {
+	height             uint64
+	rpcBlockHash       common.Hash
+	rpcTxRoot          common.Hash
+	rpcReceiptRoot     common.Hash
+	rpcSha3Uncles      common.Hash
+	rpcWithdrawalsRoot common.Hash
+	rpcTxs             []interface{}
+	header             *types.Header
+	receipts           types.Receipts
+	withdrawals        types.Withdrawals
+}
+
+// fetchBlockAndReceipts fetches the block and receipts for the given height from the RPC endpoint
+func fetchBlockAndReceipts(ctx context.Context, cel2Client *rpc.Client, cel2EthClient *ethclient.Client, height uint64) (*blockAndReceipts, error) {
+	var blockObj map[string]interface{}
+	err := cel2Client.Call(&blockObj, "eth_getBlockByNumber", fmt.Sprintf("0x%x", height), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block at height %d: %w", height, err)
+	} else if blockObj == nil {
+		return nil, fmt.Errorf("block #%d not found", height)
+	}
+
+	rawRpcBlockHash, ok := blockObj["hash"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast block hash from block at height %d", height)
+	}
+	rpcBlockHash := common.HexToHash(rawRpcBlockHash)
+
+	rpcTxRoot, ok := blockObj["transactionsRoot"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast transactionsRoot from block at height %d", height)
+	}
+
+	rpcReceiptRoot, ok := blockObj["receiptsRoot"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast receiptsRoot from block at height %d", height)
+	}
+
+	rpcSha3Uncles, ok := blockObj["sha3Uncles"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast sha3Uncles from block at height %d", height)
+	}
+
+	rpcWithdrawalsRoot, ok := blockObj["withdrawalsRoot"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast withdrawalsRoot from block at height %d", height)
+	}
+
+	txsObj, ok := blockObj["transactions"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to cast transactions from block data at height %d", height)
+	}
+
+	block, err := cel2EthClient.BlockByHash(ctx, rpcBlockHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block by hash %s: %w", rpcBlockHash, err)
+	} else if block == nil {
+		return nil, fmt.Errorf("block #%d not found", height)
+	}
+
+	receipts, err := cel2EthClient.BlockReceipts(ctx, rpc.BlockNumberOrHash{BlockHash: &rpcBlockHash})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch receipts for block %d: %v", height, err)
+	} else if receipts == nil {
+		return nil, fmt.Errorf("receipts for block #%d not found", height)
+	}
+
+	return &blockAndReceipts{
+		height:             height,
+		rpcBlockHash:       rpcBlockHash,
+		rpcTxRoot:          common.HexToHash(rpcTxRoot),
+		rpcReceiptRoot:     common.HexToHash(rpcReceiptRoot),
+		rpcSha3Uncles:      common.HexToHash(rpcSha3Uncles),
+		rpcWithdrawalsRoot: common.HexToHash(rpcWithdrawalsRoot),
+		rpcTxs:             txsObj,
+		header:             block.Header(),
+		receipts:           receipts,
+		withdrawals:        block.Withdrawals(),
+	}, nil
+}
+
+// Verify compares the hashes obtained from RPC endpoint with the values calculated locally
+func (b *blockAndReceipts) Verify(t *testing.T) error {
+	t.Helper()
+
+	failed := false
+
+	// Block Hash Test
+	calculatedBlockHash := b.header.Hash()
+	if calculatedBlockHash != b.rpcBlockHash {
+		t.Logf("Block Hash Mismatch, height=%d => calculated=%s, rpc=%s", b.height, calculatedBlockHash.Hex(), b.rpcBlockHash.Hex())
+		failed = true
+	}
+
+	// Transactions Hash Test
+	txs := make(types.Transactions, 0, len(b.rpcTxs))
+	for idx, rawTxObj := range b.rpcTxs {
+		txObj, ok := rawTxObj.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to cast transaction from block data at height %d", b.height)
+		}
+		rpcHash := txObj["hash"].(string)
+
+		jsonTx, err := json.Marshal(rawTxObj)
+		if err != nil {
+			return fmt.Errorf("failed to marshal tx: %v", err)
+		}
+
+		var tx types.Transaction
+		if err := json.Unmarshal(jsonTx, &tx); err != nil {
+			return fmt.Errorf("failed to unmarshal tx: %v", err)
+		}
+		txs = append(txs, &tx)
+
+		calculatedHash := tx.Hash()
+		if calculatedHash.Hex() != rpcHash {
+			t.Logf("Tx Hash Mismatch, block height=%d, block hash=%s, tx index=%d, tx hash=%s, tx type=%s => calculated=%s, rpc=%s", b.height, b.rpcBlockHash, idx, rpcHash, getTxTypeName(tx.Type()), calculatedHash.Hex(), rpcHash)
+			failed = true
+		}
+	}
+
+	// Tx Root Test
+	calculatedTxRoot := types.DeriveSha(txs, trie.NewStackTrie(nil))
+	if calculatedTxRoot != b.rpcTxRoot {
+		t.Logf("Tx Root Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, calculatedTxRoot, b.rpcTxRoot)
+		failed = true
+	}
+
+	// Block Receipt Root Test
+	calculatedReceiptRoot := types.DeriveSha(b.receipts, trie.NewStackTrie(nil))
+	if calculatedReceiptRoot != b.rpcReceiptRoot {
+		t.Logf("Receipt Root Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, calculatedReceiptRoot, b.rpcReceiptRoot)
+		failed = true
+	}
+
+	// Withdrawal Root Test
+	calculatedWithdrawalsRoot := types.DeriveSha(b.withdrawals, trie.NewStackTrie(nil))
+	if calculatedWithdrawalsRoot != b.rpcWithdrawalsRoot {
+		t.Logf("Withdrawal Root Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, calculatedWithdrawalsRoot, b.rpcWithdrawalsRoot)
+		failed = true
+	}
+
+	if b.rpcSha3Uncles != sha3Uncles {
+		t.Logf("Sha3 Uncles Mismatch, block height=%d => calculated=%s, rpc=%s", b.height, sha3Uncles, b.rpcSha3Uncles)
+		failed = true
+	}
+
+	if failed {
+		return fmt.Errorf("block verification failed")
+	}
+
+	return nil
+}
+
+// getTxTypeName returns the name of the transaction type
+func getTxTypeName(txType uint8) string {
+	switch txType {
+	case types.LegacyTxType:
+		return "Legacy"
+	case types.AccessListTxType:
+		return "AccessList"
+	case types.DynamicFeeTxType:
+		return "DynamicFee"
+	case types.BlobTxType:
+		return "Blob"
+	case types.SetCodeTxType:
+		return "SetCode"
+	case types.DepositTxType:
+		return "Deposit"
+	case types.CeloDynamicFeeTxType:
+		return "CeloDynamicFee"
+	case types.CeloDynamicFeeTxV2Type:
+		return "CeloDynamicFeeV2"
+	case types.CeloDenominatedTxType:
+		return "CeloDenominated"
+	default:
+		return "Unknown"
+	}
+}
+
+// fetchChainConfig fetches the chain config for the given chain ID from server
+func fetchChainConfig(t *testing.T, chainId int) (cfg *params.ChainConfig, err error) {
+	t.Helper()
+
+	var url string
+	switch chainId {
+	case params.CeloMainnetChainID:
+		url = "https://storage.googleapis.com/cel2-rollup-files/celo/genesis.json"
+	case params.CeloAlfajoresChainID:
+		url = "https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json"
+	case params.CeloBaklavaChainID:
+		url = "https://storage.googleapis.com/cel2-rollup-files/baklava/genesis.json"
+	default:
+		return nil, fmt.Errorf("unsupported chain id: %d", chainId)
+	}
+
+	genesis := new(core.Genesis)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download genesis file: %v", err)
+	}
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			t.Logf("[WARN] failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code when fetching genesis file: %d", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(genesis); err != nil {
+		return nil, fmt.Errorf("failed to decode genesis file: %v", err)
+	}
+
+	return genesis.Config, nil
+}

--- a/core/types/celo_receipt_test.go
+++ b/core/types/celo_receipt_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +58,7 @@ func checkEncodeDecodeConsistency(r *Receipt, t *testing.T) {
 	checkRLPEncodeDecodeConsistency(r, t)
 	checkStorageRLPEncodeDecodeConsistency((*ReceiptForStorage)(r), t)
 	checkBinaryEncodeDecodeConsistency(r, t)
+	checkJsonEncodeDecodeConsistency(r, t)
 }
 
 // checkRLPEncodeDecodeConsistency encodes and decodes the receipt and checks that they are equal.
@@ -102,6 +104,18 @@ func checkStorageRLPEncodeDecodeConsistency(r *ReceiptForStorage, t *testing.T) 
 	require.NoError(t, err)
 
 	require.EqualValues(t, r, &r2)
+}
+
+// checkJsonEncodeDecodeConsistency tests the consistency of JSON encoding and decoding of the receipt.
+func checkJsonEncodeDecodeConsistency(r *Receipt, t *testing.T) {
+	rawJson, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	r2 := &Receipt{}
+	err = r2.UnmarshalJSON(rawJson)
+	assert.NoError(t, err)
+
+	assert.Equal(t, r, r2)
 }
 
 // Tests that the effective gas price is correctly derived for different transaction types, in different scenarios.

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -40,7 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
 		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
-		BaseFee               *big.Int        `json:"baseFee,omitempty"`
+		BaseFee               *hexutil.Big    `json:"baseFee,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -67,7 +67,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.FeeScalar = r.FeeScalar
 	enc.L1BaseFeeScalar = (*hexutil.Uint64)(r.L1BaseFeeScalar)
 	enc.L1BlobBaseFeeScalar = (*hexutil.Uint64)(r.L1BlobBaseFeeScalar)
-	enc.BaseFee = r.BaseFee
+	enc.BaseFee = (*hexutil.Big)(r.BaseFee)
 	return json.Marshal(&enc)
 }
 
@@ -98,7 +98,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
 		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
-		BaseFee               *big.Int        `json:"baseFee,omitempty"`
+		BaseFee               *hexutil.Big    `json:"baseFee,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -182,7 +182,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		r.L1BlobBaseFeeScalar = (*uint64)(dec.L1BlobBaseFeeScalar)
 	}
 	if dec.BaseFee != nil {
-		r.BaseFee = dec.BaseFee
+		r.BaseFee = (*big.Int)(dec.BaseFee)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -121,6 +121,9 @@ type receiptMarshaling struct {
 	L1BlobBaseFeeScalar   *hexutil.Uint64
 	DepositNonce          *hexutil.Uint64
 	DepositReceiptVersion *hexutil.Uint64
+
+	// Celo
+	BaseFee *hexutil.Big
 }
 
 // receiptRLP is the consensus encoding of a receipt.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -711,7 +711,7 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 		if i == len(txs) {
 			result[i] = marshalBlockReceipt(receipt, block.Hash(), block.NumberU64(), i)
 		} else {
-			result[i] = marshalReceipt(receipt, block.Hash(), block.NumberU64(), signer, txs[i], i, api.b.ChainConfig())
+			result[i] = marshalReceipt(receipt, block.Hash(), block.NumberU64(), block.Time(), signer, txs[i], i, api.b.ChainConfig())
 		}
 	}
 	return result, nil
@@ -1643,11 +1643,11 @@ func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash commo
 
 	// Derive the sender.
 	signer := types.MakeSigner(api.b.ChainConfig(), header.Number, header.Time)
-	return marshalReceipt(receipt, blockHash, blockNumber, signer, tx, int(index), api.b.ChainConfig()), nil
+	return marshalReceipt(receipt, blockHash, blockNumber, header.Time, signer, tx, int(index), api.b.ChainConfig()), nil
 }
 
 // marshalReceipt marshals a transaction receipt into a JSON object.
-func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber uint64, signer types.Signer, tx *types.Transaction, txIndex int, chainConfig *params.ChainConfig) map[string]interface{} {
+func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber uint64, blockTime uint64, signer types.Signer, tx *types.Transaction, txIndex int, chainConfig *params.ChainConfig) map[string]interface{} {
 	from, _ := types.Sender(signer, tx)
 
 	fields := map[string]interface{}{
@@ -1723,7 +1723,7 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		fields["contractAddress"] = receipt.ContractAddress
 	}
 
-	if tx.Type() == types.CeloDynamicFeeTxV2Type {
+	if chainConfig.IsCel2(blockTime) && tx.Type() == types.CeloDynamicFeeTxV2Type {
 		fields["baseFee"] = (*hexutil.Big)(receipt.BaseFee)
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1722,6 +1722,11 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 	if receipt.ContractAddress != (common.Address{}) {
 		fields["contractAddress"] = receipt.ContractAddress
 	}
+
+	if tx.Type() == types.CeloDynamicFeeTxV2Type {
+		fields["baseFee"] = (*hexutil.Big)(receipt.BaseFee)
+	}
+
 	return fields
 }
 

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -432,6 +432,7 @@ func allEnabledChainConfig() *params.ChainConfig {
 		FjordTime:           &zeroTime,
 		Cel2Time:            &zeroTime,
 		GingerbreadBlock:    big.NewInt(0),
+		Optimism:            &params.OptimismConfig{},
 	}
 }
 
@@ -662,4 +663,254 @@ func TestCheckTxFee(t *testing.T) {
 		err := CheckTxFee(context.Background(), backend, big.NewInt(params.Ether), 4, &core.DevFeeCurrencyAddr2)
 		assert.ErrorIs(t, err, exchange.ErrUnregisteredFeeCurrency)
 	})
+}
+
+// TestMarshalReceipt tests the marshalReceipt function, which serializes a receipt object into a JSON-RPC response.
+// It focuses on ensuring that this function returns the proper schema based on the transaction type.
+func Test_marshalReceipt(t *testing.T) {
+	config := allEnabledChainConfig()
+	cel2Time := uint64(1000)
+	config.Cel2Time = &cel2Time
+
+	var (
+		blockHash                    = common.BytesToHash([]byte{0x1})
+		blockNumber           uint64 = 500
+		cumulativeGasUsed     uint64 = 500000
+		gasUsed               uint64 = 400000
+		txIndex               uint   = 0
+		gasTipCap                    = big.NewInt(100)
+		gasFeeCap                    = big.NewInt(500)
+		gas                   uint64 = 10000000
+		l1GasPrice                   = big.NewInt(50000)
+		l1GasUsed                    = big.NewInt(20000)
+		l1Fee                        = big.NewInt(0)
+		l1FeeScalar                  = big.NewFloat(0)
+		l1BlobBaseFee                = big.NewInt(300000)
+		l1BaseFeeScalar       uint64 = 0
+		L1BlobBaseFeeScalar   uint64 = 0
+		blobGasUsed           uint64 = 5000000
+		blobGasPrice                 = big.NewInt(300000)
+		from                         = common.HexToAddress("0x0000000000000000000000000000000000000bbb")
+		sourceHash                   = common.BytesToHash([]byte{0xaa})
+		depositNonce          uint64 = 100
+		depositReceiptVersion uint64 = 1
+		feeCurrency                  = core.DevFeeCurrencyAddr
+		gatewayFeeRecipient          = common.HexToAddress("0x0000000000000000000000000000000000000eee")
+		gatewayFee                   = big.NewInt(100)
+		logs                         = []*types.Log{
+			{
+				Address: common.BytesToAddress([]byte{0x33}),
+				Topics:  []common.Hash{common.HexToHash("dead")},
+				Data:    []byte{0x01, 0x02, 0x03},
+			},
+		}
+	)
+
+	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber), blockTime)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	receipt := types.Receipt{
+		Type:                  types.DynamicFeeTxType,
+		CumulativeGasUsed:     cumulativeGasUsed,
+		Status:                types.ReceiptStatusSuccessful,
+		GasUsed:               gasUsed,
+		Logs:                  logs,
+		BlockHash:             blockHash,
+		BlockNumber:           big.NewInt(int64(blockNumber)),
+		TransactionIndex:      txIndex,
+		L1GasPrice:            l1GasPrice,
+		L1GasUsed:             l1GasUsed,
+		L1Fee:                 l1Fee,
+		FeeScalar:             l1FeeScalar,
+		L1BlobBaseFee:         l1BlobBaseFee,
+		L1BaseFeeScalar:       &l1BaseFeeScalar,
+		L1BlobBaseFeeScalar:   &L1BlobBaseFeeScalar,
+		BlobGasUsed:           blobGasUsed,
+		BlobGasPrice:          blobGasPrice,
+		DepositNonce:          &depositNonce,
+		DepositReceiptVersion: &depositReceiptVersion,
+	}
+	receipt.Bloom = types.CreateBloom(types.Receipts{&receipt})
+
+	t.Run("LegacyTx receipt", func(t *testing.T) {
+		tx, err := types.SignTx(types.NewTx(&types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: gasPrice,
+			Gas:      gasLimit,
+			To:       &to,
+			Value:    value,
+			Data:     []byte{},
+		}), signer, key)
+		require.NoError(t, err)
+
+		// Disable Optimism Config
+		config := *config
+		config.Optimism = nil
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), &config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, false)
+	})
+
+	t.Run("DynamicFeeTx receipt", func(t *testing.T) {
+		tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+			Nonce:     nonce,
+			GasTipCap: gasTipCap,
+			GasFeeCap: gasFeeCap,
+			Gas:       gasLimit,
+			To:        &to,
+			Value:     value,
+			Data:      []byte{},
+		}), signer, key)
+		require.NoError(t, err)
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+	})
+
+	t.Run("DepositTx receipt", func(t *testing.T) {
+		tx := types.NewTx(&types.DepositTx{
+			SourceHash:          sourceHash,
+			From:                from,
+			To:                  &to,
+			Value:               value,
+			Gas:                 gas,
+			IsSystemTransaction: true,
+			Data:                []byte{},
+		})
+		require.NoError(t, err)
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+	})
+
+	t.Run("CeloDynamicFeeTxV1 receipt", func(t *testing.T) {
+		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTx{
+			ChainID:             big.NewInt(params.CeloAlfajoresChainID),
+			Nonce:               nonce,
+			GasTipCap:           gasTipCap,
+			GasFeeCap:           gasFeeCap,
+			Gas:                 gas,
+			FeeCurrency:         &feeCurrency,
+			GatewayFeeRecipient: &gatewayFeeRecipient,
+			GatewayFee:          gatewayFee,
+			To:                  &to,
+			Value:               value,
+			Data:                []byte{},
+		}), signer, key)
+		require.NoError(t, err)
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+	})
+
+	t.Run("CeloDynamicFeeTxV2 receipt", func(t *testing.T) {
+		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTxV2{
+			ChainID:     big.NewInt(params.CeloAlfajoresChainID),
+			Nonce:       nonce,
+			GasTipCap:   gasTipCap,
+			GasFeeCap:   gasFeeCap,
+			Gas:         gas,
+			FeeCurrency: &feeCurrency,
+			To:          &to,
+			Value:       value,
+			Data:        []byte{},
+		}), signer, key)
+		require.NoError(t, err)
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+	})
+}
+
+// checkReceiptFields is a helper function to perform a detailed comparison and verification of the contents of a transaction receipt
+// retrieved from an RPC endpoint
+// it specifically checks for the presence and values of special fields that are exported based on the transaction type
+func checkReceiptFields(
+	t *testing.T,
+	rpcReceipt map[string]interface{},
+	receipt *types.Receipt,
+	tx *types.Transaction,
+	signer types.Signer,
+	blockhash common.Hash,
+	blockNumber uint64,
+	txIndex uint,
+	isCel2 bool,
+) {
+	t.Helper()
+
+	from, err := types.Sender(signer, tx)
+	require.NoError(t, err)
+
+	assert.Equal(t, hexutil.Uint(tx.Type()), rpcReceipt["type"])
+	assert.Equal(t, blockhash, rpcReceipt["blockHash"])
+	assert.Equal(t, hexutil.Uint64(blockNumber), rpcReceipt["blockNumber"])
+	assert.Equal(t, tx.Hash(), rpcReceipt["transactionHash"])
+	assert.Equal(t, hexutil.Uint64(txIndex), rpcReceipt["transactionIndex"])
+	assert.Equal(t, from, rpcReceipt["from"])
+	assert.Equal(t, tx.To(), rpcReceipt["to"])
+	assert.Equal(t, hexutil.Uint64(receipt.GasUsed), rpcReceipt["gasUsed"])
+	assert.Equal(t, hexutil.Uint64(receipt.CumulativeGasUsed), rpcReceipt["cumulativeGasUsed"])
+	assert.Equal(t, receipt.Logs, rpcReceipt["logs"])
+	assert.Equal(t, receipt.Bloom, rpcReceipt["logsBloom"])
+	assert.Equal(t, hexutil.Uint(receipt.Status), rpcReceipt["status"])
+	assert.Equal(t, receipt.Logs, rpcReceipt["logs"])
+
+	if receipt.ContractAddress != (common.Address{}) {
+		assert.Equal(t, receipt.ContractAddress, rpcReceipt["contractAddress"])
+	} else {
+		assert.Nil(t, rpcReceipt["contractAddress"])
+	}
+
+	if isCel2 && !tx.IsDepositTx() {
+		assert.Equal(t, (*hexutil.Big)(receipt.L1GasPrice), rpcReceipt["l1GasPrice"])
+		assert.Equal(t, (*hexutil.Big)(receipt.L1GasUsed), rpcReceipt["l1GasUsed"])
+		assert.Equal(t, (*hexutil.Big)(receipt.L1Fee), rpcReceipt["l1Fee"])
+		assert.Equal(t, receipt.FeeScalar.String(), rpcReceipt["l1FeeScalar"])
+		assert.Equal(t, (*hexutil.Big)(receipt.L1BlobBaseFee), rpcReceipt["l1BlobBaseFee"])
+		assert.Equal(t, hexutil.Uint64(*receipt.L1BaseFeeScalar), rpcReceipt["l1BaseFeeScalar"])
+		assert.Equal(t, hexutil.Uint64(*receipt.L1BlobBaseFeeScalar), rpcReceipt["l1BlobBaseFeeScalar"])
+	} else {
+		assert.Nil(t, rpcReceipt["l1GasPrice"])
+		assert.Nil(t, rpcReceipt["l1GasUsed"])
+		assert.Nil(t, rpcReceipt["l1Fee"])
+		assert.Nil(t, rpcReceipt["l1FeeScalar"])
+		assert.Nil(t, rpcReceipt["l1BlobBaseFee"])
+		assert.Nil(t, rpcReceipt["l1BaseFeeScalar"])
+		assert.Nil(t, rpcReceipt["l1BlobBaseFeeScalar"])
+	}
+
+	if isCel2 && tx.IsDepositTx() {
+		assert.Equal(t, hexutil.Uint64(*receipt.DepositNonce), rpcReceipt["depositNonce"])
+		assert.Equal(t, hexutil.Uint64(*receipt.DepositReceiptVersion), rpcReceipt["depositReceiptVersion"])
+	} else {
+		assert.Nil(t, rpcReceipt["depositNonce"])
+		assert.Nil(t, rpcReceipt["depositReceiptVersion"])
+	}
+
+	if isCel2 && tx.Type() == types.CeloDynamicFeeTxV2Type {
+		assert.Equal(t, (*hexutil.Big)(receipt.BaseFee), rpcReceipt["baseFee"])
+	} else {
+		assert.Nil(t, rpcReceipt["baseFee"])
+	}
 }

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -672,6 +672,9 @@ func Test_marshalReceipt(t *testing.T) {
 	cel2Time := uint64(1000)
 	config.Cel2Time = &cel2Time
 
+	cel1Config := *config
+	cel1Config.Optimism = nil
+
 	var (
 		blockHash                    = common.BytesToHash([]byte{0x1})
 		blockNumber           uint64 = 500
@@ -692,6 +695,7 @@ func Test_marshalReceipt(t *testing.T) {
 		blobGasPrice                 = big.NewInt(300000)
 		from                         = common.HexToAddress("0x0000000000000000000000000000000000000bbb")
 		sourceHash                   = common.BytesToHash([]byte{0xaa})
+		baseFee                      = big.NewInt(100000)
 		depositNonce          uint64 = 100
 		depositReceiptVersion uint64 = 1
 		feeCurrency                  = core.DevFeeCurrencyAddr
@@ -730,6 +734,7 @@ func Test_marshalReceipt(t *testing.T) {
 		BlobGasPrice:          blobGasPrice,
 		DepositNonce:          &depositNonce,
 		DepositReceiptVersion: &depositReceiptVersion,
+		BaseFee:               baseFee,
 	}
 	receipt.Bloom = types.CreateBloom(types.Receipts{&receipt})
 
@@ -744,16 +749,12 @@ func Test_marshalReceipt(t *testing.T) {
 		}), signer, key)
 		require.NoError(t, err)
 
-		// Disable Optimism Config
-		config := *config
-		config.Optimism = nil
-
 		receipt := receipt
 		receipt.TxHash = tx.Hash()
 
-		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), &config)
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time-1, signer, tx, int(txIndex), &cel1Config)
 
-		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, false)
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time-1, txIndex, &cel1Config)
 	})
 
 	t.Run("DynamicFeeTx receipt", func(t *testing.T) {
@@ -771,9 +772,9 @@ func Test_marshalReceipt(t *testing.T) {
 		receipt := receipt
 		receipt.TxHash = tx.Hash()
 
-		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time, signer, tx, int(txIndex), config)
 
-		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time, txIndex, config)
 	})
 
 	t.Run("DepositTx receipt", func(t *testing.T) {
@@ -791,9 +792,9 @@ func Test_marshalReceipt(t *testing.T) {
 		receipt := receipt
 		receipt.TxHash = tx.Hash()
 
-		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time, signer, tx, int(txIndex), config)
 
-		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time, txIndex, config)
 	})
 
 	t.Run("CeloDynamicFeeTxV1 receipt", func(t *testing.T) {
@@ -815,12 +816,12 @@ func Test_marshalReceipt(t *testing.T) {
 		receipt := receipt
 		receipt.TxHash = tx.Hash()
 
-		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time, signer, tx, int(txIndex), config)
 
-		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time, txIndex, config)
 	})
 
-	t.Run("CeloDynamicFeeTxV2 receipt", func(t *testing.T) {
+	t.Run("CeloDynamicFeeTxV2 receipt (Post Cel2)", func(t *testing.T) {
 		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTxV2{
 			ChainID:     big.NewInt(params.CeloAlfajoresChainID),
 			Nonce:       nonce,
@@ -837,9 +838,31 @@ func Test_marshalReceipt(t *testing.T) {
 		receipt := receipt
 		receipt.TxHash = tx.Hash()
 
-		result := marshalReceipt(&receipt, blockHash, blockNumber, signer, tx, int(txIndex), config)
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time, signer, tx, int(txIndex), config)
 
-		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, txIndex, true)
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time, txIndex, config)
+	})
+
+	t.Run("CeloDynamicFeeTxV2 receipt (Pre Cel2)", func(t *testing.T) {
+		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTxV2{
+			ChainID:     big.NewInt(params.CeloAlfajoresChainID),
+			Nonce:       nonce,
+			GasTipCap:   gasTipCap,
+			GasFeeCap:   gasFeeCap,
+			Gas:         gas,
+			FeeCurrency: &feeCurrency,
+			To:          &to,
+			Value:       value,
+			Data:        []byte{},
+		}), signer, key)
+		require.NoError(t, err)
+
+		receipt := receipt
+		receipt.TxHash = tx.Hash()
+
+		result := marshalReceipt(&receipt, blockHash, blockNumber, cel2Time-1, signer, tx, int(txIndex), &cel1Config)
+
+		checkReceiptFields(t, result, &receipt, tx, signer, blockHash, blockNumber, cel2Time-1, txIndex, &cel1Config)
 	})
 }
 
@@ -854,8 +877,9 @@ func checkReceiptFields(
 	signer types.Signer,
 	blockhash common.Hash,
 	blockNumber uint64,
+	blockTime uint64,
 	txIndex uint,
-	isCel2 bool,
+	config *params.ChainConfig,
 ) {
 	t.Helper()
 
@@ -882,7 +906,7 @@ func checkReceiptFields(
 		assert.Nil(t, rpcReceipt["contractAddress"])
 	}
 
-	if isCel2 && !tx.IsDepositTx() {
+	if config.IsCel2(blockTime) && !tx.IsDepositTx() {
 		assert.Equal(t, (*hexutil.Big)(receipt.L1GasPrice), rpcReceipt["l1GasPrice"])
 		assert.Equal(t, (*hexutil.Big)(receipt.L1GasUsed), rpcReceipt["l1GasUsed"])
 		assert.Equal(t, (*hexutil.Big)(receipt.L1Fee), rpcReceipt["l1Fee"])
@@ -900,7 +924,7 @@ func checkReceiptFields(
 		assert.Nil(t, rpcReceipt["l1BlobBaseFeeScalar"])
 	}
 
-	if isCel2 && tx.IsDepositTx() {
+	if config.IsCel2(blockTime) && tx.IsDepositTx() {
 		assert.Equal(t, hexutil.Uint64(*receipt.DepositNonce), rpcReceipt["depositNonce"])
 		assert.Equal(t, hexutil.Uint64(*receipt.DepositReceiptVersion), rpcReceipt["depositReceiptVersion"])
 	} else {
@@ -908,7 +932,7 @@ func checkReceiptFields(
 		assert.Nil(t, rpcReceipt["depositReceiptVersion"])
 	}
 
-	if isCel2 && tx.Type() == types.CeloDynamicFeeTxV2Type {
+	if config.IsCel2(blockTime) && tx.Type() == types.CeloDynamicFeeTxV2Type {
 		assert.Equal(t, (*hexutil.Big)(receipt.BaseFee), rpcReceipt["baseFee"])
 	} else {
 		assert.Nil(t, rpcReceipt["baseFee"])


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/956
Closes https://github.com/celo-org/op-geth/issues/350

This PR adds `baseFee` field for CeloDynamicFeeTxV2 receipt because it's necessary for calculating receipt root remotely.

## How to check

1. Run `op-geth` locally with the change of this PR

2. Switch to `alecps/receiptRootCheck` for running test code
3. Copy `core/types/receipt.go` and `core/types/gen_receipt_json.go` in this PR into the branch (This is required for mapping JSON-RPC response properly in test code)
4. Run `go run ./receipt_root_test --debug <Local RPC URL> 31123401` and make sure it passes


## How to test

I added a new script, `compat_test/hash_consistency_test.go`, which calculates BlockHash, TxHash, TxRoot, ReceiptRoot, and WithdrawalsRoot across multiple blocks starting from a specified height.

I ran a local `op-geth` node with the changes from the PR forAlfajores testnet and confirmed that the BlockHash, TxHash, TxRoot, ReceiptRoot, and WithdrawalsRoot of all L2 blocks were properly calculated based on RPC response locally

```bash
$ go test -v ./compat_test -tags compat_test -run TestHashConsistency -timeout 1h -op-geth-url ws://localhost:9994 --start-block 31056500 --block-interval 1
```
