### PR TITLE
fix: skip storage entries with missing preimage keys (#32051)

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -182,7 +182,11 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 					log.Error("Failed to decode the value returned by iterator", "error", err)
 					continue
 				}
-				account.Storage[common.BytesToHash(s.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(content)
+				key := s.trie.GetKey(storageIt.Key)
+				if key == nil {
+					continue
+				}
+				account.Storage[common.BytesToHash(key)] = common.Bytes2Hex(content)
 			}
 		}
 		c.OnAccount(address, account)


### PR DESCRIPTION
When `GetKey` is called, a missing preimage can cause the function to return a `nil` key. This, in turn, makes `account.Storage` persist an incorrect value.

This cherry-picks the up-upstream commit https://github.com/ethereum/go-ethereum/commit/05e199408fa23f22a1958853d2629df96da77ee4, see PR https://github.com/ethereum/go-ethereum/pull/32051

The change seems safe to apply and should not have any effect outside of the edge case describe in the PR.

Closes https://github.com/celo-org/op-geth/issues/426