### PR TITLE
Add tests for miner tx ordering with local and remote transactions

### DIFF
--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -103,7 +103,7 @@ func CeloGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			Balance: big.NewInt(0),
 			Storage: map[common.Hash]common.Hash{
 				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr.Bytes())):    devBalance32, // _balances[DevAddr]
-				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr2.Bytes())):   devBalance32, // _balances[DevAddr]
+				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr2.Bytes())):   devBalance32, // _balances[DevAddr2]
 				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(fundedAddr.Bytes())): devBalance32, // _balances[fund]
 				common.HexToHash("0x2"): devBalance32, // _totalSupply
 			},

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -37,9 +37,10 @@ func incHash(addr common.Hash, i int64) common.Hash {
 }
 
 var (
-	DevPrivateKey, _ = crypto.HexToECDSA("2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5")
-	DevAddr          = common.BytesToAddress(DevAddr32.Bytes())
-	DevAddr32        = common.HexToHash("0x42cf1bbc38BaAA3c4898ce8790e21eD2738c6A4a")
+	DevPrivateKey, _  = crypto.HexToECDSA("2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5")
+	DevAddr           = common.HexToAddress("0x42cf1bbc38BaAA3c4898ce8790e21eD2738c6A4a")
+	DevPrivateKey2, _ = crypto.HexToECDSA("fbc0c0a6b8e05a2770632982af1ea41bd444390b34476b52d57b0d455911a94c")
+	DevAddr2          = common.HexToAddress("0xf280E427723B0ee6a1eF614ffFBDE15DB5fED5b1")
 
 	DevFeeCurrencyAddr      = common.HexToAddress("0x000000000000000000000000000000000000ce16") // worth half as much as native CELO
 	DevFeeCurrencyAddr2     = common.HexToAddress("0x000000000000000000000000000000000000ce17") // worth twice as much as native CELO
@@ -91,7 +92,8 @@ func CeloGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			Code:    feeCurrencyBytecode,
 			Balance: big.NewInt(0),
 			Storage: map[common.Hash]common.Hash{
-				CalcMapAddr(common.HexToHash("0x0"), DevAddr32):                              devBalance32, // _balances[DevAddr]
+				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr.Bytes())):    devBalance32, // _balances[DevAddr]
+				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr2.Bytes())):   devBalance32, // _balances[DevAddr2]
 				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(fundedAddr.Bytes())): devBalance32, // _balances[fund]
 				common.HexToHash("0x2"): devBalance32, // _totalSupply
 			},
@@ -100,7 +102,8 @@ func CeloGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			Code:    feeCurrencyBytecode,
 			Balance: big.NewInt(0),
 			Storage: map[common.Hash]common.Hash{
-				CalcMapAddr(common.HexToHash("0x0"), DevAddr32):                              devBalance32, // _balances[DevAddr]
+				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr.Bytes())):    devBalance32, // _balances[DevAddr]
+				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(DevAddr2.Bytes())):   devBalance32, // _balances[DevAddr]
 				CalcMapAddr(common.HexToHash("0x0"), common.BytesToHash(fundedAddr.Bytes())): devBalance32, // _balances[fund]
 				common.HexToHash("0x2"): devBalance32, // _totalSupply
 			},
@@ -129,6 +132,9 @@ func CeloGenesisAccounts(fundedAddr common.Address) GenesisAlloc {
 			// This oracle is available for tests of contracts outside the celo_genesis, so no initialization is done at this point
 		},
 		DevAddr: {
+			Balance: DevBalance,
+		},
+		DevAddr2: {
 			Balance: DevBalance,
 		},
 		FaucetAddr: {

--- a/miner/celo_worker_test.go
+++ b/miner/celo_worker_test.go
@@ -1,0 +1,235 @@
+// Copyright 2025 The celo Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package miner
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMinerFillTransactionsOrdering verifies that the miner orders transactions
+// based solely on their locality (local or remote), nonce, and gas price.
+func TestMinerFillTransactionsOrdering(t *testing.T) {
+	t.Parallel()
+
+	var (
+		key1     = core.DevPrivateKey
+		address1 = core.DevAddr
+		key2     = core.DevPrivateKey2
+
+		miner       = createCeloMiner(t)
+		signer      = types.LatestSigner(miner.chainConfig)
+		parentBlock = miner.chain.CurrentBlock()
+	)
+
+	// BaseFee: 0.875 GWei
+	txs := []*types.Transaction{
+		// Effective: 100 GWei
+		types.MustSignNewTx(key1, signer, &types.LegacyTx{
+			Nonce:    0,
+			To:       &common.ZeroAddress,
+			Value:    big.NewInt(1),
+			Gas:      71000,
+			GasPrice: big.NewInt(100 * params.GWei),
+		}),
+		// Effective: 99 GWei
+		types.MustSignNewTx(key2, signer, &types.LegacyTx{
+			Nonce:    0,
+			To:       &common.ZeroAddress,
+			Value:    big.NewInt(2),
+			Gas:      71000,
+			GasPrice: big.NewInt(99 * params.GWei),
+		}),
+		// Effective: 98.875 GWei
+		types.MustSignNewTx(key2, signer, &types.DynamicFeeTx{
+			ChainID:   miner.chainConfig.ChainID,
+			Nonce:     1,
+			To:        &common.ZeroAddress,
+			Value:     big.NewInt(3),
+			Gas:       71000,
+			GasFeeCap: big.NewInt(10000 * params.GWei),
+			GasTipCap: big.NewInt(98 * params.GWei),
+		}),
+		// Effective: 97.875 GWei
+		types.MustSignNewTx(key1, signer, &types.CeloDynamicFeeTxV2{
+			ChainID:     miner.chainConfig.ChainID,
+			Nonce:       1,
+			To:          &common.ZeroAddress,
+			Value:       big.NewInt(4),
+			Gas:         71000,
+			GasFeeCap:   big.NewInt(10000 * params.GWei),
+			GasTipCap:   big.NewInt(194 * params.GWei),
+			FeeCurrency: &core.DevFeeCurrencyAddr,
+		}),
+		// Effective: 90 GWei
+		types.MustSignNewTx(key1, signer, &types.AccessListTx{
+			Nonce:    2,
+			To:       &common.ZeroAddress,
+			Value:    big.NewInt(5),
+			Gas:      71000,
+			GasPrice: big.NewInt(95 * params.GWei),
+		}),
+		// Effective: 50 GWei
+		types.MustSignNewTx(key2, signer, &types.LegacyTx{
+			Nonce:    2,
+			To:       &common.ZeroAddress,
+			Value:    big.NewInt(6),
+			Gas:      71000,
+			GasPrice: big.NewInt(50 * params.GWei),
+		}),
+		// Effective: 200 GWei
+		types.MustSignNewTx(key2, signer, &types.LegacyTx{
+			Nonce:    3,
+			To:       &common.ZeroAddress,
+			Value:    big.NewInt(7),
+			Gas:      71000,
+			GasPrice: big.NewInt(200 * params.GWei),
+		}),
+	}
+
+	assertNoErrors := func(t *testing.T, errs []error) {
+		t.Helper()
+		for _, err := range errs {
+			require.NoError(t, err)
+		}
+	}
+
+	// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are local
+	t.Run("all local transactions", func(t *testing.T) {
+		miner := createCeloMiner(t)
+		txs := shuffle(txs)
+
+		errs := miner.txpool.Add(txs, true, false)
+		assertNoErrors(t, errs)
+
+		res := miner.generateWork(&generateParams{
+			parentHash: parentBlock.Hash(),
+			timestamp:  parentBlock.Time + 1,
+			random:     common.HexToHash("0xcafebabe"),
+			noTxs:      false,
+			forceTime:  true,
+		}, false)
+		require.NoError(t, res.err)
+
+		require.Len(t, res.block.Transactions(), len(txs))
+		for index, tx := range res.block.Transactions() {
+			assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
+		}
+	})
+
+	// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are remote
+	t.Run("all remote transactions", func(t *testing.T) {
+		miner := createCeloMiner(t)
+		txs := shuffle(txs)
+
+		miner.txpool.Clear()
+		errs := miner.txpool.Add(txs, false, false)
+		assertNoErrors(t, errs)
+
+		res := miner.generateWork(&generateParams{
+			parentHash: parentBlock.Hash(),
+			timestamp:  parentBlock.Time + 1,
+			random:     common.HexToHash("0xcafebabe"),
+			noTxs:      false,
+			forceTime:  true,
+		}, false)
+		require.NoError(t, res.err)
+
+		require.Len(t, res.block.Transactions(), len(txs))
+		for index, tx := range res.block.Transactions() {
+			assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
+		}
+	})
+
+	// verify that all transactions from Account1 are prioritized by adding them to the TxPool as local transactions,
+	// while transactions from Account2 are added as remote transactions
+	t.Run("mixed local & remote transactions", func(t *testing.T) {
+		miner := createCeloMiner(t)
+		txs := shuffle(txs)
+
+		var acc1TxNum, acc2TxNum uint64
+
+		miner.txpool.Clear()
+		// Add all transactions from account1 as local, and those from account2 as remote
+		for _, tx := range txs {
+			sender, err := types.Sender(signer, tx)
+			require.NoError(t, err)
+
+			isAccount1 := sender == address1
+			errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, false)
+			assertNoErrors(t, errs)
+
+			if isAccount1 {
+				acc1TxNum++
+			} else {
+				acc2TxNum++
+			}
+		}
+
+		res := miner.generateWork(&generateParams{
+			parentHash: parentBlock.Hash(),
+			timestamp:  parentBlock.Time + 1,
+			random:     common.HexToHash("0xcafebabe"),
+			noTxs:      false,
+			forceTime:  true,
+		}, false)
+		require.NoError(t, res.err)
+
+		var acc1TxCount, acc2TxCount uint64
+
+		require.Len(t, res.block.Transactions(), len(txs))
+		for _, tx := range res.block.Transactions() {
+			sender, _ := types.Sender(signer, tx)
+
+			if sender == address1 {
+				fmt.Printf("address1 %s\n", sender)
+				assert.Equal(t, acc1TxCount, tx.Nonce())
+				assert.Zero(t, acc2TxCount, "transactions from Account2 should not be ordered before transactions from Account1")
+				acc1TxCount++
+			} else {
+				fmt.Printf("address2 %s\n", sender)
+				assert.Equal(t, acc2TxCount, tx.Nonce())
+				assert.Equal(t, acc1TxNum, acc1TxCount, "transactions from Account1 should not be ordered after transactions from Account2")
+				acc2TxCount++
+			}
+		}
+	})
+}
+
+func shuffle[T any](original []T) []T {
+	shuffled := make([]T, len(original))
+	copy(shuffled, original)
+
+	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n := len(shuffled)
+	for i := n - 1; i > 0; i-- {
+		j := gen.Intn(i + 1)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	}
+
+	return shuffled
+}

--- a/miner/celo_worker_test.go
+++ b/miner/celo_worker_test.go
@@ -17,13 +17,13 @@
 package miner
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -41,77 +41,112 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		address1 = core.DevAddr
 		key2     = core.DevPrivateKey2
 
-		miner       = createCeloMiner(t)
-		signer      = types.LatestSigner(miner.chainConfig)
-		parentBlock = miner.chain.CurrentBlock()
+		miner        = createCeloMiner(t)
+		signer       = types.LatestSigner(miner.chainConfig)
+		parentHeader = miner.chain.CurrentBlock()
 	)
 
-	// BaseFee: 0.875 GWei
-	txs := []*types.Transaction{
-		// Effective: 100 GWei
-		types.MustSignNewTx(key1, signer, &types.LegacyTx{
-			Nonce:    0,
-			To:       &common.ZeroAddress,
-			Value:    big.NewInt(1),
-			Gas:      71000,
-			GasPrice: big.NewInt(100 * params.GWei),
-		}),
-		// Effective: 99 GWei
-		types.MustSignNewTx(key2, signer, &types.LegacyTx{
-			Nonce:    0,
-			To:       &common.ZeroAddress,
-			Value:    big.NewInt(2),
-			Gas:      71000,
-			GasPrice: big.NewInt(99 * params.GWei),
-		}),
-		// Effective: 98.875 GWei
-		types.MustSignNewTx(key2, signer, &types.DynamicFeeTx{
-			ChainID:   miner.chainConfig.ChainID,
-			Nonce:     1,
-			To:        &common.ZeroAddress,
-			Value:     big.NewInt(3),
-			Gas:       71000,
-			GasFeeCap: big.NewInt(10000 * params.GWei),
-			GasTipCap: big.NewInt(98 * params.GWei),
-		}),
-		// Effective: 97.875 GWei
-		types.MustSignNewTx(key1, signer, &types.CeloDynamicFeeTxV2{
-			ChainID:     miner.chainConfig.ChainID,
-			Nonce:       1,
-			To:          &common.ZeroAddress,
-			Value:       big.NewInt(4),
-			Gas:         71000,
-			GasFeeCap:   big.NewInt(10000 * params.GWei),
-			GasTipCap:   big.NewInt(194 * params.GWei),
-			FeeCurrency: &core.DevFeeCurrencyAddr,
-		}),
-		// Effective: 90 GWei
-		types.MustSignNewTx(key1, signer, &types.AccessListTx{
-			Nonce:    2,
-			To:       &common.ZeroAddress,
-			Value:    big.NewInt(5),
-			Gas:      71000,
-			GasPrice: big.NewInt(95 * params.GWei),
-		}),
-		// Effective: 50 GWei
-		types.MustSignNewTx(key2, signer, &types.LegacyTx{
-			Nonce:    2,
-			To:       &common.ZeroAddress,
-			Value:    big.NewInt(6),
-			Gas:      71000,
-			GasPrice: big.NewInt(50 * params.GWei),
-		}),
-		// Effective: 200 GWei
-		types.MustSignNewTx(key2, signer, &types.LegacyTx{
-			Nonce:    3,
-			To:       &common.ZeroAddress,
-			Value:    big.NewInt(7),
-			Gas:      71000,
-			GasPrice: big.NewInt(200 * params.GWei),
-		}),
+	txAndEffectiveGasPrices := []struct {
+		tx               *types.Transaction
+		expectedGasPrice *big.Int // expected effective gas price on Celo after base-fee reduction
+	}{
+		{
+			expectedGasPrice: big.NewInt(99.125 * params.GWei),
+			tx: types.MustSignNewTx(key1, signer, &types.LegacyTx{
+				Nonce:    0,
+				To:       &common.ZeroAddress,
+				Value:    big.NewInt(1),
+				Gas:      71000,
+				GasPrice: big.NewInt(100 * params.GWei),
+			}),
+		},
+		{
+			expectedGasPrice: big.NewInt(98.125 * params.GWei),
+			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
+				Nonce:    0,
+				To:       &common.ZeroAddress,
+				Value:    big.NewInt(2),
+				Gas:      71000,
+				GasPrice: big.NewInt(99 * params.GWei),
+			}),
+		},
+		{
+			expectedGasPrice: big.NewInt(98 * params.GWei),
+			tx: types.MustSignNewTx(key2, signer, &types.DynamicFeeTx{
+				ChainID:   miner.chainConfig.ChainID,
+				Nonce:     1,
+				To:        &common.ZeroAddress,
+				Value:     big.NewInt(3),
+				Gas:       71000,
+				GasFeeCap: big.NewInt(10000 * params.GWei),
+				GasTipCap: big.NewInt(98 * params.GWei),
+			}),
+		},
+		{
+			// 97.875 GWei
+			expectedGasPrice: big.NewInt(97 * params.GWei),
+			tx: types.MustSignNewTx(key1, signer, &types.CeloDynamicFeeTxV2{
+				ChainID:     miner.chainConfig.ChainID,
+				Nonce:       1,
+				To:          &common.ZeroAddress,
+				Value:       big.NewInt(4),
+				Gas:         71000,
+				GasFeeCap:   big.NewInt(10000 * params.GWei),
+				GasTipCap:   big.NewInt(194 * params.GWei),
+				FeeCurrency: &core.DevFeeCurrencyAddr,
+			}),
+		},
+		{
+			expectedGasPrice: big.NewInt(94.125 * params.GWei),
+			tx: types.MustSignNewTx(key1, signer, &types.AccessListTx{
+				Nonce:    2,
+				To:       &common.ZeroAddress,
+				Value:    big.NewInt(5),
+				Gas:      71000,
+				GasPrice: big.NewInt(95 * params.GWei),
+			}),
+		},
+		{
+			expectedGasPrice: big.NewInt(49.125 * params.GWei),
+			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
+				Nonce:    2,
+				To:       &common.ZeroAddress,
+				Value:    big.NewInt(6),
+				Gas:      71000,
+				GasPrice: big.NewInt(50 * params.GWei),
+			}),
+		},
+		{
+			expectedGasPrice: big.NewInt(199.125 * params.GWei),
+			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
+				Nonce:    3,
+				To:       &common.ZeroAddress,
+				Value:    big.NewInt(7),
+				Gas:      71000,
+				GasPrice: big.NewInt(200 * params.GWei),
+			}),
+		},
 	}
 
-	assertNoErrors := func(t *testing.T, errs []error) {
+	// Get BaseFee and Rates
+	baseFee := eip1559.CalcBaseFee(miner.chainConfig, parentHeader, parentHeader.Time+1)
+
+	stateDb, err := miner.backend.BlockChain().StateAt(parentHeader.Root)
+	require.NoError(t, err)
+	rates := core.GetExchangeRates(parentHeader, miner.chainConfig, stateDb)
+
+	// Creates a slice of transactions while validating effective gas prices
+	txs := make([]*types.Transaction, len(txAndEffectiveGasPrices))
+	for idx := range txAndEffectiveGasPrices {
+		txs[idx] = txAndEffectiveGasPrices[idx].tx
+
+		effectiveGasPrice, err := txs[idx].EffectiveGasTipInCelo(baseFee, rates)
+		require.NoError(t, err)
+
+		require.Equal(t, txAndEffectiveGasPrices[idx].expectedGasPrice, effectiveGasPrice)
+	}
+
+	requireNoErrors := func(t *testing.T, errs []error) {
 		t.Helper()
 		for _, err := range errs {
 			require.NoError(t, err)
@@ -124,11 +159,11 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		txs := shuffle(txs)
 
 		errs := miner.txpool.Add(txs, true, false)
-		assertNoErrors(t, errs)
+		requireNoErrors(t, errs)
 
 		res := miner.generateWork(&generateParams{
-			parentHash: parentBlock.Hash(),
-			timestamp:  parentBlock.Time + 1,
+			parentHash: parentHeader.Hash(),
+			timestamp:  parentHeader.Time + 1,
 			random:     common.HexToHash("0xcafebabe"),
 			noTxs:      false,
 			forceTime:  true,
@@ -148,11 +183,11 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 
 		miner.txpool.Clear()
 		errs := miner.txpool.Add(txs, false, false)
-		assertNoErrors(t, errs)
+		requireNoErrors(t, errs)
 
 		res := miner.generateWork(&generateParams{
-			parentHash: parentBlock.Hash(),
-			timestamp:  parentBlock.Time + 1,
+			parentHash: parentHeader.Hash(),
+			timestamp:  parentHeader.Time + 1,
 			random:     common.HexToHash("0xcafebabe"),
 			noTxs:      false,
 			forceTime:  true,
@@ -181,7 +216,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 
 			isAccount1 := sender == address1
 			errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, false)
-			assertNoErrors(t, errs)
+			requireNoErrors(t, errs)
 
 			if isAccount1 {
 				acc1TxNum++
@@ -191,8 +226,8 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		}
 
 		res := miner.generateWork(&generateParams{
-			parentHash: parentBlock.Hash(),
-			timestamp:  parentBlock.Time + 1,
+			parentHash: parentHeader.Hash(),
+			timestamp:  parentHeader.Time + 1,
 			random:     common.HexToHash("0xcafebabe"),
 			noTxs:      false,
 			forceTime:  true,
@@ -206,12 +241,10 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			sender, _ := types.Sender(signer, tx)
 
 			if sender == address1 {
-				fmt.Printf("address1 %s\n", sender)
 				assert.Equal(t, acc1TxCount, tx.Nonce())
 				assert.Zero(t, acc2TxCount, "transactions from Account2 should not be ordered before transactions from Account1")
 				acc1TxCount++
 			} else {
-				fmt.Printf("address2 %s\n", sender)
 				assert.Equal(t, acc2TxCount, tx.Nonce())
 				assert.Equal(t, acc1TxNum, acc1TxCount, "transactions from Account1 should not be ordered after transactions from Account2")
 				acc2TxCount++

--- a/miner/celo_worker_test.go
+++ b/miner/celo_worker_test.go
@@ -44,12 +44,12 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		parentHeader = miner.chain.CurrentBlock()
 	)
 
-	txAndExpectedGasPrices := []struct {
-		tx               *types.Transaction
-		expectedGasPrice *big.Int // expected effective gas price on Celo after base-fee reduction
+	txAndExpectedEffectiveTips := []struct {
+		tx                   *types.Transaction
+		expectedEffectiveTip *big.Int // expected effective gas price on Celo after base-fee reduction
 	}{
 		{
-			expectedGasPrice: big.NewInt(99.125 * params.GWei),
+			expectedEffectiveTip: big.NewInt(99.125 * params.GWei),
 			tx: types.MustSignNewTx(key1, signer, &types.LegacyTx{
 				Nonce:    0,
 				To:       &common.ZeroAddress,
@@ -59,7 +59,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(98.125 * params.GWei),
+			expectedEffectiveTip: big.NewInt(98.125 * params.GWei),
 			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
 				Nonce:    0,
 				To:       &common.ZeroAddress,
@@ -69,7 +69,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(98 * params.GWei),
+			expectedEffectiveTip: big.NewInt(98 * params.GWei),
 			tx: types.MustSignNewTx(key2, signer, &types.DynamicFeeTx{
 				ChainID:   miner.chainConfig.ChainID,
 				Nonce:     1,
@@ -81,7 +81,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(97 * params.GWei),
+			expectedEffectiveTip: big.NewInt(97 * params.GWei),
 			tx: types.MustSignNewTx(key1, signer, &types.CeloDynamicFeeTxV2{
 				ChainID:     miner.chainConfig.ChainID,
 				Nonce:       1,
@@ -94,7 +94,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(94.125 * params.GWei),
+			expectedEffectiveTip: big.NewInt(94.125 * params.GWei),
 			tx: types.MustSignNewTx(key1, signer, &types.AccessListTx{
 				Nonce:    2,
 				To:       &common.ZeroAddress,
@@ -104,7 +104,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(49.125 * params.GWei),
+			expectedEffectiveTip: big.NewInt(49.125 * params.GWei),
 			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
 				Nonce:    2,
 				To:       &common.ZeroAddress,
@@ -114,7 +114,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			expectedGasPrice: big.NewInt(199.125 * params.GWei),
+			expectedEffectiveTip: big.NewInt(199.125 * params.GWei),
 			tx: types.MustSignNewTx(key2, signer, &types.LegacyTx{
 				Nonce:    3,
 				To:       &common.ZeroAddress,
@@ -159,14 +159,14 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 	rates := core.GetExchangeRates(parentHeader, miner.chainConfig, stateDb)
 
 	// Creates a slice of transactions while validating effective gas prices
-	txs := make([]*types.Transaction, len(txAndExpectedGasPrices))
-	for idx := range txAndExpectedGasPrices {
-		txs[idx] = txAndExpectedGasPrices[idx].tx
+	txs := make([]*types.Transaction, len(txAndExpectedEffectiveTips))
+	for idx := range txAndExpectedEffectiveTips {
+		txs[idx] = txAndExpectedEffectiveTips[idx].tx
 
 		effectiveGasPrice, err := txs[idx].EffectiveGasTipInCelo(baseFee, rates)
 		require.NoError(t, err)
 
-		require.Equal(t, txAndExpectedGasPrices[idx].expectedGasPrice, effectiveGasPrice)
+		require.Equal(t, txAndExpectedEffectiveTips[idx].expectedEffectiveTip, effectiveGasPrice)
 	}
 
 	requireNoErrors := func(t *testing.T, errs []error) {

--- a/miner/celo_worker_test.go
+++ b/miner/celo_worker_test.go
@@ -18,9 +18,7 @@ package miner
 
 import (
 	"math/big"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -46,7 +44,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		parentHeader = miner.chain.CurrentBlock()
 	)
 
-	txAndEffectiveGasPrices := []struct {
+	txAndExpectedGasPrices := []struct {
 		tx               *types.Transaction
 		expectedGasPrice *big.Int // expected effective gas price on Celo after base-fee reduction
 	}{
@@ -83,7 +81,6 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			}),
 		},
 		{
-			// 97.875 GWei
 			expectedGasPrice: big.NewInt(97 * params.GWei),
 			tx: types.MustSignNewTx(key1, signer, &types.CeloDynamicFeeTxV2{
 				ChainID:     miner.chainConfig.ChainID,
@@ -128,6 +125,32 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		},
 	}
 
+	testCases := []struct {
+		name      string
+		txIndices []int // list of indices used to determine order of transactions
+	}{
+		{
+			name:      "original order",
+			txIndices: []int{0, 1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:      "reverse order",
+			txIndices: []int{6, 5, 4, 3, 2, 1, 0},
+		},
+		{
+			name:      "Account 1’s transactions first, followed by Account 2’s transactions",
+			txIndices: []int{0, 3, 4, 1, 2, 5, 6},
+		},
+		{
+			name:      "Account 2’s transactions first, followed by Account 1’s transactions",
+			txIndices: []int{1, 2, 5, 6, 0, 3, 4},
+		},
+		{
+			name:      "random order",
+			txIndices: []int{3, 0, 5, 1, 6, 2, 4},
+		},
+	}
+
 	// Get BaseFee and Rates
 	baseFee := eip1559.CalcBaseFee(miner.chainConfig, parentHeader, parentHeader.Time+1)
 
@@ -136,14 +159,14 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 	rates := core.GetExchangeRates(parentHeader, miner.chainConfig, stateDb)
 
 	// Creates a slice of transactions while validating effective gas prices
-	txs := make([]*types.Transaction, len(txAndEffectiveGasPrices))
-	for idx := range txAndEffectiveGasPrices {
-		txs[idx] = txAndEffectiveGasPrices[idx].tx
+	txs := make([]*types.Transaction, len(txAndExpectedGasPrices))
+	for idx := range txAndExpectedGasPrices {
+		txs[idx] = txAndExpectedGasPrices[idx].tx
 
 		effectiveGasPrice, err := txs[idx].EffectiveGasTipInCelo(baseFee, rates)
 		require.NoError(t, err)
 
-		require.Equal(t, txAndEffectiveGasPrices[idx].expectedGasPrice, effectiveGasPrice)
+		require.Equal(t, txAndExpectedGasPrices[idx].expectedGasPrice, effectiveGasPrice)
 	}
 
 	requireNoErrors := func(t *testing.T, errs []error) {
@@ -153,116 +176,113 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 		}
 	}
 
-	// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are local
-	t.Run("all local transactions", func(t *testing.T) {
-		miner := createCeloMiner(t)
-		txs := shuffle(txs)
-
-		errs := miner.txpool.Add(txs, true, false)
-		requireNoErrors(t, errs)
-
-		res := miner.generateWork(&generateParams{
-			parentHash: parentHeader.Hash(),
-			timestamp:  parentHeader.Time + 1,
-			random:     common.HexToHash("0xcafebabe"),
-			noTxs:      false,
-			forceTime:  true,
-		}, false)
-		require.NoError(t, res.err)
-
-		require.Len(t, res.block.Transactions(), len(txs))
-		for index, tx := range res.block.Transactions() {
-			assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
+	reorderTxs := func(original []*types.Transaction, indicies []int) []*types.Transaction {
+		ordered := make([]*types.Transaction, len(original))
+		for idx := range indicies {
+			ordered[idx] = original[indicies[idx]]
 		}
-	})
-
-	// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are remote
-	t.Run("all remote transactions", func(t *testing.T) {
-		miner := createCeloMiner(t)
-		txs := shuffle(txs)
-
-		miner.txpool.Clear()
-		errs := miner.txpool.Add(txs, false, false)
-		requireNoErrors(t, errs)
-
-		res := miner.generateWork(&generateParams{
-			parentHash: parentHeader.Hash(),
-			timestamp:  parentHeader.Time + 1,
-			random:     common.HexToHash("0xcafebabe"),
-			noTxs:      false,
-			forceTime:  true,
-		}, false)
-		require.NoError(t, res.err)
-
-		require.Len(t, res.block.Transactions(), len(txs))
-		for index, tx := range res.block.Transactions() {
-			assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
-		}
-	})
-
-	// verify that all transactions from Account1 are prioritized by adding them to the TxPool as local transactions,
-	// while transactions from Account2 are added as remote transactions
-	t.Run("mixed local & remote transactions", func(t *testing.T) {
-		miner := createCeloMiner(t)
-		txs := shuffle(txs)
-
-		var acc1TxNum, acc2TxNum uint64
-
-		miner.txpool.Clear()
-		// Add all transactions from account1 as local, and those from account2 as remote
-		for _, tx := range txs {
-			sender, err := types.Sender(signer, tx)
-			require.NoError(t, err)
-
-			isAccount1 := sender == address1
-			errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, false)
-			requireNoErrors(t, errs)
-
-			if isAccount1 {
-				acc1TxNum++
-			} else {
-				acc2TxNum++
-			}
-		}
-
-		res := miner.generateWork(&generateParams{
-			parentHash: parentHeader.Hash(),
-			timestamp:  parentHeader.Time + 1,
-			random:     common.HexToHash("0xcafebabe"),
-			noTxs:      false,
-			forceTime:  true,
-		}, false)
-		require.NoError(t, res.err)
-
-		var acc1TxCount, acc2TxCount uint64
-
-		require.Len(t, res.block.Transactions(), len(txs))
-		for _, tx := range res.block.Transactions() {
-			sender, _ := types.Sender(signer, tx)
-
-			if sender == address1 {
-				assert.Equal(t, acc1TxCount, tx.Nonce())
-				assert.Zero(t, acc2TxCount, "transactions from Account2 should not be ordered before transactions from Account1")
-				acc1TxCount++
-			} else {
-				assert.Equal(t, acc2TxCount, tx.Nonce())
-				assert.Equal(t, acc1TxNum, acc1TxCount, "transactions from Account1 should not be ordered after transactions from Account2")
-				acc2TxCount++
-			}
-		}
-	})
-}
-
-func shuffle[T any](original []T) []T {
-	shuffled := make([]T, len(original))
-	copy(shuffled, original)
-
-	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
-	n := len(shuffled)
-	for i := n - 1; i > 0; i-- {
-		j := gen.Intn(i + 1)
-		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		return ordered
 	}
 
-	return shuffled
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			txs := reorderTxs(txs, test.txIndices)
+
+			// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are local
+			t.Run("all local transactions", func(t *testing.T) {
+				miner := createCeloMiner(t)
+
+				errs := miner.txpool.Add(txs, true, false)
+				requireNoErrors(t, errs)
+
+				res := miner.generateWork(&generateParams{
+					parentHash: parentHeader.Hash(),
+					timestamp:  parentHeader.Time + 1,
+					random:     common.HexToHash("0xcafebabe"),
+					noTxs:      false,
+					forceTime:  true,
+				}, false)
+				require.NoError(t, res.err)
+
+				require.Len(t, res.block.Transactions(), len(txs))
+				for index, tx := range res.block.Transactions() {
+					assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
+				}
+			})
+
+			// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are remote
+			t.Run("all remote transactions", func(t *testing.T) {
+				miner := createCeloMiner(t)
+
+				miner.txpool.Clear()
+				errs := miner.txpool.Add(txs, false, false)
+				requireNoErrors(t, errs)
+
+				res := miner.generateWork(&generateParams{
+					parentHash: parentHeader.Hash(),
+					timestamp:  parentHeader.Time + 1,
+					random:     common.HexToHash("0xcafebabe"),
+					noTxs:      false,
+					forceTime:  true,
+				}, false)
+				require.NoError(t, res.err)
+
+				require.Len(t, res.block.Transactions(), len(txs))
+				for index, tx := range res.block.Transactions() {
+					assert.Equal(t, tx.Value(), big.NewInt(int64(index+1)))
+				}
+			})
+
+			// verify that all transactions from Account1 are prioritized by adding them to the TxPool as local transactions,
+			// while transactions from Account2 are added as remote transactions
+			t.Run("mixed local & remote transactions", func(t *testing.T) {
+				miner := createCeloMiner(t)
+
+				var acc1TxNum, acc2TxNum uint64
+
+				miner.txpool.Clear()
+				// Add all transactions from account1 as local, and those from account2 as remote
+				for _, tx := range txs {
+					sender, err := types.Sender(signer, tx)
+					require.NoError(t, err)
+
+					isAccount1 := sender == address1
+					errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, false)
+					requireNoErrors(t, errs)
+
+					if isAccount1 {
+						acc1TxNum++
+					} else {
+						acc2TxNum++
+					}
+				}
+
+				res := miner.generateWork(&generateParams{
+					parentHash: parentHeader.Hash(),
+					timestamp:  parentHeader.Time + 1,
+					random:     common.HexToHash("0xcafebabe"),
+					noTxs:      false,
+					forceTime:  true,
+				}, false)
+				require.NoError(t, res.err)
+
+				var acc1TxCount, acc2TxCount uint64
+
+				require.Len(t, res.block.Transactions(), len(txs))
+				for _, tx := range res.block.Transactions() {
+					sender, _ := types.Sender(signer, tx)
+
+					if sender == address1 {
+						assert.Equal(t, acc1TxCount, tx.Nonce())
+						assert.Zero(t, acc2TxCount, "transactions from Account2 should not be ordered before transactions from Account1")
+						acc1TxCount++
+					} else {
+						assert.Equal(t, acc2TxCount, tx.Nonce())
+						assert.Equal(t, acc1TxNum, acc1TxCount, "transactions from Account1 should not be ordered after transactions from Account2")
+						acc2TxCount++
+					}
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/celo-org/op-geth/issues/358

This PR adds tests to verify transaction ordering by the miner, taking into fee currency conversion and transaction locality — scenarios that are not covered by existing tests.

This PR also adds a new seed account to `CeloGenesisAccounts` for the tests.
