### PR TITLE
Reenable test_fee_currency_fails_on_credit.sh

### DIFF
--- a/e2e_test/run_all_tests.sh
+++ b/e2e_test/run_all_tests.sh
@@ -44,14 +44,6 @@ for f in test_*"$TEST_GLOB"*; do
 		  continue
 		  ;;
 	    esac
-	else
-		case $f in
-		  # Skip test fee currency fails on credit, it seems broken
-		  test_fee_currency_fails_on_credit.sh)
-		  echo "skipping file $f"
-		  continue
-		  ;;
-	    esac
 	fi
 	echo -e "\nRun $f"
 	if "./$f"; then


### PR DESCRIPTION
It has been disabled in https://github.com/celo-org/op-geth/commit/d9518cc5b23cbd3aee95d5f64a06d560e52dc16d#diff-7e9dfb8659cce411851abf104e7bf34d826781fb4dc07fc9cb3a1a5b82fa5af1R48-R54, but since it works fine for me now, I don't see a reason to keep it disabled.