### PR TITLE
Fix celo legacy signer equal function

### DIFF
--- a/core/types/celo_transaction_signing.go
+++ b/core/types/celo_transaction_signing.go
@@ -119,5 +119,5 @@ func (c *celoSigner) Equal(s Signer) bool {
 }
 
 func (c *celoSigner) latestFork() fork {
-	return c.activatedForks[len(c.activatedForks)-1]
+	return c.activatedForks[0]
 }

--- a/core/types/celo_transaction_signing_forks.go
+++ b/core/types/celo_transaction_signing_forks.go
@@ -85,7 +85,7 @@ func (c *celoLegacy) active(blockTime uint64, config *params.ChainConfig) bool {
 }
 
 func (c *celoLegacy) equal(other fork) bool {
-	_, ok := other.(*cel2)
+	_, ok := other.(*celoLegacy)
 	return ok
 }
 


### PR DESCRIPTION
I believe this bug only affected caching of signers not signing behaviour. (However I think we should run a sync test with this change before we merge)

This is because 'equal' is only used by `Sender(signer Signer, tx *Transaction) (common.Address, error)`, in order to re-use previously calculated results for a given transaction, so the effect of this bug for the celoLegacy fork would be that it would never have resulted in a cache hit.

Alternatively we could end up with MakeSigner returning the celoLegacy fork and LatestSigner returning the cel2 fork and then having those forks match inadvertently.

If the legacy fork were used first followed by the cel2 fork. We could end up considering the tx type as not supported (because it was deprecated in the cel2 fork).

Or the other way around we could end up calculating the sender for a deprecated transaction type.

However I don't think these cases can happen because LatestSigner is only used for tx submission, so whenever we are in a context where LatestSigner is called we will be dealing with a block that occurred after the cel2 hardfork. And vice versa if we are in a context where the block occurred before the cel2 hardfork then we won't be calling LatestSigner.

