### PR TITLE
Add CeloChaosChainID

### DIFF
--- a/params/celo_config.go
+++ b/params/celo_config.go
@@ -7,6 +7,7 @@ import (
 const (
 	CeloMainnetChainID = 42220
 	CeloSepoliaChainID = 11142220
+	CeloChaosChainID   = 11162320
 )
 
 // GasLimits holds the gas limit changes for a given chain


### PR DESCRIPTION
This is not used in op-geth yet, but I would use it in op-node for the fusaka BPO schedule fix if it was available. So it makes sense to add it for that use and similar ones.