### PR TITLE
Install envsubst in the "Docker Build Push" workflow

### DIFF
--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -28,6 +28,10 @@ jobs:
           workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth/providers/github-by-repos
           service-account: op-geth-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com
           docker-gcp-registries: us-west1-docker.pkg.dev
+      - name: Install envsubst
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
       - name: Build and push container
         uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0.5
         with:


### PR DESCRIPTION
Runner base image seems to not include `gettext-base` package now. Forcing installing it in an additional step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Docker build workflow has `envsubst` available on the runner.
> 
> - Adds an `apt-get install -y gettext-base` step in `.github/workflows/docker-build-scan.yaml` before the container build
> - No changes to build logic, images, or tags; authentication and build steps remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c1ee1bd644a6993c21174f444d91f4497165f64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->