### PR TITLE
Remove alfajores and baklava testnet code

### DIFF
--- a/.github/workflows/e2e-test-deployed-network.yaml
+++ b/.github/workflows/e2e-test-deployed-network.yaml
@@ -21,6 +21,6 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: ./.github/workflows/composite/setup
-        - name: Run e2e tests alfajores
+        - name: Run e2e tests celo-sepolia
           shell: bash
           run: NETWORK=celo-sepolia e2e_test/run_all_tests.sh

--- a/contracts/addresses/addresses.go
+++ b/contracts/addresses/addresses.go
@@ -20,18 +20,6 @@ var (
 		FeeCurrencyDirectory: common.HexToAddress("0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276"),
 	}
 
-	AlfajoresAddresses = &CeloAddresses{
-		CeloToken:            common.HexToAddress("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"),
-		FeeHandler:           common.HexToAddress("0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38"),
-		FeeCurrencyDirectory: common.HexToAddress("0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF"),
-	}
-
-	BaklavaAddresses = &CeloAddresses{
-		CeloToken:            common.HexToAddress("0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"),
-		FeeHandler:           common.HexToAddress("0xeed0A69c51079114C280f7b936C79e24bD94013e"),
-		FeeCurrencyDirectory: common.HexToAddress("0xD59E1599F45e42Eb356202B2C714D6C7b734C034"),
-	}
-
 	CeloSepoliaAddresses = &CeloAddresses{
 		CeloToken:            common.HexToAddress("0x471EcE3750Da237f93B8E339c536989b8978a438"),
 		FeeHandler:           common.HexToAddress("0xcD437749E43A154C07F3553504c68fBfD56B8778"),
@@ -47,10 +35,6 @@ func GetAddresses(chainID *big.Int) *CeloAddresses {
 		return nil
 	}
 	switch chainID.Uint64() {
-	case params.CeloAlfajoresChainID:
-		return AlfajoresAddresses
-	case params.CeloBaklavaChainID:
-		return BaklavaAddresses
 	case params.CeloSepoliaChainID:
 		return CeloSepoliaAddresses
 	case params.CeloMainnetChainID:

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -155,11 +155,6 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	forBlock := ^uint64(0)
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
-		// Alfajores requires a custom cost function see link for a detailed explanation
-		// https://github.com/celo-org/op-geth/pull/271
-		if config.IsCel2(blockTime) && !config.IsHolocene(blockTime) && config.ChainID.Uint64() == params.CeloAlfajoresChainID {
-			return func(rcd RollupCostData) (fee, gasUsed *big.Int) { return new(big.Int), new(big.Int) }
-		}
 		if !config.IsOptimismEcotone(blockTime) {
 			return newL1CostFuncBedrock(config, statedb, blockTime)
 		}

--- a/e2e_test/js-tests/viem_setup.mjs
+++ b/e2e_test/js-tests/viem_setup.mjs
@@ -7,26 +7,14 @@ import {
 	webSocket,
 	defineChain,
 } from "viem";
-import { celo, celoAlfajores, celoSepolia } from "viem/chains";
+import { celo, celoSepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 
 // Setup up chain
 const devChain = defineChain({
-	...celoAlfajores,
+	...celoSepolia,
 	id: 1337,
 	name: "local dev chain",
-	rpcUrls: {
-		default: {
-			http: [process.env.ETH_RPC_URL],
-			webSocket: [process.env.ETH_RPC_URL],
-		},
-	},
-});
-
-const celoBaklava = defineChain({
-	...celoAlfajores,
-	id: 62320,
-	name: "baklava",
 	rpcUrls: {
 		default: {
 			http: [process.env.ETH_RPC_URL],
@@ -47,10 +35,6 @@ const celoMainnet = defineChain({
 
 const chain = (() => {
 	switch (process.env.NETWORK) {
-		case 'alfajores':
-			return celoAlfajores
-		case 'baklava':
-			return celoBaklava
 		case 'celo-sepolia':
 			return celoSepolia
 		case 'mainnet':
@@ -62,8 +46,6 @@ const chain = (() => {
 
 const transportForNetwork = (() => {
 	switch (process.env.NETWORK) {
-		case 'alfajores':
-		case 'baklava':
 		case 'celo-sepolia':
 		case 'mainnet':
 			return webSocket(process.env.ETH_RPC_URL);

--- a/e2e_test/shared.sh
+++ b/e2e_test/shared.sh
@@ -18,22 +18,6 @@ mainnet)
 	export FEE_CURRENCY_DIRECTORY_ADDR=0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276
 	echo "Using mainnet network"
 	;;
-alfajores)
-	export ETH_RPC_URL=wss://alfajores-forno.celo-testnet.org/ws
-	export TOKEN_ADDR=0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9
-	export FEE_HANDLER=0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38
-	export FEE_CURRENCY=0x4822e58de6f5e485eF90df51C41CE01721331dC0
-	export FEE_CURRENCY_DIRECTORY_ADDR=0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF
-	echo "Using Alfajores network"
-	;;
-baklava)
-	export ETH_RPC_URL=wss://baklava-forno.celo-testnet.org/ws
-	export TOKEN_ADDR=0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8
-	export FEE_HANDLER=0xeed0A69c51079114C280f7b936C79e24bD94013e
-	export FEE_CURRENCY=0x62492A644A588FD904270BeD06ad52B9abfEA1aE
-	export FEE_CURRENCY_DIRECTORY_ADDR=0xD59E1599F45e42Eb356202B2C714D6C7b734C034
-	echo "Using Baklava network"
-	;;
 celo-sepolia)
 	export ETH_RPC_URL=wss://forno.celo-sepolia.celo-testnet.org/ws
 	export TOKEN_ADDR=0x471EcE3750Da237f93B8E339c536989b8978a438

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -278,17 +278,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Add Celo-specific overrides
 	// This is a temporary workaround until Celo chains are available in the superchain registry.
 	// See https://github.com/celo-org/op-geth/issues/389
-	switch networkID {
-	case params.CeloMainnetChainID:
+	if networkID == params.CeloMainnetChainID {
 		activationTime := params.CeloMainnetIsthmusTimestamp
-		overrides.OverrideOptimismHolocene = &activationTime
-		overrides.OverrideOptimismIsthmus = &activationTime
-	case params.CeloAlfajoresChainID:
-		activationTime := params.AlfajoresIsthmusTimestamp
-		overrides.OverrideOptimismHolocene = &activationTime
-		overrides.OverrideOptimismIsthmus = &activationTime
-	case params.CeloBaklavaChainID:
-		activationTime := params.BaklavaIsthmusTimestamp
 		overrides.OverrideOptimismHolocene = &activationTime
 		overrides.OverrideOptimismIsthmus = &activationTime
 	}

--- a/eth/tracers/internal/tracetest/makeTestFromRPC.js
+++ b/eth/tracers/internal/tracetest/makeTestFromRPC.js
@@ -63,7 +63,7 @@ function getChainConfig(chainId) {
 
 	// Celo-specific config
 	if (isCeloChain(chainId)) {
-		// Celo networks (Mainnet, Alfajores, Baklava, Sepolia)
+		// Celo networks (Mainnet, Sepolia)
 		return {
 			...baseConfig,
 			cel2Time: 0,

--- a/internal/ethapi/celo_api_test.go
+++ b/internal/ethapi/celo_api_test.go
@@ -387,7 +387,7 @@ func TestNewRPCTransactionDynamicFee(t *testing.T) {
 func allEnabledChainConfig() *params.ChainConfig {
 	zeroTime := uint64(0)
 	return &params.ChainConfig{
-		ChainID:             big.NewInt(params.CeloAlfajoresChainID),
+		ChainID:             big.NewInt(params.CeloMainnetChainID),
 		HomesteadBlock:      big.NewInt(0),
 		EIP150Block:         big.NewInt(0),
 		EIP155Block:         big.NewInt(0),
@@ -775,7 +775,7 @@ func Test_marshalReceipt(t *testing.T) {
 
 	t.Run("CeloDynamicFeeTxV1 receipt", func(t *testing.T) {
 		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTx{
-			ChainID:             big.NewInt(params.CeloAlfajoresChainID),
+			ChainID:             big.NewInt(params.CeloMainnetChainID),
 			Nonce:               nonce,
 			GasTipCap:           gasTipCap,
 			GasFeeCap:           gasFeeCap,
@@ -799,7 +799,7 @@ func Test_marshalReceipt(t *testing.T) {
 
 	t.Run("CeloDynamicFeeTxV2 receipt (Post Cel2)", func(t *testing.T) {
 		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTxV2{
-			ChainID:     big.NewInt(params.CeloAlfajoresChainID),
+			ChainID:     big.NewInt(params.CeloMainnetChainID),
 			Nonce:       nonce,
 			GasTipCap:   gasTipCap,
 			GasFeeCap:   gasFeeCap,
@@ -821,7 +821,7 @@ func Test_marshalReceipt(t *testing.T) {
 
 	t.Run("CeloDynamicFeeTxV2 receipt (Pre Cel2)", func(t *testing.T) {
 		tx, err := types.SignTx(types.NewTx(&types.CeloDynamicFeeTxV2{
-			ChainID:     big.NewInt(params.CeloAlfajoresChainID),
+			ChainID:     big.NewInt(params.CeloMainnetChainID),
 			Nonce:       nonce,
 			GasTipCap:   gasTipCap,
 			GasFeeCap:   gasFeeCap,

--- a/internal/ethapi/celo_block_test.go
+++ b/internal/ethapi/celo_block_test.go
@@ -156,18 +156,6 @@ func Test_retrievePreGingerbreadGasLimit(t *testing.T) {
 			expected: big.NewInt(32e6),
 		},
 		{
-			name:     "should return latest gas limit value for Celo Alfajores",
-			chainId:  params.CeloAlfajoresChainID,
-			height:   big.NewInt(11143973),
-			expected: big.NewInt(35e6),
-		},
-		{
-			name:     "should return latest gas limit value for Celo Baklava",
-			chainId:  params.CeloBaklavaChainID,
-			height:   big.NewInt(15158971),
-			expected: big.NewInt(20e6),
-		},
-		{
 			name:     "should return nil if chainId is unknown",
 			chainId:  12345,
 			height:   big.NewInt(10),

--- a/params/celo.go
+++ b/params/celo.go
@@ -3,7 +3,5 @@ package params
 const (
 	DefaultGasLimit uint64 = 20000000 // Gas limit of the blocks before BlockchainParams contract is loaded.
 
-	BaklavaIsthmusTimestamp     uint64 = 1749654000 // Wed Jun 11 2025 15:00:00 GMT+0000
-	AlfajoresIsthmusTimestamp   uint64 = 1750863600 // Wed Jun 25 2025 15:00:00 GMT+0000
 	CeloMainnetIsthmusTimestamp uint64 = 1752073200 // Wed Jul 09 2025 15:00:00 GMT+0000
 )

--- a/params/celo_config.go
+++ b/params/celo_config.go
@@ -5,10 +5,8 @@ import (
 )
 
 const (
-	CeloMainnetChainID   = 42220
-	CeloAlfajoresChainID = 44787
-	CeloBaklavaChainID   = 62320
-	CeloSepoliaChainID   = 11142220
+	CeloMainnetChainID = 42220
+	CeloSepoliaChainID = 11142220
 )
 
 // GasLimits holds the gas limit changes for a given chain
@@ -49,31 +47,8 @@ var (
 		},
 	}
 
-	alfajoresGasLimits = &GasLimits{
-		changes: []LimitChange{
-			{big.NewInt(0), 20e6},
-			{big.NewInt(912), 10e6},
-			{big.NewInt(1392355), 130e6},
-			{big.NewInt(1507905), 13e6},
-			{big.NewInt(4581182), 20e6},
-			{big.NewInt(11143973), 35e6},
-		},
-	}
-
-	baklavaGasLimits = &GasLimits{
-		changes: []LimitChange{
-			{big.NewInt(0), 20e6},
-			{big.NewInt(1230), 10e6},
-			{big.NewInt(1713181), 130e6},
-			{big.NewInt(1945003), 13e6},
-			{big.NewInt(15158971), 20e6},
-		},
-	}
-
 	PreGingerbreadNetworkGasLimits = map[uint64]*GasLimits{
-		CeloMainnetChainID:   mainnetGasLimits,
-		CeloAlfajoresChainID: alfajoresGasLimits,
-		CeloBaklavaChainID:   baklavaGasLimits,
+		CeloMainnetChainID: mainnetGasLimits,
 	}
 
 	// This config should be kept up to date with our mainnet config so that the --dev flag produces

--- a/params/celo_config_test.go
+++ b/params/celo_config_test.go
@@ -26,6 +26,4 @@ func TestGasLimits_Limit(t *testing.T) {
 	}
 
 	subTest(t, "mainnet", CeloMainnetChainID, mainnetGasLimits.changes)
-	subTest(t, "alfajores", CeloAlfajoresChainID, alfajoresGasLimits.changes)
-	subTest(t, "baklava", CeloBaklavaChainID, baklavaGasLimits.changes)
 }


### PR DESCRIPTION
These testnets have been sunset. This removes:
- Chain IDs and gas limit configurations
- Isthmus activation timestamps
- Contract addresses
- Alfajores-specific L1 cost function workaround
- E2E test network configurations
- Related test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves [#1107](https://github.com/celo-org/celo-blockchain-planning/issues/1107)