### PR TITLE
Use realistic config for dev mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2024,7 +2024,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Info("Using developer account", "address", developer.Address)
 
 		// Create a new developer genesis block or reuse existing one
-		cfg.Genesis = core.DeveloperGenesisBlock(ctx.Uint64(DeveloperGasLimitFlag.Name), &developer.Address)
+		cfg.Genesis = core.CeloDeveloperGenesisBlock(ctx.Uint64(DeveloperGasLimitFlag.Name), &developer.Address)
 		if ctx.IsSet(DataDirFlag.Name) {
 			chaindb := tryMakeReadOnlyDatabase(ctx, stack)
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {

--- a/core/celo_genesis.go
+++ b/core/celo_genesis.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/contracts/celo"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // Decode 0x prefixed hex string from file (including trailing newline)
@@ -182,4 +183,27 @@ func (g *Genesis) SetInitingGenesis() {
 // InitingGenesis returns true if this genesis is being used in the initGenesis operation.
 func (g *Genesis) InitingGenesis() bool {
 	return g.initingGenesis
+}
+
+// CeloDeveloperGenesisBlock returns the 'geth --dev' genesis block with Celo-specific configurations.
+// It differs from the standard DeveloperGenesisBlock in that it:
+// 1. Uses a more realistic chain configuration that mirrors mainnet settings
+// 2. Includes Celo-specific genesis accounts and contract deployments
+// 3. Sets up fee currency contracts and mock oracles for testing
+//
+// This ensures that development mode behaves as closely as possible to mainnet,
+// making it more suitable for testing and development purposes.
+func CeloDeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
+	genesis := DeveloperGenesisBlock(gasLimit, faucet)
+
+	// Set our own more realistic config
+	config := *params.DevChainConfig
+	genesis.Config = &config
+
+	// Add state from celoGenesisAccounts
+	for addr, data := range CeloGenesisAccounts(common.HexToAddress("0x2")) {
+		genesis.Alloc[addr] = data
+	}
+
+	return genesis
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -828,12 +828,6 @@ func DeveloperGenesisBlock(gasLimit uint64, faucet *common.Address) *Genesis {
 	if faucet != nil {
 		genesis.Alloc[*faucet] = types.Account{Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))}
 	}
-
-	// Add state from celoGenesisAccounts
-	for addr, data := range CeloGenesisAccounts(common.HexToAddress("0x2")) {
-		genesis.Alloc[addr] = data
-	}
-
 	return genesis
 }
 

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -66,10 +66,6 @@ async function sendTypedCreateTransaction(type, feeCurrency) {
 	describe("viem smoke test, tx type " + type, () => {
 		const feeCurrency = type == "cip64" ? process.env.FEE_CURRENCY.toLowerCase() : undefined;
 		let l1Fee = 0n;
-		if (!process.env.NETWORK) {
-			// Local dev chain does not have L1 fees (Optimism is unset)
-			l1Fee = undefined;
-		}
 		it("send tx", async () => {
 			const send = await sendTypedTransaction(type, feeCurrency);
 			await check(send, {type, feeCurrency}, {l1Fee});

--- a/e2e_test/test_base_fee_recipient.sh
+++ b/e2e_test/test_base_fee_recipient.sh
@@ -11,12 +11,10 @@ block_number=$(echo $tx_json | jq -r '.blockNumber' | cast to-dec)
 block=$(cast block --json --full $block_number)
 gas_used=$(echo $block | jq -r '.gasUsed' | cast to-dec)
 base_fee=$(echo $block | jq -r '.baseFeePerGas' | cast to-dec)
-if [[ -n $NETWORK  ]]; then
-	# Every block in a non dev system contains a system tx that pays nothing for gas so we must subtract this from the total gas per block
-	system_tx_hash=$(echo $block | jq -r '.transactions[] | select(.from | ascii_downcase  == "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001") | .hash')
-	system_tx_gas=$(cast receipt --json $system_tx_hash | jq -r '.cumulativeGasUsed' | cast to-dec)
-	gas_used=$((gas_used - system_tx_gas))
-fi
+# Every block contains a system tx (the first tx) that pays nothing for gas so we must subtract this from the total gas per block
+system_tx_hash=$(echo $block | jq -r '.transactions[0] | .hash')
+system_tx_gas=$(cast receipt --json $system_tx_hash | jq -r '.cumulativeGasUsed' | cast to-dec)
+gas_used=$((gas_used - system_tx_gas))
 balance_before=$(cast balance --block $((block_number-1)) $FEE_HANDLER)
 balance_after=$(cast balance --block $block_number $FEE_HANDLER)
 balance_change=$((balance_after - balance_before))

--- a/eth/catalyst/celo_simulated_beacon.go
+++ b/eth/catalyst/celo_simulated_beacon.go
@@ -1,0 +1,49 @@
+package catalyst
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	// PostEcotoneGasParamsLength is the length of gas parameters after the Ecotone fork
+	// See - types.extractL1GasParamsPostEcotone
+	PostEcotoneGasParamsLength = 164
+)
+
+func (c *SimulatedBeacon) payloadGasLimit() *uint64 {
+	if c.eth.BlockChain().Config().Optimism == nil {
+		return nil
+	}
+	// If Optimism config is set we need to set the gas limit in the payload attributes.
+	return &c.eth.BlockChain().CurrentBlock().GasLimit
+}
+
+func (c *SimulatedBeacon) payloadSystemTransaction() ([][]byte, error) {
+	// Post ecotone we need to provide a system transaction to set L1 gas params, we don't actually need to
+	// set realistic values for the gas params, since in Celo we ensure L1 gas fees of zero.
+	// However this is required in order to be able to correctly derive receipt fields.
+	// See types.Receipts.DeriveFields.
+	if c.eth.BlockChain().Config().Optimism != nil && c.eth.BlockChain().Config().IsEcotone(c.eth.BlockChain().CurrentBlock().Time) {
+		sysTx := &types.DepositTx{
+			SourceHash:          common.Hash{},
+			From:                common.Address{},
+			To:                  &common.Address{},
+			Mint:                nil,
+			Value:               big.NewInt(0),
+			Gas:                 50000,
+			IsSystemTransaction: true,
+			Data:                make([]byte, PostEcotoneGasParamsLength),
+		}
+
+		l1Tx := types.NewTx(sysTx)
+		systemTxBytes, err := l1Tx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{systemTxBytes}, nil
+	}
+	return nil, nil
+}

--- a/eth/catalyst/celo_simulated_beacon.go
+++ b/eth/catalyst/celo_simulated_beacon.go
@@ -22,10 +22,12 @@ func (c *SimulatedBeacon) payloadGasLimit() *uint64 {
 }
 
 func (c *SimulatedBeacon) payloadSystemTransaction() ([][]byte, error) {
-	// Post ecotone we need to provide a system transaction to set L1 gas params, we don't actually need to
-	// set realistic values for the gas params, since in Celo we ensure L1 gas fees of zero.
-	// However this is required in order to be able to correctly derive receipt fields.
-	// See types.Receipts.DeriveFields.
+	// Post ecotone we need to provide a system transaction to set L1 gas params.
+	// This mechanism doesn't work in the STF, since no L2 contracts are pre-deployed.
+	// The l1 gas-parameters are defaulting to 0, which is coincidentally what we expect in Celo.
+	// This is why we don't need to set realistic values in the system transaction here, except for 
+	// the `Data` field, which is used by `types.Receipts.DeriveFields` and expected to be all 0 to match 
+	// what is deducted in the STF.
 	if c.eth.BlockChain().Config().Optimism != nil && c.eth.BlockChain().Config().IsEcotone(c.eth.BlockChain().CurrentBlock().Time) {
 		sysTx := &types.DepositTx{
 			SourceHash:          common.Hash{},

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -171,6 +171,12 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 		return fmt.Errorf("failed to sync txpool: %w", err)
 	}
 
+	// Construct optional system transaction, dependent on optimism config.
+	transactions, err := c.payloadSystemTransaction()
+	if err != nil {
+		return err
+	}
+
 	var random [32]byte
 	rand.Read(random[:])
 	fcResponse, err := c.engineAPI.forkchoiceUpdated(c.curForkchoiceState, &engine.PayloadAttributes{
@@ -179,6 +185,8 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal, timestamp u
 		Withdrawals:           withdrawals,
 		Random:                random,
 		BeaconRoot:            &common.Hash{},
+		GasLimit:              c.payloadGasLimit(),
+		Transactions:          transactions,
 	}, engine.PayloadV3, false)
 	if err != nil {
 		return err

--- a/params/celo_config.go
+++ b/params/celo_config.go
@@ -1,6 +1,8 @@
 package params
 
-import "math/big"
+import (
+	"math/big"
+)
 
 const (
 	CeloMainnetChainID   = 42220
@@ -71,5 +73,67 @@ var (
 		CeloMainnetChainID:   mainnetGasLimits,
 		CeloAlfajoresChainID: alfajoresGasLimits,
 		CeloBaklavaChainID:   baklavaGasLimits,
+	}
+
+	// This config should be kept up to date with our mainnet config so that the --dev flag produces
+	// results as close as possible to mainnet.
+	DevChainConfig = &ChainConfig{
+		ChainID: big.NewInt(1337),
+
+		// Ethereum forks
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArrowGlacierBlock:   big.NewInt(0),
+		GrayGlacierBlock:    big.NewInt(0),
+		MergeNetsplitBlock:  big.NewInt(0),
+		ShanghaiTime:        newUint64(0),
+		CancunTime:          newUint64(0),
+		PragueTime:          nil,
+		VerkleTime:          nil,
+
+		// Optimism forks
+		BedrockBlock: big.NewInt(0),
+		RegolithTime: newUint64(0),
+		CanyonTime:   newUint64(0),
+		EcotoneTime:  newUint64(0),
+		FjordTime:    newUint64(0),
+		GraniteTime:  newUint64(0),
+		HoloceneTime: nil,
+		IsthmusTime:  nil,
+		InteropTime:  nil,
+
+		// Celo forks
+		Cel2Time:         newUint64(0),
+		GingerbreadBlock: big.NewInt(0),
+
+		TerminalTotalDifficulty: big.NewInt(0),
+
+		// Consensus engines
+		Ethash: nil,
+		Clique: nil,
+
+		Optimism: &OptimismConfig{
+			EIP1559Denominator:       400,
+			EIP1559DenominatorCanyon: newUint64(400),
+			EIP1559Elasticity:        5,
+		},
+
+		Celo: &CeloConfig{
+			// 25000000000 is the base fee floor for mainnet, we use a lower value for dev mode
+			// because the real value breaks many of our e2e tests.
+			// TODO: Set to the real value - https://github.com/celo-org/celo-blockchain-planning/issues/1032
+			EIP1559BaseFeeFloor: 250000000,
+		},
 	}
 )


### PR DESCRIPTION
The dev mode config now mostly reflects our mainnet config.

Dev mode now uses a `CeloDeveloperGenesisBlock` in place of
`DeveloperGenesisBlock` to generate a genesis block with realistic
config. The original `DeveloperGenesisBlock` remains (with celo
additions removed) since it is used by some go tests.

In order to support this updated config, the SimulatedBeacon
was updated to include gas limit and a system transaction in
the payload attributes passed to forkChoiceUpdated.