### PR TITLE
Add fee currency blocklist console bindings

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -158,6 +158,35 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'getBlocklistFeeCurrencies',
+			call: 'admin_getBlocklistFeeCurrencies',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'disableBlocklistFeeCurrencies',
+			call: 'admin_disableBlocklistFeeCurrencies',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'enableBlocklistFeeCurrencies',
+			call: 'admin_enableBlocklistFeeCurrencies',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'getDisabledBlocklistFeeCurrencies',
+			call: 'admin_getDisabledBlocklistFeeCurrencies',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'unblockFeeCurrency',
+			call: 'admin_unblockFeeCurrency',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
This PR adds the geth console bindings for the blocklist commands.

Tested locally, was able to test enable/disable & get disabled functionality, but haven't tested unblock and get blocklisted functionality as it's not easy to set up that context.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/1208

```
❯ ./build/bin/geth attach --datadir test-datadir/
Welcome to the Geth JavaScript console!

instance: Geth/v0.1.0-untagged-56f9cfcb-20250819/darwin-arm64/go1.24.3
at block: 0 (Thu Jan 01 1970 01:00:00 GMT+0100 (CET))
 datadir: /Users/pierspowlesland/projects/op-geth/test-datadir
 modules: admin:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0

To exit, press ctrl-d or type exit
> admin.disableBlocklistFeeCurrencies(["0x4675c7e5baafbffbca748158becba61ef3b0a263"])
null
> admin.getDisabledBlocklistFeeCurrencies()
["0x4675c7e5baafbffbca748158becba61ef3b0a263"]
> admin.disableBlocklistFeeCurrencies(["0x4675c7e5baafbffbca748158becba61ef3b0a263","0x4675c7e5baafbffbca748158becba61ef3b0a264"])
null
> admin.getDisabledBlocklistFeeCurrencies()
["0x4675c7e5baafbffbca748158becba61ef3b0a264", "0x4675c7e5baafbffbca748158becba61ef3b0a263"]
> admin.enableBlocklistFeeCurrencies(["0x4675c7e5baafbffbca748158becba61ef3b0a264"])
null
> admin.getDisabledBlocklistFeeCurrencies()
["0x4675c7e5baafbffbca748158becba61ef3b0a263"]
>
```