### PR TITLE
Skip e2e test fee currency unblock

### DIFF
--- a/e2e_test/run_all_tests.sh
+++ b/e2e_test/run_all_tests.sh
@@ -43,7 +43,15 @@ for f in test_*"$TEST_GLOB"*; do
 		  echo "skipping file $f"
 		  continue
 		  ;;
-	    esac
+		esac
+	else
+		# test_fee_currency_unblock is currenty failing on the tip of celo-rebase-12
+		case $f in
+		  test_fee_currency_unblock.sh)
+		  echo "skipping file $f"
+		  continue
+		  ;;
+		esac
 	fi
 	echo -e "\nRun $f"
 	if "./$f"; then


### PR DESCRIPTION
This test is failing for me when run locally

Environment:
```
forge --version
forge 0.2.0 (143abd6 2024-09-04T00:24:41.963834000Z)
```

Log:
```
./e2e_test/run_all_tests.sh  unblock
Using local network
go run build/ci.go install ./cmd/geth
>>> /nix/store/s9lcj79q6p6bnx4jwlf310ar9vhnf0g5-go-1.23.5/share/go/bin/go build -ldflags "--buildid=none -X github.com/ethereum/go-ethereum/internal/version.gitCommit=c326d0ac6b11a9405fc47963f85549c2d182e556 -X github.com/ethereum/go-ethereum/internal/version.gitDate=20250423 -s" -tags urfave_cli_no_docs,ckzg -trimpath -v -o /Users/pierspowlesland/projects/op-geth/build/bin/geth ./cmd/geth
Done building.
Run "./build/bin/geth" to launch geth.
Geth ready, start tests
Error:
server returned an error response: error code -32000: transaction indexing is in progress, data: "transaction indexing is in progress"
Globbing with "unblock"
for file test_fee_currency_unblock.sh

Run test_fee_currency_unblock.sh
Using local network
+ trap 'kill %%' EXIT
+ tail -F -n0 geth.log
+ sleep 0.2
++ deploy_fee_currency false false true
++ DEFAULT_INTRINSIC_GAS=60000
+++ forge create --json --root /Users/pierspowlesland/projects/op-geth/e2e_test/debug-fee-currency --contracts /Users/pierspowlesland/projects/op-geth/e2e_test/debug-fee-currency --private-key 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 DebugFeeCurrency.sol:DebugFeeCurrency --constructor-args 100000000000000000000000000 false false true
+++ jq .deployedTo -r
++ local fee_currency=0x585809932b336Cc0F8F7bc6f157801d4266A7483
++ '[' -z 0x585809932b336Cc0F8F7bc6f157801d4266A7483 ']'
++ cast send --private-key 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0003 'setExchangeRate(address, uint256, uint256)' 0x585809932b336Cc0F8F7bc6f157801d4266A7483 2ether 1ether
++ cast send --private-key 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276 'setCurrencyConfig(address, address, uint256)' 0x585809932b336Cc0F8F7bc6f157801d4266A7483 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0003 60000
++ echo 0x585809932b336Cc0F8F7bc6f157801d4266A7483
+ fee_currency=0x585809932b336Cc0F8F7bc6f157801d4266A7483
+ cip_64_tx 0x585809932b336Cc0F8F7bc6f157801d4266A7483 1 true 2
+ assert_cip_64_tx false
+ local value
+ read -r value
++ cast chain-id
+ /Users/pierspowlesland/projects/op-geth/e2e_test/js-tests/send_tx.mjs 1337 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 0x585809932b336Cc0F8F7bc6f157801d4266A7483 1 true 2
+ local expected_error=
++ echo '{"success":false,"replaced":false,"error":null}'
++ jq .success
+ '[' false '!=' false ']'
+ '[' -z '' ']'
+ expected_error=null
+ echo '{"success":false,"replaced":false,"error":null}'
+ jq .error
+ grep -qE null
+ sleep 2
+ unblock_fee_currency 0x585809932b336Cc0F8F7bc6f157801d4266A7483
+ cast rpc admin_unblockFeeCurrency 0x585809932b336Cc0F8F7bc6f157801d4266A7483
true
+ cip_64_tx 0x585809932b336Cc0F8F7bc6f157801d4266A7483 1 true 2
+ assert_cip_64_tx false
+ local value
+ read -r value
++ cast chain-id
+ /Users/pierspowlesland/projects/op-geth/e2e_test/js-tests/send_tx.mjs 1337 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 0x585809932b336Cc0F8F7bc6f157801d4266A7483 1 true 2
+ local expected_error=
++ echo '{"success":false,"replaced":false,"error":null}'
++ jq .success
+ '[' false '!=' false ']'
+ '[' -z '' ']'
+ expected_error=null
+ echo '{"success":false,"replaced":false,"error":null}'
+ jq .error
+ grep -qE null
+ cleanup_fee_currency 0x585809932b336Cc0F8F7bc6f157801d4266A7483
+ local fee_currency=0x585809932b336Cc0F8F7bc6f157801d4266A7483
+ cast send --private-key 0x2771aff413cac48d9f8c114fabddd9195a2129f3c2c436caa07e27bb7f58ead5 0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276 'removeCurrencies(address, uint256)' 0x585809932b336Cc0F8F7bc6f157801d4266A7483 2 --json
+ jq 'if .status == "0x1" then 0 else 1 end' -r
0
+ sleep 0.5
++ grep -Ec 'fee-currency EVM execution error.+fee-currency contract error during internal EVM call: surpassed maximum allowed intrinsic gas for CreditFees\(\) in fee-currency' debug-fee-currency/geth.unblock_fee_currency.log
+ '[' 1 -ne 2 ']'
+ exit 1
+ kill %%
FAIL test_fee_currency_unblock.sh ❌

1/1 failed.
```