### PR TITLE
Update GitHub workflow for Docker build, using a recent reusable-workflow version

### DIFF
--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -24,7 +24,7 @@ jobs:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth/providers/github-by-repos
       service-account: op-geth-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com
       artifact-registry: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth
-      access-token-lifetime: 60m
+      access-token-lifetime: 120m
       platforms: ${{ startsWith(github.ref, 'refs/heads/celo') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       tags: ${{ github.sha }}
       context: .

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -7,38 +7,26 @@ on:
       - '!**'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-permissions:
-  contents: read
-
 jobs:
   build-scan-container-geth:
-    runs-on: ['self-hosted', 'org', 'ubuntu-22-04']
     permissions:
-      contents: read
+      contents: write
+      actions: read
+      pull-requests: write
       security-events: write
+      attestations: write
       id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login at GCP Artifact Registry
-        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0.5
-        with:
-          workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth/providers/github-by-repos
-          service-account: op-geth-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com
-          docker-gcp-registries: us-west1-docker.pkg.dev
-      - name: Install envsubst
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext-base
-      - name: Build and push container
-        uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0.5
-        with:
-          platforms: ${{ startsWith(github.ref, 'refs/heads/celo') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          registry: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth
-          tags: ${{ github.sha }}
-          context: .
-          dockerfile: Dockerfile
-          push: true
-          trivy: ${{ startsWith(github.ref, 'refs/heads/celo') }}
+    concurrency:
+      group:   ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1
+    with:
+      workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth/providers/github-by-repos
+      service-account: op-geth-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com
+      artifact-registry: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth
+      access-token-lifetime: 60m
+      platforms: ${{ startsWith(github.ref, 'refs/heads/celo') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+      tags: ${{ github.sha }}
+      context: .
+      trivy-enabled: ${{ startsWith(github.ref, 'refs/heads/celo') }}
+      timeout-minutes: 120

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -24,9 +24,9 @@ jobs:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth/providers/github-by-repos
       service-account: op-geth-dev@blockchaintestsglobaltestnet.iam.gserviceaccount.com
       artifact-registry: us-west1-docker.pkg.dev/blockchaintestsglobaltestnet/dev-images/op-geth
-      access-token-lifetime: 120m
+      access-token-lifetime: 60m
       platforms: ${{ startsWith(github.ref, 'refs/heads/celo') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       tags: ${{ github.sha }}
       context: .
-      trivy-enabled: ${{ startsWith(github.ref, 'refs/heads/celo') }}
+      trivy-enabled: false
       timeout-minutes: 120

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -32,12 +32,12 @@ jobs:
     concurrency:
       group:   ${{ github.workflow }}-${{ github.head_ref || github.ref }}
       cancel-in-progress: true
-    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.0.0-alpha
+    uses: celo-org/reusable-workflows/.github/workflows/docker-build.yaml@v3.1
     with:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-op-geth-release/providers/github-by-repos
       service-account: op-geth-release@blockchaintestsglobaltestnet.iam.gserviceaccount.com
       artifact-registry: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-geth
-      access-token-lifetime: 120m
+      access-token-lifetime: 60m
       platforms: linux/amd64,linux/arm64
       tags: ${{ needs.set-tags.outputs.tags }}
       context: .


### PR DESCRIPTION
Update GitHub workflow for Docker build, using a recent reusable-workflow version.

Replaces #457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI changes affect how Docker images are built/pushed and adjust GitHub permissions, which can impact release/build reliability and security posture if misconfigured.
> 
> **Overview**
> Switches the `docker-build-scan` workflow from inline build/push steps to the `celo-org/reusable-workflows` `docker-build.yaml@v3.1`, and adds job-level `concurrency` plus expanded permissions (notably `contents: write`, `pull-requests: write`, and `attestations: write`).
> 
> Updates the release publishing workflow to use `docker-build.yaml@v3.1` (from `v3.0.0-alpha`) and reduces `access-token-lifetime` from 120m to 60m.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdef0ed4e422d2b1c96e81776acc2d5b35458fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->