### PR TITLE
Trace base fee recipient in all Cel2 cases

### DIFF
--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -112,8 +112,8 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-				context = test.Context.toBlockContext(test.Genesis)
 				st      = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				context = test.Context.toBlockContext(test.Genesis, st.StateDB)
 			)
 			st.Close()
 
@@ -202,13 +202,13 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		b.Fatalf("failed to parse testcase input: %v", err)
 	}
 	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-	context := test.Context.toBlockContext(test.Genesis)
+	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+	defer state.Close()
+	context := test.Context.toBlockContext(test.Genesis, state.StateDB)
 	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee, context.FeeCurrencyContext.ExchangeRates)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
-	defer state.Close()
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -96,8 +96,8 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 		return fmt.Errorf("failed to parse testcase input: %v", err)
 	}
 	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-	context := test.Context.toBlockContext(test.Genesis)
 	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+	context := test.Context.toBlockContext(test.Genesis, state.StateDB)
 	defer state.Close()
 
 	// Create the tracer, the EVM environment and run it

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -95,8 +95,8 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-				context = test.Context.toBlockContext(test.Genesis)
 				state   = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				context = test.Context.toBlockContext(test.Genesis, state.StateDB)
 			)
 			defer state.Close()
 			// Required for the fee currency prestate tests

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/cel2_no_fee_currency.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/cel2_no_fee_currency.json
@@ -1,0 +1,109 @@
+{
+  "genesis": {
+    "baseFeePerGas": "997500000",
+    "blobGasUsed": "0",
+    "difficulty": "0",
+    "excessBlobGas": "0",
+    "extraData": "0x",
+    "gasLimit": "11500000",
+    "hash": "0x22ac23fe9d130d8d0b632d749aa6c3485cb6ac9be736a42b2cf7d0496ac79039",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "mixHash": "0x45c8c6769aaab35d7f70841dab67c00e5961cebdec44a8e051d84768974a1f28",
+    "nonce": "0x0000000000000000",
+    "number": "1",
+    "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "stateRoot": "0x793fca7b6baf768b0e61d2cd33fbaaeb0a43273413a69bfcb192ef4a526ac285",
+    "timestamp": "1752588029",
+    "withdrawals": [],
+    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "alloc": {
+        "0x0000000000000000000000000000000000000000": {
+          "balance": "0x4e3b29200",
+          "nonce": "2"
+        },
+        "0x0000000000000000000000000000000000005555": {
+          "balance": "0x0"
+        },
+        "0x7fa73c21523e01895036b25927677c074cd0a1a5": {
+          "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffecede4018af7",
+          "nonce": "1"
+        }
+      },
+    "config": {
+        "chainId": 1337,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "arrowGlacierBlock": 0,
+        "grayGlacierBlock": 0,
+        "mergeNetsplitBlock": 0,
+        "shanghaiTime": 0,
+        "cancunTime": 0,
+        "bedrockBlock": 0,
+        "regolithTime": 0,
+        "canyonTime": 0,
+        "ecotoneTime": 0,
+        "fjordTime": 0,
+        "graniteTime": 0,
+        "cel2Time": 0,
+        "gingerbreadBlock": 0,
+        "terminalTotalDifficulty": 0,
+        "depositContractAddress": "0x0000000000000000000000000000000000000000",
+        "optimism": {
+          "eip1559Elasticity": 5,
+          "eip1559Denominator": 400,
+          "eip1559DenominatorCanyon": 400
+        },
+        "celo": {
+          "eip1559BaseFeeFloor": 250000000
+        }
+      }
+  },
+  "context": {
+    "number": "2",
+    "difficulty": "0",
+    "timestamp": "1752588072",
+    "gasLimit": "11500000",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "baseFeePerGas": "995083231"
+  },
+  "input": "0x02f87482053901830f42408476f88b008252089400000000000000000000000000000000000055558902b5e3af16b188000080c001a0d8cb2fca6021f6f821c3c6d3b9952cb48ad42d87310a7ea84f3fe6cd95d42248a0775bb7be90867adf02e3fc9603414251209bab0afd55edd7959d1feb0ff79b4b",
+  "result": {
+    "post": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x9c7652400"
+      },
+      "0x0000000000000000000000000000000000005555": {
+        "balance": "0x2b5e3af16b1880000"
+      },
+      "0x7fa73c21523e01895036b25927677c074cd0a1a5": {
+        "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffd4a1c2ad0e78b6bff",
+        "nonce": 2
+      }
+    },
+    "pre": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x4e3b29200",
+        "nonce": 2
+      },
+      "0x0000000000000000000000000000000000005555": {
+        "balance": "0x0"
+      },
+      "0x7fa73c21523e01895036b25927677c074cd0a1a5": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffecede4018af7",
+        "nonce": 1
+      }
+    }
+  },
+  "tracerConfig": {
+    "diffMode": true
+  }
+}

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/cel2_no_fee_currency.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/cel2_no_fee_currency.json
@@ -84,6 +84,9 @@
       "0x0000000000000000000000000000000000005555": {
         "balance": "0x2b5e3af16b1880000"
       },
+      "0xcd437749e43a154c07f3553504c68fbfd56b8778": {
+        "balance": "0x1301673b8cf8"
+      },
       "0x7fa73c21523e01895036b25927677c074cd0a1a5": {
         "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffd4a1c2ad0e78b6bff",
         "nonce": 2
@@ -95,6 +98,9 @@
         "nonce": 2
       },
       "0x0000000000000000000000000000000000005555": {
+        "balance": "0x0"
+      },
+      "0xcd437749e43a154c07f3553504c68fbfd56b8778": {
         "balance": "0x0"
       },
       "0x7fa73c21523e01895036b25927677c074cd0a1a5": {

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/optimism.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/optimism.json
@@ -1,0 +1,94 @@
+{
+  "genesis": {
+    "baseFeePerGas": "1000000000",
+    "blobGasUsed": "0",
+    "difficulty": "0",
+    "excessBlobGas": "0",
+    "extraData": "0x",
+    "gasLimit": "11500000",
+    "hash": "0x4a3a3699d4d328652bfea00c9fdc2be4768519142e10e0d6cebdbec5056f101e",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nonce": "0x0000000000000000",
+    "number": "0",
+    "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "stateRoot": "0x0344388281802511fb31b24f96f087a8b935683646d2a75de96465703505e065",
+    "timestamp": "0",
+    "withdrawals": [],
+    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "alloc": {
+        "0x0000000000000000000000000000000000000000": {
+          "balance": "0x0"
+        },
+        "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+          "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
+        }
+      },
+    "config": {
+        "chainId": 1337,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "arrowGlacierBlock": 0,
+        "grayGlacierBlock": 0,
+        "bedrockBlock": 0,
+        "shanghaiTime": 0,
+        "cancunTime": 0,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "depositContractAddress": "0x0000000000000000000000000000000000000000",
+	"optimism": {
+	    "eip1559Elasticity": 6,
+	    "eip1559Denominator": 50,
+	    "eip1559DenominatorCanyon": 250
+	}
+    }
+  },
+  "context": {
+    "number": "1",
+    "difficulty": "0",
+    "timestamp": "1729512767",
+    "gasLimit": "11511229",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "baseFeePerGas": "875000000",
+    "random": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+    "random": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "input": "0x02f8708205398001847735940182520894f7b094d8c987eff69afec8f93153ac9829577125880de0b6b3a764000080c001a0e44882c072410fbadfd4783a71be745edfcedd9fc9ab55b66e25bb039db2f579a017c13129640ceff7ffa674bcff74bcce168404aa8450a67ece2737ca5a554a12",
+  "result": {
+    "post": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x5208"
+      },
+      "0x4200000000000000000000000000000000000019": {
+	  "balance": "0x10b643590600"
+      },
+      "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffef49bca6a7ef",
+        "nonce": 1
+      }
+    },
+    "pre": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x0"
+      },
+      "0x4200000000000000000000000000000000000019": {
+	  "balance": "0x0"
+      },
+      "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+        "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
+      }
+    }
+  },
+  "tracerConfig": {
+    "diffMode": true
+  }
+}

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -55,7 +55,7 @@ type traceContext struct {
 	FeeCurrencyContext common.FeeCurrencyContext `json:"feeCurrencyContext"`
 }
 
-func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
+func (c *traceContext) toBlockContext(genesis *core.Genesis, statedb types.StateGetter) vm.BlockContext {
 	context := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
@@ -64,6 +64,7 @@ func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 		Time:        uint64(c.Time),
 		Difficulty:  (*big.Int)(c.Difficulty),
 		GasLimit:    uint64(c.GasLimit),
+		L1CostFunc:  types.NewL1CostFunc(genesis.Config, statedb),
 		// Celo specific
 		FeeCurrencyContext: c.FeeCurrencyContext,
 	}

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/contracts/addresses"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -177,11 +178,16 @@ func (t *prestateTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction
 		t.lookupAccount(addr)
 	}
 
-	if t.chainConfig.Optimism != nil {
+	if t.chainConfig.Cel2Time != nil {
+		// Look up the storage that will receive the base fee
+		if tx.FeeCurrency() == nil {
+			feeHandlerAddress := addresses.GetAddressesOrDefault(t.chainConfig.ChainID, addresses.MainnetAddresses).FeeHandler
+			t.lookupAccount(feeHandlerAddress)
+		} else {
+			t.lookupAccount(*tx.FeeCurrency())
+		}
+	} else if t.chainConfig.Optimism != nil {
 		t.lookupAccount(params.OptimismBaseFeeRecipient)
-	}
-	if tx.FeeCurrency() != nil {
-		t.lookupAccount(*tx.FeeCurrency())
 	}
 }
 

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -69,6 +69,9 @@ type prestateTracer struct {
 	reason    error       // Textual reason for the interruption
 	created   map[common.Address]bool
 	deleted   map[common.Address]bool
+
+	// Required on OP-Stack to detect Optimism flag
+	chainConfig *params.ChainConfig
 }
 
 type prestateTracerConfig struct {
@@ -88,6 +91,9 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 		config:  config,
 		created: make(map[common.Address]bool),
 		deleted: make(map[common.Address]bool),
+
+		// Required on OP-Stack to detect Optimism flag
+		chainConfig: chainConfig,
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
@@ -171,6 +177,9 @@ func (t *prestateTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction
 		t.lookupAccount(addr)
 	}
 
+	if t.chainConfig.Optimism != nil {
+		t.lookupAccount(params.OptimismBaseFeeRecipient)
+	}
 	if tx.FeeCurrency() != nil {
 		t.lookupAccount(*tx.FeeCurrency())
 	}


### PR DESCRIPTION
We used to only track the FeeCurrency address, which ignored the base fee recipient for non-fee-currency cases.

This PR contains:
* The first commit is taken from [my related upstream PR](https://github.com/ethereum-optimism/op-geth/pull/407)
* A prestate diff tracing test for a non-fee-currency Cel2 tx
* The actual change that tracks the FeeHandler address in prestate tracing

I suggest a commit-by-commit review.

Closes https://github.com/celo-org/op-geth/issues/216