### PR TITLE
isthmus: Add hardfork timestamps

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -224,8 +224,29 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 		vmConfig.Tracer = t
 	}
-	// Override the chain config with provided settings.
+
 	var overrides core.ChainOverrides
+	// Add Celo-specific overrides
+	// This is a temporary workaround until Celo chains are available in the superchain registry.
+	// See https://github.com/celo-org/op-geth/issues/389
+	if config.Genesis != nil { // some tests do not have a genesis
+		switch config.Genesis.Config.ChainID.Uint64() {
+		case params.CeloMainnetChainID:
+			activationTime := params.CeloMainnetIsthmusTimestamp
+			overrides.OverrideOptimismHolocene = &activationTime
+			overrides.OverrideOptimismIsthmus = &activationTime
+		case params.CeloAlfajoresChainID:
+			activationTime := params.AlfajoresIsthmusTimestamp
+			overrides.OverrideOptimismHolocene = &activationTime
+			overrides.OverrideOptimismIsthmus = &activationTime
+		case params.CeloBaklavaChainID:
+			activationTime := params.BaklavaIsthmusTimestamp
+			overrides.OverrideOptimismHolocene = &activationTime
+			overrides.OverrideOptimismIsthmus = &activationTime
+		}
+	}
+
+	// Override the chain config with provided settings.
 	if config.OverrideCancun != nil {
 		overrides.OverrideCancun = config.OverrideCancun
 	}

--- a/params/celo.go
+++ b/params/celo.go
@@ -2,4 +2,8 @@ package params
 
 const (
 	DefaultGasLimit uint64 = 20000000 // Gas limit of the blocks before BlockchainParams contract is loaded.
+
+	BaklavaIsthmusTimestamp     uint64 = 1749049861 // Wed Jun 04 2025 15:11:01 GMT+0000
+	AlfajoresIsthmusTimestamp   uint64 = 1749654322 // Wed Jun 11 2025 15:05:22 GMT+0000
+	CeloMainnetIsthmusTimestamp uint64 = 1750863765 // Wed Jun 25 2025 15:02:45 GMT+0000
 )


### PR DESCRIPTION
HF activation overrides for celo networks
(Workaround until having the config in the superchain)