### PR TITLE
Ensure non zero tips

### DIFF
--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -86,6 +86,12 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 			if err != nil {
 				return err
 			}
+			// When a currency is worth more than celo it can happen the the celo denominated min
+			// tip results in a 0 min tip for the currency. We enforce that there must always be a
+			// non zero tip.
+			if minTip.Sign() == 0 {
+				minTip = big.NewInt(1)
+			}
 			if tx.EffectiveGasTipIntCmp(minTip, baseFeeFloor) < 0 {
 				return ErrUnderpriced
 			}

--- a/core/txpool/legacypool/celo_legacypool_test.go
+++ b/core/txpool/legacypool/celo_legacypool_test.go
@@ -178,27 +178,14 @@ func TestBelowMinTipValidityCheck(t *testing.T) {
 	}
 }
 
-func TestExpectMinTipRoundingFeeCurrency(t *testing.T) {
+func TestMinTipEnforcement(t *testing.T) {
 	t.Parallel()
 
 	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
 	defer pool.Close()
 
-	// the min-tip is set to 1 per default
-
-	// even though the gas-tip-cap as well as the effective gas tip at the base-fee-floor
-	// is 0, the transaction is still accepted.
-	// This is because at a min-tip requirement of 1, a more valuable currency than native
-	// token will get rounded down to a min-tip of 0 during conversion.
+	// the min-tip is set to 1 wei per default
+	// One wei of celo converts to 0 wei of feeCurrencyTwo, even so it is not possible to submit a transaction with a gas-tip-cap of 0.
 	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(50), big.NewInt(0), &feeCurrencyTwo, key)
-	assert.NoError(t, pool.addRemote(tx))
-
-	// set the required min-tip to 10
-	pool.SetGasTip(big.NewInt(10))
-
-	// but as soon as we increase the min-tip, the check rejects a gas-tip-cap that is too low after conversion
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(100), big.NewInt(4), &feeCurrencyTwo, key)
-	if err, want := pool.addRemote(tx), txpool.ErrUnderpriced; !errors.Is(err, want) {
-		t.Errorf("want %v have %v", want, err)
-	}
+	assert.Error(t, pool.addRemote(tx))
 }

--- a/e2e_test/js-tests/test_viem_tx.mjs
+++ b/e2e_test/js-tests/test_viem_tx.mjs
@@ -311,7 +311,54 @@ describe("viem send tx", () => {
 		assert.isAtMost(Number(receipt.effectiveGasPrice), Number(maxFeePerGas), "effective gas price is too high");
 		assert.isAbove(Number(receipt.effectiveGasPrice), Number(maxFeePerGas) * 0.7, "effective gas price is too low");
 	}).timeout(10_000);
+
+	it("zero tip tx rejected", async () => {
+		const gasPrice = await publicClient.getGasPrice();
+		let request = await walletClient.prepareTransactionRequest({
+			to: "0x00000000000000000000000000000000DeaDBeef",
+			gas: TX_GAS,
+			maxFeePerGas: gasPrice,
+			maxPriorityFeePerGas: 0n,
+		});
+		await expectTxFail(request, "transaction underpriced");
+	}).timeout(10_000);
+
+	it("zero tip fee currency tx rejected", async () => {
+		const fc = process.env.FEE_CURRENCY;
+		const [maxFeePerGas, _] = await getGasFees(publicClient, 0n, fc);
+		const request = await walletClient.prepareTransactionRequest({
+			to: "0x00000000000000000000000000000000DeaDBeef",
+			gas: await getIntrinsicGasForFeeCurrency(TX_GAS, fc),
+			feeCurrency: fc,
+			maxFeePerGas: maxFeePerGas,
+			maxPriorityFeePerGas: 0n,
+		});
+		await expectTxFail(request, "transaction underpriced");
+	}).timeout(10_000);
 });
+
+// expectTxFail expects the transaction to fail with an error that contains the given errorString.
+async function expectTxFail(txRequest, errorString) {
+	const signedTx = await walletClient.signTransaction(txRequest);
+	try {
+		await walletClient.sendRawTransaction({
+			serializedTransaction: signedTx,
+		});
+	} catch (err) {
+		// Combine multiple error properties to get comprehensive error information
+		const errorMessage = [
+			err.shortMessage,
+			err.details,
+			err.cause?.message,
+			err.cause?.details
+		].filter(Boolean).join(' | ');
+		if (!errorMessage.includes(errorString)) {
+			assert.fail(`Expected error to contain "${errorString}", but got: ${errorMessage}`);
+		}
+		return;
+	}
+	assert.fail("expecting transaction sending to fail")
+}
 
 async function getRate(feeCurrencyAddress) {
 	const abi = parseAbi(['function getExchangeRate(address token) public view returns (uint256 numerator, uint256 denominator)']);


### PR DESCRIPTION
This PR adds an e2e test to ensure that zero tip transactions are not accepted by op-geth.

It also fixes a condition that allowed fee currency transactions to be submitted with a zero tip.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/1096

Note: The e2e tests are failing on alfajores because this fix has not been deployed there yet.