### PR TITLE
Defaults CeloAddresses to mainnet's if networkId is not recognised

### DIFF
--- a/contracts/addresses/addresses.go
+++ b/contracts/addresses/addresses.go
@@ -48,7 +48,8 @@ func GetAddresses(chainID *big.Int) *CeloAddresses {
 	case params.CeloMainnetChainID:
 		return MainnetAddresses
 	default:
-		return nil
+		// default to mainnet
+		return MainnetAddresses
 	}
 }
 


### PR DESCRIPTION
If the networkId is not recognised, defaults CeloAddresses to mainnet, assuming these have been injected as precompiles in genesis.
Required having some default for new testnets, if we don't want to include them on code.