### PR TITLE
Disable custom L1 cost function for Alfajores from Holocene upgrade

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -126,7 +126,7 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	selectFunc := func(blockTime uint64) l1CostFunc {
 		// Alfajores requires a custom cost function see link for a detailed explanation
 		// https://github.com/celo-org/op-geth/pull/271
-		if config.IsCel2(blockTime) && config.ChainID.Uint64() == params.CeloAlfajoresChainID {
+		if config.IsCel2(blockTime) && !config.IsHolocene(blockTime) && config.ChainID.Uint64() == params.CeloAlfajoresChainID {
 			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
 		}
 		if !config.IsOptimismEcotone(blockTime) {


### PR DESCRIPTION
This PR disabled a custom L1 cost function for Alfajores, which has been introduced in https://github.com/celo-org/op-geth/pull/271, from next upgrade, Holocene.

This change will have no effect to L1‑cost fee on Alfajores because all networks already set L1 fee scalar to zero. However, it brings Alfajores into closer alignment with Mainnet.