### PR TITLE
Fix  miner.TestDAFilters

### DIFF
--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -329,7 +329,7 @@ func testDAFilters(t *testing.T, maxDATxSize, maxDABlockSize *big.Int, expectedT
 	w, b := newTestWorker(t, config, ethash.NewFaker(), db, 0)
 	w.SetMaxDASize(maxDATxSize, maxDABlockSize)
 	txs := genTxs(1, numDAFilterTxs)
-	b.txPool.Add(txs, false)
+	b.txPool.Add(txs, true)
 
 	params1559 := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 	args := newPayloadArgs(b.chain.CurrentBlock().Hash(), params1559)


### PR DESCRIPTION
This fixes a synchronisation error in `miner.TestDAFilters` transactions were being added to the pool asynchronously and this introduced race conditions that could cause the test to fail randomly, running with a count of 1000 is enough to generate a few failures:

```
go test ./miner/ -run TestDAFilters -count 1000
--- FAIL: TestDAFilters (0.00s)
    --- FAIL: TestDAFilters/with-tx-filter-max-too-high (0.02s)
        payload_building_test.go:345: Unexpected transaction set: got 1, expected 257
--- FAIL: TestDAFilters (0.00s)
    --- FAIL: TestDAFilters/with-block-filter-max-too-high (0.03s)
        payload_building_test.go:345: Unexpected transaction set: got 1, expected 257
--- FAIL: TestDAFilters (0.00s)
    --- FAIL: TestDAFilters/with-tx-filter-max-too-high (0.02s)
        payload_building_test.go:345: Unexpected transaction set: got 1, expected 257
--- FAIL: TestDAFilters (0.00s)
    --- FAIL: TestDAFilters/with-tx-filter-max-too-high (0.02s)
        payload_building_test.go:345: Unexpected transaction set: got 1, expected 257
--- FAIL: TestDAFilters (0.00s)
    --- FAIL: TestDAFilters/with-nil-tx-filters (0.05s)
        payload_building_test.go:345: Unexpected transaction set: got 1, expected 257
FAIL
FAIL    github.com/ethereum/go-ethereum/miner   28.241s
FAIL
```

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/1027
