### PR TITLE
Ignore Celo base fee floor after Jovian

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -61,7 +61,8 @@ func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Heade
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header, time uint64) (response *big.Int) {
 	defer func() {
 		// If the base fee response is below the floor, intercept the return and return the floor instead.
-		if config.Celo != nil {
+		// Skip this for Jovian and later, as OP's minBaseFee mechanism handles it.
+		if config.Celo != nil && !config.IsJovian(time) {
 			baseFeeFloor := new(big.Int).SetUint64(config.Celo.EIP1559BaseFeeFloor)
 			if response.Cmp(baseFeeFloor) < 0 {
 				response = baseFeeFloor

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -79,11 +79,9 @@ func opConfig() *params.ChainConfig {
 }
 
 func celoConfig() *params.ChainConfig {
-	config := copyConfig(params.TestChainConfig)
-	ct := uint64(10)
-	config.Cel2Time = &ct
+	config := opConfig()
+	config.Cel2Time = &testCanyonTime
 	config.Celo = &params.CeloConfig{EIP1559BaseFeeFloor: params.InitialBaseFee}
-
 	return config
 }
 
@@ -235,18 +233,20 @@ func TestCalcBaseFeeOptimismHolocene(t *testing.T) {
 	}
 }
 
-// TestCalcBaseFeeCeloFloor assumes all blocks are 1559-blocks
+// TestCalcBaseFeeCeloFloor tests that the Celo base fee floor is enforced pre-Jovian
 func TestCalcBaseFeeCeloFloor(t *testing.T) {
 	config := celoConfig()
+	config.JovianTime = nil // Disable Jovian to test pre-Jovian behavior
+
 	tests := []struct {
 		parentBaseFee   int64
 		parentGasLimit  uint64
 		parentGasUsed   uint64
 		expectedBaseFee int64
 	}{
-		{params.InitialBaseFee, 20000000, 10000000, params.InitialBaseFee}, // usage == target
-		{params.InitialBaseFee, 20000000, 7000000, params.InitialBaseFee},  // usage below target
-		{params.InitialBaseFee, 20000000, 11000000, 1012500000},            // usage above target
+		{params.InitialBaseFee, 20_000_000, 10_000_000, params.InitialBaseFee}, // usage == target
+		{params.InitialBaseFee, 20_000_000, 7_000_000, params.InitialBaseFee},  // usage below target, clamped to floor
+		{params.InitialBaseFee, 20_000_000, 11_000_000, 1_012_500_000},         // usage above target
 	}
 	for i, test := range tests {
 		parent := &types.Header{
@@ -254,11 +254,88 @@ func TestCalcBaseFeeCeloFloor(t *testing.T) {
 			GasLimit: test.parentGasLimit,
 			GasUsed:  test.parentGasUsed,
 			BaseFee:  big.NewInt(test.parentBaseFee),
-			Time:     *config.Cel2Time,
+			Time:     testHoloceneTime,
+			// Holocene is active, so extra data is decoded (elasticity=2, denominator=8)
+			Extra: EncodeHoloceneExtraData(8, 2),
 		}
 		if have, want := CalcBaseFee(config, parent, parent.Time+2), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
+	}
+}
+
+// TestCalcBaseFeeCeloFloorDisabledPostJovian tests the realistic post-Jovian scenario:
+// - Celo base fee floor is configured but NOT enforced (Jovian is active)
+// - OP minBaseFee IS enforced
+func TestCalcBaseFeeCeloFloorDisabledPostJovian(t *testing.T) {
+	config := celoConfig()
+	celoFloor := config.Celo.EIP1559BaseFeeFloor // 1e9 (InitialBaseFee)
+	parentGasLimit := uint64(30_000_000)
+	denom := uint64(50)
+	elasticity := uint64(6)
+	parentGasTarget := parentGasLimit / elasticity
+	const zeroParentBlobGasUsed = 0
+
+	tests := []struct {
+		name              string
+		parentBaseFee     int64
+		parentGasUsed     uint64
+		parentBlobGasUsed uint64
+		minBaseFee        uint64
+		expectedBaseFee   uint64
+	}{
+		// Test 1: Calculated base fee < minBaseFee < Celo floor
+		// The calculated base fee (1) is below both floors, but only minBaseFee is enforced
+		{
+			name:              "calculated < minBaseFee < celoFloor",
+			parentBaseFee:     1,
+			parentGasUsed:     parentGasTarget,
+			parentBlobGasUsed: zeroParentBlobGasUsed,
+			minBaseFee:        5e8, // 0.5 Gwei, below Celo floor of 1 Gwei
+			expectedBaseFee:   5e8, // minBaseFee enforced, not Celo floor
+		},
+		// Test 2: Calculated base fee < Celo floor < minBaseFee
+		// minBaseFee is higher than Celo floor, and is enforced
+		{
+			name:              "calculated < celoFloor < minBaseFee",
+			parentBaseFee:     1,
+			parentGasUsed:     parentGasTarget,
+			parentBlobGasUsed: zeroParentBlobGasUsed,
+			minBaseFee:        2e9, // 2 Gwei, above Celo floor of 1 Gwei
+			expectedBaseFee:   2e9, // minBaseFee enforced
+		},
+		// Test 3: minBaseFee < Calculated base fee < Celo floor
+		// The calculated base fee is above minBaseFee but below Celo floor
+		// Neither floor should be enforced - we get the calculated value
+		// With parentBaseFee=9e8 and usage below target, base fee decreases
+		// gasUsedDelta = 4_000_000 - 5_000_000 = -1_000_000
+		// 9e8 * 1_000_000 / 5_000_000 / 50 = 3_600_000
+		// 9e8 - 3_600_000 = 896_400_000, which is below Celo floor but above minBaseFee
+		{
+			name:              "minBaseFee < calculated < celoFloor",
+			parentBaseFee:     9e8,
+			parentGasUsed:     parentGasTarget - 1_000_000,
+			parentBlobGasUsed: zeroParentBlobGasUsed,
+			minBaseFee:        1e8,         // 0.1 Gwei
+			expectedBaseFee:   896_400_000, // calculated value, Celo floor NOT enforced
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parent := &types.Header{
+				Number:      common.Big32,
+				GasLimit:    parentGasLimit,
+				GasUsed:     test.parentGasUsed,
+				BlobGasUsed: &test.parentBlobGasUsed,
+				BaseFee:     big.NewInt(test.parentBaseFee),
+				Time:        testJovianTime,
+				Extra:       EncodeOptimismExtraData(config, testJovianTime, denom, elasticity, &test.minBaseFee),
+			}
+			have := CalcBaseFee(config, parent, parent.Time+2)
+			want := big.NewInt(int64(test.expectedBaseFee))
+			require.Equal(t, want, have, "test %s: celoFloor=%d, minBaseFee=%d", test.name, celoFloor, test.minBaseFee)
+		})
 	}
 }
 

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -6,17 +6,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/exchange"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
 var (
-
-	// ErrGasPriceDoesNotExceedBaseFeeFloor is returned if the gas price specified is
-	// lower than the configured base-fee-floor
-	ErrGasPriceDoesNotExceedBaseFeeFloor = errors.New("gas-price is less than the base-fee-floor")
-	ErrMinimumEffectiveGasTipBelowMinTip = errors.New("effective gas tip at base-fee-floor is below threshold")
+	// ErrGasFeeCapBelowMinBaseFee is returned if the gas fee cap is below the minimum base fee
+	ErrGasFeeCapBelowMinBaseFee = errors.New("gas fee cap is below the minimum base fee")
 )
 
 // AcceptSet is a set of accepted transaction types for a transaction subpool.
@@ -69,16 +67,31 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 		return exchange.ErrUnregisteredFeeCurrency
 	}
 
-	// Skip Celo base fee floor validation for Jovian and later, as OP's minBaseFee mechanism handles it.
-	if opts.Config.Celo != nil && !opts.Config.IsJovian(head.Time) {
-		baseFeeFloor, err := exchange.ConvertCeloToCurrency(currencyCtx.ExchangeRates, tx.FeeCurrency(), new(big.Int).SetUint64(opts.Config.Celo.EIP1559BaseFeeFloor))
+	// Determine the base fee floor based on the fork
+	var baseFeeFloorNative *big.Int
+	if opts.Config.IsMinBaseFee(head.Time) {
+		// Post-MinBaseFee: use OP minBaseFee from header
+		_, _, minBaseFee := eip1559.DecodeOptimismExtraData(opts.Config, head.Time, head.Extra)
+		if minBaseFee != nil && *minBaseFee > 0 {
+			baseFeeFloorNative = new(big.Int).SetUint64(*minBaseFee)
+		}
+	} else if opts.Config.Celo != nil {
+		// Pre-MinBaseFee: use Celo config floor
+		baseFeeFloorNative = new(big.Int).SetUint64(opts.Config.Celo.EIP1559BaseFeeFloor)
+	}
+
+	if baseFeeFloorNative != nil {
+		baseFeeFloor, err := exchange.ConvertCeloToCurrency(
+			currencyCtx.ExchangeRates,
+			tx.FeeCurrency(),
+			baseFeeFloorNative,
+		)
 		if err != nil {
 			return err
 		}
-
 		// Check that the fee cap exceeds the base fee floor
 		if baseFeeFloor.Cmp(tx.GasFeeCap()) == 1 {
-			return ErrGasPriceDoesNotExceedBaseFeeFloor
+			return ErrGasFeeCapBelowMinBaseFee
 		}
 
 		// Make sure that the effective gas tip at the base fee floor is at least the

--- a/core/txpool/celo_validation.go
+++ b/core/txpool/celo_validation.go
@@ -69,7 +69,8 @@ func CeloValidateTransaction(tx *types.Transaction, head *types.Header,
 		return exchange.ErrUnregisteredFeeCurrency
 	}
 
-	if opts.Config.Celo != nil {
+	// Skip Celo base fee floor validation for Jovian and later, as OP's minBaseFee mechanism handles it.
+	if opts.Config.Celo != nil && !opts.Config.IsJovian(head.Time) {
 		baseFeeFloor, err := exchange.ConvertCeloToCurrency(currencyCtx.ExchangeRates, tx.FeeCurrency(), new(big.Int).SetUint64(opts.Config.Celo.EIP1559BaseFeeFloor))
 		if err != nil {
 			return err

--- a/core/txpool/legacypool/celo_legacypool_test.go
+++ b/core/txpool/legacypool/celo_legacypool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -84,7 +85,7 @@ func newDBWithCeloGenesis(config *params.ChainConfig, fundedAddress common.Addre
 	return state.NewDatabase(triedb, nil), block
 }
 
-func setupCeloPoolWithConfig(config *params.ChainConfig) (*LegacyPool, *ecdsa.PrivateKey) {
+func setupCeloPoolWithConfig(config *params.ChainConfig, minBaseFee ...uint64) (*LegacyPool, *ecdsa.PrivateKey) {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
@@ -102,6 +103,13 @@ func setupCeloPoolWithConfig(config *params.ChainConfig) (*LegacyPool, *ecdsa.Pr
 	// that the fee-currency allocs are accessible from the state
 	// and can be used to create the fee-currency context in the txpool
 	block.Root = stateRoot
+	// Encode minBaseFee in ExtraData (defaults to 0)
+	mbf := uint64(0)
+	if len(minBaseFee) > 0 {
+		mbf = minBaseFee[0]
+	}
+	block.Extra = eip1559.EncodeMinBaseFeeExtraData(250, 6, mbf)
+
 	if err := pool.Init(testTxPoolConfig.PriceLimit, block, newReserver()); err != nil {
 		panic(err)
 	}
@@ -121,16 +129,16 @@ func TestBelowBaseFeeFloorValidityCheck(t *testing.T) {
 
 	// We need to ensure that the tip cap fulfils the min tip requirement since that is checked first in ValidateTransaction.
 	tx := pricedCip64Transaction(preJovianChainConfig, 0, 21000, big.NewInt(99), big.NewInt(1), nil, key)
-	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
 	// also test with fee currency conversion
 	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(198), big.NewInt(2), &feeCurrencyOne, key)
-	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
 	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(48), big.NewInt(1), &feeCurrencyTwo, key)
-	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
 }
@@ -212,12 +220,14 @@ func TestExpectMinTipRoundingFeeCurrency(t *testing.T) {
 }
 
 // Verify that transactions with gas price below the Celo base fee floor are
-// accepted when Jovian is active, because the Celo floor validation is skipped
-// in favor of OP's minBaseFee mechanism.
+// accepted when Jovian is active and minBaseFee is 0, because the Celo floor
+// validation is skipped in favor of OP's minBaseFee mechanism.
 func TestBaseFeeFloorNotEnforcedPostJovian(t *testing.T) {
 	t.Parallel()
 
-	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	// Use minBaseFee=0 so that transactions with low fees are accepted
+	// (Celo floor is not enforced, and OP minBaseFee=0 means no OP floor either)
+	pool, key := setupCeloPoolWithConfig(defaultChainConfig, 0)
 	defer pool.Close()
 
 	// Transaction with gas price below Celo base fee floor should be ACCEPTED
@@ -228,5 +238,63 @@ func TestBaseFeeFloorNotEnforcedPostJovian(t *testing.T) {
 
 	// Also test with fee currency - gas price below converted floor should be accepted
 	tx = pricedCip64Transaction(defaultChainConfig, 1, 21000+feeCurrencyIntrinsicGas, big.NewInt(198), big.NewInt(2), &feeCurrencyOne, key)
+	assert.NoError(t, pool.addRemote(tx))
+}
+
+// Verify that transactions with gas fee cap below the OP minBaseFee are rejected
+// when Jovian is active.
+func TestBelowMinBaseFeeRejected(t *testing.T) {
+	t.Parallel()
+
+	// Set minBaseFee=100
+	pool, key := setupCeloPoolWithConfig(defaultChainConfig, 100)
+	defer pool.Close()
+
+	// Transaction with gas fee cap below minBaseFee should be REJECTED
+	// The gas fee cap of 99 is below the minBaseFee of 100.
+	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(99), big.NewInt(1), nil, key)
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
+	}
+
+	// Also test with fee currency conversion
+	// feeCurrencyOne is worth half as much as native CELO, so minBaseFee=100 converts to 200
+	// A gas fee cap of 199 should be rejected
+	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(199), big.NewInt(2), &feeCurrencyOne, key)
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
+	}
+
+	// feeCurrencyTwo is worth twice as much as native CELO, so minBaseFee=100 converts to 50
+	// A gas fee cap of 49 should be rejected
+	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(49), big.NewInt(1), &feeCurrencyTwo, key)
+	if err, want := pool.addRemoteSync(tx), txpool.ErrGasFeeCapBelowMinBaseFee; !errors.Is(err, want) {
+		t.Errorf("want %v have %v", want, err)
+	}
+}
+
+// Verify that transactions with gas fee cap at or above the OP minBaseFee are accepted
+// when Jovian is active.
+func TestAboveMinBaseFeeAccepted(t *testing.T) {
+	t.Parallel()
+
+	// Set minBaseFee=100
+	pool, key := setupCeloPoolWithConfig(defaultChainConfig, 100)
+	defer pool.Close()
+
+	// Transaction with gas fee cap at minBaseFee should be ACCEPTED
+	// The gas fee cap of 101 (100 + 1 for min tip) is at/above the minBaseFee of 100.
+	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(101), big.NewInt(1), nil, key)
+	assert.NoError(t, pool.addRemote(tx))
+
+	// Also test with fee currency conversion
+	// feeCurrencyOne is worth half as much as native CELO, so minBaseFee=100 converts to 200
+	// A gas fee cap of 202 (200 + 2 for min tip) should be accepted
+	tx = pricedCip64Transaction(defaultChainConfig, 1, 21000+feeCurrencyIntrinsicGas, big.NewInt(202), big.NewInt(2), &feeCurrencyOne, key)
+	assert.NoError(t, pool.addRemote(tx))
+
+	// feeCurrencyTwo is worth twice as much as native CELO, so minBaseFee=100 converts to 50
+	// A gas fee cap of 51 (50 + 1 for min tip) should be accepted
+	tx = pricedCip64Transaction(defaultChainConfig, 2, 21000+feeCurrencyIntrinsicGas, big.NewInt(51), big.NewInt(1), &feeCurrencyTwo, key)
 	assert.NoError(t, pool.addRemote(tx))
 }

--- a/core/txpool/legacypool/celo_legacypool_test.go
+++ b/core/txpool/legacypool/celo_legacypool_test.go
@@ -24,7 +24,9 @@ func celoConfig(baseFeeFloor uint64) *params.ChainConfig {
 	cpy := *params.TestChainConfig
 	config := &cpy
 	ct := uint64(0)
+	jt := uint64(0)
 	config.Cel2Time = &ct
+	config.JovianTime = &jt
 	config.Celo = &params.CeloConfig{EIP1559BaseFeeFloor: baseFeeFloor}
 	return config
 }
@@ -37,7 +39,13 @@ var (
 	feeCurrencyIntrinsicGas = core.FeeCurrencyIntrinsicGas
 	defaultBaseFeeFloor     = 100
 	defaultChainConfig      = celoConfig(uint64(defaultBaseFeeFloor))
+	preJovianChainConfig    *params.ChainConfig
 )
+
+func init() {
+	preJovianChainConfig = celoConfig(uint64(defaultBaseFeeFloor))
+	preJovianChainConfig.JovianTime = nil
+}
 
 func pricedCip64Transaction(
 	config *params.ChainConfig,
@@ -105,23 +113,23 @@ func setupCeloPoolWithConfig(config *params.ChainConfig) (*LegacyPool, *ecdsa.Pr
 func TestBelowBaseFeeFloorValidityCheck(t *testing.T) {
 	t.Parallel()
 
-	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	pool, key := setupCeloPoolWithConfig(preJovianChainConfig)
 	defer pool.Close()
 
 	// gas-price below base-fee-floor should return early
 	// and thus raise an error in the validation
 
 	// We need to ensure that the tip cap fulfils the min tip requirement since that is checked first in ValidateTransaction.
-	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(99), big.NewInt(1), nil, key)
+	tx := pricedCip64Transaction(preJovianChainConfig, 0, 21000, big.NewInt(99), big.NewInt(1), nil, key)
 	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
 	// also test with fee currency conversion
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(198), big.NewInt(2), &feeCurrencyOne, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(198), big.NewInt(2), &feeCurrencyOne, key)
 	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(48), big.NewInt(1), &feeCurrencyTwo, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(48), big.NewInt(1), &feeCurrencyTwo, key)
 	if err, want := pool.addRemoteSync(tx), txpool.ErrGasPriceDoesNotExceedBaseFeeFloor; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
@@ -130,24 +138,24 @@ func TestBelowBaseFeeFloorValidityCheck(t *testing.T) {
 func TestAboveBaseFeeFloorValidityCheck(t *testing.T) {
 	t.Parallel()
 
-	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	pool, key := setupCeloPoolWithConfig(preJovianChainConfig)
 	defer pool.Close()
 
 	// gas-price just at base-fee-floor should be valid,
 	// this also adds the required min-tip of 1
-	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(101), big.NewInt(1), nil, key)
+	tx := pricedCip64Transaction(preJovianChainConfig, 0, 21000, big.NewInt(101), big.NewInt(1), nil, key)
 	assert.NoError(t, pool.addRemote(tx))
 	// also test with fee currency conversion, increase nonce because of previous tx was valid
-	tx = pricedCip64Transaction(defaultChainConfig, 1, 21000+feeCurrencyIntrinsicGas, big.NewInt(202), big.NewInt(2), &feeCurrencyOne, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 1, 21000+feeCurrencyIntrinsicGas, big.NewInt(202), big.NewInt(2), &feeCurrencyOne, key)
 	assert.NoError(t, pool.addRemote(tx))
-	tx = pricedCip64Transaction(defaultChainConfig, 2, 21000+feeCurrencyIntrinsicGas, big.NewInt(51), big.NewInt(1), &feeCurrencyTwo, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 2, 21000+feeCurrencyIntrinsicGas, big.NewInt(51), big.NewInt(1), &feeCurrencyTwo, key)
 	assert.NoError(t, pool.addRemote(tx))
 }
 
 func TestBelowMinTipValidityCheck(t *testing.T) {
 	t.Parallel()
 
-	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	pool, key := setupCeloPoolWithConfig(preJovianChainConfig)
 	defer pool.Close()
 
 	// the min-tip is set to 1 per default
@@ -155,11 +163,11 @@ func TestBelowMinTipValidityCheck(t *testing.T) {
 	// Gas-price just at base-fee-floor should be valid,
 	// the effective gas-price would also pass the min-tip restriction of 1.
 	// However the explicit gas-tip-cap at 0 should reject the transaction.
-	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(101), big.NewInt(0), nil, key)
+	tx := pricedCip64Transaction(preJovianChainConfig, 0, 21000, big.NewInt(101), big.NewInt(0), nil, key)
 	if err, want := pool.addRemote(tx), txpool.ErrTxGasPriceTooLow; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(202), big.NewInt(0), &feeCurrencyOne, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(202), big.NewInt(0), &feeCurrencyOne, key)
 	if err, want := pool.addRemote(tx), txpool.ErrTxGasPriceTooLow; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
@@ -168,11 +176,11 @@ func TestBelowMinTipValidityCheck(t *testing.T) {
 	// tested above.
 	// Now the effective gas-tip should still be below the min-tip, since we consume everything
 	// for the base fee floor and thus the tx should get rejected.
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(100), big.NewInt(1), nil, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000, big.NewInt(100), big.NewInt(1), nil, key)
 	if err, want := pool.addRemote(tx), txpool.ErrUnderpriced; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(200), big.NewInt(2), &feeCurrencyOne, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(200), big.NewInt(2), &feeCurrencyOne, key)
 	if err, want := pool.addRemote(tx), txpool.ErrUnderpriced; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
@@ -181,7 +189,7 @@ func TestBelowMinTipValidityCheck(t *testing.T) {
 func TestExpectMinTipRoundingFeeCurrency(t *testing.T) {
 	t.Parallel()
 
-	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	pool, key := setupCeloPoolWithConfig(preJovianChainConfig)
 	defer pool.Close()
 
 	// the min-tip is set to 1 per default
@@ -190,15 +198,35 @@ func TestExpectMinTipRoundingFeeCurrency(t *testing.T) {
 	// is 0, the transaction is still accepted.
 	// This is because at a min-tip requirement of 1, a more valuable currency than native
 	// token will get rounded down to a min-tip of 0 during conversion.
-	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(50), big.NewInt(0), &feeCurrencyTwo, key)
+	tx := pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(50), big.NewInt(0), &feeCurrencyTwo, key)
 	assert.NoError(t, pool.addRemote(tx))
 
 	// set the required min-tip to 10
 	pool.SetGasTip(big.NewInt(10))
 
 	// but as soon as we increase the min-tip, the check rejects a gas-tip-cap that is too low after conversion
-	tx = pricedCip64Transaction(defaultChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(100), big.NewInt(4), &feeCurrencyTwo, key)
+	tx = pricedCip64Transaction(preJovianChainConfig, 0, 21000+feeCurrencyIntrinsicGas, big.NewInt(100), big.NewInt(4), &feeCurrencyTwo, key)
 	if err, want := pool.addRemote(tx), txpool.ErrTxGasPriceTooLow; !errors.Is(err, want) {
 		t.Errorf("want %v have %v", want, err)
 	}
+}
+
+// Verify that transactions with gas price below the Celo base fee floor are
+// accepted when Jovian is active, because the Celo floor validation is skipped
+// in favor of OP's minBaseFee mechanism.
+func TestBaseFeeFloorNotEnforcedPostJovian(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupCeloPoolWithConfig(defaultChainConfig)
+	defer pool.Close()
+
+	// Transaction with gas price below Celo base fee floor should be ACCEPTED
+	// because Jovian is active and Celo floor validation is not enforced.
+	// The gas fee cap of 99 is below the defaultBaseFeeFloor of 100.
+	tx := pricedCip64Transaction(defaultChainConfig, 0, 21000, big.NewInt(99), big.NewInt(1), nil, key)
+	assert.NoError(t, pool.addRemote(tx))
+
+	// Also test with fee currency - gas price below converted floor should be accepted
+	tx = pricedCip64Transaction(defaultChainConfig, 1, 21000+feeCurrencyIntrinsicGas, big.NewInt(198), big.NewInt(2), &feeCurrencyOne, key)
+	assert.NoError(t, pool.addRemote(tx))
 }


### PR DESCRIPTION
We want to use Jovian's `minBaseFee` instead.
