### PR TITLE
Fix flaky issue in TestMinerFillTransactionsOrdering

### DIFF
--- a/miner/celo_worker_test.go
+++ b/miner/celo_worker_test.go
@@ -191,8 +191,9 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are local
 			t.Run("all local transactions", func(t *testing.T) {
 				miner := createCeloMiner(t)
+				parentHeader = miner.chain.CurrentBlock()
 
-				errs := miner.txpool.Add(txs, true, false)
+				errs := miner.txpool.Add(txs, true, true)
 				requireNoErrors(t, errs)
 
 				res := miner.generateWork(&generateParams{
@@ -200,7 +201,6 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 					timestamp:  parentHeader.Time + 1,
 					random:     common.HexToHash("0xcafebabe"),
 					noTxs:      false,
-					forceTime:  true,
 				}, false)
 				require.NoError(t, res.err)
 
@@ -213,9 +213,10 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			// Verify that transaction ordering depends only on nonce and gas price when all transactions in the TxPool are remote
 			t.Run("all remote transactions", func(t *testing.T) {
 				miner := createCeloMiner(t)
+				parentHeader = miner.chain.CurrentBlock()
 
 				miner.txpool.Clear()
-				errs := miner.txpool.Add(txs, false, false)
+				errs := miner.txpool.Add(txs, false, true)
 				requireNoErrors(t, errs)
 
 				res := miner.generateWork(&generateParams{
@@ -237,6 +238,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 			// while transactions from Account2 are added as remote transactions
 			t.Run("mixed local & remote transactions", func(t *testing.T) {
 				miner := createCeloMiner(t)
+				parentHeader := miner.chain.CurrentBlock()
 
 				var acc1TxNum, acc2TxNum uint64
 
@@ -247,7 +249,7 @@ func TestMinerFillTransactionsOrdering(t *testing.T) {
 					require.NoError(t, err)
 
 					isAccount1 := sender == address1
-					errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, false)
+					errs := miner.txpool.Add([]*types.Transaction{tx}, isAccount1, true)
 					requireNoErrors(t, errs)
 
 					if isAccount1 {


### PR DESCRIPTION
Fix https://github.com/celo-org/celo-blockchain-planning/issues/1028

This PR fixes flaky issue of TestMinerFillTransactionsOrdering which was added in https://github.com/celo-org/op-geth/pull/369

- Change `sync` args in TxPool's `Add` call to true in order to ensure promotion to complete before starting miner's task 
- Get `parentHeader` in each test scope, not global scope

I confirmed that running TestMinerFillTransactionsOrdering 1,000 times locally resulted in zero failures.

```bash
$ go test -count=1000 -run=^TestMinerFillTransactionsOrdering$ ./miner/...
```