### PR TITLE
Remove non zero tip enforcement

### DIFF
--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -87,12 +87,6 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 			if err != nil {
 				return err
 			}
-			// When a currency is worth more than celo it can happen the the celo denominated min
-			// tip results in a 0 min tip for the currency. We enforce that there must always be a
-			// non zero tip.
-			if minTip.Sign() == 0 {
-				minTip = big.NewInt(1)
-			}
 			if tx.EffectiveGasTipIntCmp(minTip, baseFeeFloor) < 0 {
 				return ErrUnderpriced
 			}

--- a/core/txpool/legacypool/celo_legacypool_test.go
+++ b/core/txpool/legacypool/celo_legacypool_test.go
@@ -178,14 +178,27 @@ func TestBelowMinTipValidityCheck(t *testing.T) {
 	}
 }
 
-func TestMinTipEnforcement(t *testing.T) {
+func TestExpectMinTipRoundingFeeCurrency(t *testing.T) {
 	t.Parallel()
 
 	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
 	defer pool.Close()
 
-	// the min-tip is set to 1 wei per default
-	// One wei of celo converts to 0 wei of feeCurrencyTwo, even so it is not possible to submit a transaction with a gas-tip-cap of 0.
+	// the min-tip is set to 1 per default
+
+	// even though the gas-tip-cap as well as the effective gas tip at the base-fee-floor
+	// is 0, the transaction is still accepted.
+	// This is because at a min-tip requirement of 1, a more valuable currency than native
+	// token will get rounded down to a min-tip of 0 during conversion.
 	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(50), big.NewInt(0), &feeCurrencyTwo, key)
-	assert.Error(t, pool.addRemote(tx))
+	assert.NoError(t, pool.addRemote(tx))
+
+	// set the required min-tip to 10
+	pool.SetGasTip(big.NewInt(10))
+
+	// but as soon as we increase the min-tip, the check rejects a gas-tip-cap that is too low after conversion
+	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(100), big.NewInt(4), &feeCurrencyTwo, key)
+	if err, want := pool.addRemote(tx), txpool.ErrTxGasPriceTooLow; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
+	}
 }

--- a/e2e_test/js-tests/test_viem_tx.mjs
+++ b/e2e_test/js-tests/test_viem_tx.mjs
@@ -330,18 +330,6 @@ describe("viem send tx", () => {
 		await expectTxFail(request, "transaction gas price below minimum");
 	}).timeout(10_000);
 
-	it("zero tip fee currency tx rejected", async () => {
-		const fc = process.env.FEE_CURRENCY;
-		const [maxFeePerGas, _] = await getGasFees(publicClient, 0n, fc);
-		const request = await walletClient.prepareTransactionRequest({
-			to: "0x00000000000000000000000000000000DeaDBeef",
-			gas: await getIntrinsicGasForFeeCurrency(TX_GAS, fc),
-			feeCurrency: fc,
-			maxFeePerGas: maxFeePerGas,
-			maxPriorityFeePerGas: 0n,
-		});
-		await expectTxFail(request, "transaction gas price below minimum");
-	}).timeout(10_000);
 });
 
 // expectTxFail expects the transaction to fail with an error that contains the given errorString.


### PR DESCRIPTION
Reverts the changes made in https://github.com/celo-org/op-geth/pull/401

Originally when I added the non zero tip enforcement for min tips greater than zero, we had been facing problems with zero tip transactions getting stuck in the mempool and I felt that enforcing non zero tips would be a safer way to progress going forward.

But actually using the `txpool.nolocals` seems to have resolved all stuck transaction issues and given that zero tips are still possible if the miner sets the min tip to zero, i don't see any tangible benefit from sometimes making the tip 1 wei as opposed to zero.

This change brings us closer to upstream and avoids breakng any flows that do result in zero tip transactions.

----
The e2e tests run against alfajores are failing but that seems to be a problem present in celo-rebase-14, so not introduced by this PR.