### PR TITLE
Fix failing e2e test

### DIFF
--- a/contracts/celo_backend.go
+++ b/contracts/celo_backend.go
@@ -69,6 +69,7 @@ func (b *CeloBackend) NewEVM(feeCurrencyContext *common.FeeCurrencyContext) *vm.
 				panic("Non-zero transfers not implemented, yet.")
 			}
 		},
+		Random: &common.Hash{}, // Setting this is important since it is used to set IsMerge
 	}
 	if feeCurrencyContext != nil {
 		blockCtx.FeeCurrencyContext = *feeCurrencyContext

--- a/e2e_test/debug-fee-currency/lib.sh
+++ b/e2e_test/debug-fee-currency/lib.sh
@@ -19,7 +19,7 @@ function deploy_fee_currency() {
 	(
 		DEFAULT_INTRINSIC_GAS=60000
 		local fee_currency=$(
-			forge create --json --broadcast --root "$SCRIPT_DIR/debug-fee-currency" --contracts "$SCRIPT_DIR/debug-fee-currency" --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 $3 | jq .deployedTo -r
+			forge create --json --root "$SCRIPT_DIR/debug-fee-currency" --contracts "$SCRIPT_DIR/debug-fee-currency" --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 $3 | jq .deployedTo -r
 		)
 		if [ -z "${fee_currency}" ]; then
 			exit 1

--- a/e2e_test/debug-fee-currency/lib.sh
+++ b/e2e_test/debug-fee-currency/lib.sh
@@ -89,3 +89,21 @@ function assert_cip_64_tx() {
 function estimate_tx() {
 	$SCRIPT_DIR/js-tests/estimate_tx.mjs "$(cast chain-id)" $1 $2
 }
+
+# args:
+# 	$1: feeCurrency (address):
+function enable_block_list_fee_currency() {
+	cast rpc admin_enableBlocklistFeeCurrencies '["'"$1"'"]'
+}
+
+# args:
+# 	$1: feeCurrency (address):
+function disable_block_list_fee_currency() {
+	cast rpc admin_disableBlocklistFeeCurrencies '["'"$1"'"]'
+}
+
+# args:
+# 	$1: feeCurrency (address):
+function unblock_fee_currency() {
+	cast rpc admin_unblockFeeCurrency $1
+}

--- a/e2e_test/debug-fee-currency/lib.sh
+++ b/e2e_test/debug-fee-currency/lib.sh
@@ -19,7 +19,7 @@ function deploy_fee_currency() {
 	(
 		DEFAULT_INTRINSIC_GAS=60000
 		local fee_currency=$(
-			forge create --root "$SCRIPT_DIR/debug-fee-currency" --contracts "$SCRIPT_DIR/debug-fee-currency" --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 $3 --json | jq .deployedTo -r
+			forge create --json --broadcast --root "$SCRIPT_DIR/debug-fee-currency" --contracts "$SCRIPT_DIR/debug-fee-currency" --private-key $ACC_PRIVKEY DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args '100000000000000000000000000' $1 $2 $3 | jq .deployedTo -r
 		)
 		if [ -z "${fee_currency}" ]; then
 			exit 1

--- a/e2e_test/run_all_tests.sh
+++ b/e2e_test/run_all_tests.sh
@@ -11,7 +11,7 @@ if [ -z $NETWORK ]; then
     cd "$SCRIPT_DIR/.." || exit 1
     make geth
     trap 'kill %%' EXIT # kill bg job at exit
-    build/bin/geth --dev --http --http.api eth,web3,net --txpool.nolocals &>"$SCRIPT_DIR/geth.log" &
+    build/bin/geth --dev --http --http.api eth,web3,net,admin --txpool.nolocals &>"$SCRIPT_DIR/geth.log" &
     
     # Wait for geth to be ready
     for _ in {1..10}; do
@@ -39,7 +39,7 @@ for f in test_*"$TEST_GLOB"*; do
 	if [[ -n $NETWORK ]]; then
 		case $f in
 		  # Skip tests that require a local network.
-		  test_fee_currency_fails_on_credit.sh|test_fee_currency_fails_on_debit.sh|test_fee_currency_fails_intrinsic.sh|test_value_and_fee_currency_balance_check.sh|test_fee_currency_gas_estimation.sh)
+		  test_fee_currency_fails_on_credit.sh|test_fee_currency_fails_on_debit.sh|test_fee_currency_fails_intrinsic.sh|test_value_and_fee_currency_balance_check.sh|test_fee_currency_gas_estimation.sh|test_fee_currency_disable_blocking.sh|test_fee_currency_disable_and_enable_blocking.sh|test_fee_currency_unblock.sh)
 		  echo "skipping file $f"
 		  continue
 		  ;;

--- a/e2e_test/test_fee_currency_disable_and_enable_blocking.sh
+++ b/e2e_test/test_fee_currency_disable_and_enable_blocking.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+set -eo pipefail
+
+source shared.sh
+source debug-fee-currency/lib.sh
+
+tail -F -n0 geth.log >debug-fee-currency/geth.disable_and_enable_blocking.log & # start log capture
+trap 'kill %%' EXIT # kill bg tail job on exit
+(
+	sleep 0.2
+	fee_currency=$(deploy_fee_currency false false true)
+
+	# Disable and Enable blocking for the fee currency
+	disable_block_list_fee_currency $fee_currency
+	enable_block_list_fee_currency $fee_currency
+
+	# trigger the first failed call to the CreditFees(), causing the
+	# currency to get temporarily blocklisted.
+	cip_64_tx $fee_currency 1 true 2 | assert_cip_64_tx false
+
+	sleep 2
+
+	# since the fee currency is temporarily blocked,
+	# this should NOT make the transaction execute anymore,
+	# but invalidate the transaction earlier.
+	cip_64_tx $fee_currency 1 true 2 | assert_cip_64_tx false
+
+	cleanup_fee_currency $fee_currency
+)
+sleep 0.5
+# Even though we send the faulty fee‑currency transaction twice,
+# the execution error should occur only once.
+if [ "$(grep -Ec "fee-currency EVM execution error.+fee-currency contract error during internal EVM call: surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency" debug-fee-currency/geth.disable_and_enable_blocking.log)" -ne 1 ]; then exit 1; fi

--- a/e2e_test/test_fee_currency_disable_blocking.sh
+++ b/e2e_test/test_fee_currency_disable_blocking.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+set -eo pipefail
+
+source shared.sh
+source debug-fee-currency/lib.sh
+
+tail -F -n0 geth.log >debug-fee-currency/geth.disable_blocking.log & # start log capture
+trap 'kill %%' EXIT # kill bg tail job on exit
+(
+	sleep 0.2
+	fee_currency=$(deploy_fee_currency false false true)
+
+	# Disable blocking for the fee currency
+	disable_block_list_fee_currency $fee_currency
+
+	# Send a transaction that is expected to fail
+	# It should be processed across several consecutive block builds.
+	cip_64_tx $fee_currency 1 true 2 | assert_cip_64_tx false
+
+	sleep 2
+
+	cleanup_fee_currency $fee_currency
+)
+sleep 0.5
+# Because blocking was disabled, the execution error should appear multiple times
+if [ "$(grep -Ec "fee-currency EVM execution error.+fee-currency contract error during internal EVM call: surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency" debug-fee-currency/geth.disable_blocking.log)" -le 1 ]; then exit 1; fi

--- a/e2e_test/test_fee_currency_fails_intrinsic.sh
+++ b/e2e_test/test_fee_currency_fails_intrinsic.sh
@@ -30,4 +30,4 @@ trap 'kill %%' EXIT # kill bg tail job on exit
 sleep 0.5
 # although we sent a transaction wih faulty fee-currency twice,
 # the EVM call should have been executed only once
-if [ "$(grep -Ec "fee-currency EVM execution error, temporarily blocking fee-currency in local txpools .+ surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency" debug-fee-currency/geth.intrinsic.log)" -ne 1 ]; then exit 1; fi
+if [ "$(grep -Ec "fee-currency EVM execution error.+fee-currency contract error during internal EVM call: surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency" debug-fee-currency/geth.intrinsic.log)" -ne 1 ]; then exit 1; fi

--- a/e2e_test/test_fee_currency_fails_on_credit.sh
+++ b/e2e_test/test_fee_currency_fails_on_credit.sh
@@ -29,5 +29,4 @@ trap 'kill %%' EXIT # kill bg tail job on exit
 sleep 0.5
 # although we sent a transaction wih faulty fee-currency twice,
 # the EVM call should have been executed only once
-grep "" debug-fee-currency/geth.partial.log
-if [ "$(grep -Ec "fee-currency EVM execution error, temporarily blocking fee-currency in local txpools .+ This DebugFeeCurrency always fails in \(old\) creditGasFees!" debug-fee-currency/geth.partial.log)" -ne 1 ]; then exit 1; fi
+if [ "$(grep -Ec "fee-currency EVM execution error.+fee-currency contract error during internal EVM call: CreditFees\(\) call error: creditGasFees reverted: This DebugFeeCurrency always fails in \(old\) creditGasFees!" debug-fee-currency/geth.partial.log)" -ne 1 ]; then exit 1; fi

--- a/e2e_test/test_fee_currency_unblock.sh
+++ b/e2e_test/test_fee_currency_unblock.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+set -eo pipefail
+
+source shared.sh
+source debug-fee-currency/lib.sh
+
+tail -F -n0 geth.log >debug-fee-currency/geth.unblock_fee_currency.log & # start log capture
+trap 'kill %%' EXIT # kill bg tail job on exit
+(
+	sleep 0.2
+	fee_currency=$(deploy_fee_currency false false true)
+
+	# trigger the first failed call to the CreditFees(), causing the
+	# currency to get temporarily blocklisted
+	cip_64_tx $fee_currency 1 true 2 | assert_cip_64_tx false
+
+	sleep 2
+	# Unblock the currency via the admin API
+	unblock_fee_currency $fee_currency
+
+	# since the fee currency was unblocked,
+	# this should be executed in miner
+	cip_64_tx $fee_currency 1 true 2 | assert_cip_64_tx false
+
+	cleanup_fee_currency $fee_currency
+)
+sleep 0.5
+# expect the execution error to appear twice
+if [ "$(grep -Ec "fee-currency EVM execution error.+fee-currency contract error during internal EVM call: surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency" debug-fee-currency/geth.unblock_fee_currency.log)" -ne 2 ]; then exit 1; fi


### PR DESCRIPTION
Resolves https://github.com/celo-org/celo-blockchain-planning/issues/999

This PR fixes several e2e tests that fail due to recent changes.
- Adds Random field to the block context for `TryDebitFees`, which is required to enable Shanghai fork in EVM layer
- Fixes log assertions in several existing e2e tests.

Additionally, this PR introduces a few e2e tests for admin fee currency control API that has been added in https://github.com/celo-org/op-geth/pull/364/files