### PR TITLE
Celo rebase 16 security fixes

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -235,6 +235,12 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if len(header.Extra) > int(params.MaximumExtraDataSize) {
 		return fmt.Errorf("extra-data longer than 32 bytes (%d)", len(header.Extra))
 	}
+	// Validate Optimism extraData format
+	if chain.Config().IsOptimism() {
+		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
+			return fmt.Errorf("invalid optimism extraData: %w", err)
+		}
+	}
 	// Verify the seal parts. Ensure the nonce and uncle hash are the expected value.
 	if header.Nonce != beaconNonce {
 		return errInvalidNonce

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -124,6 +124,9 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if prv.PublicKey.Curve != pub.Curve {
 		return nil, ErrInvalidCurve
 	}
+	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, ErrInvalidPublicKey
+	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -73,6 +73,10 @@ func (bitCurve *BitCurve) Params() *elliptic.CurveParams {
 
 // IsOnCurve returns true if the given (x,y) lies on the BitCurve.
 func (bitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
+	if x.Cmp(bitCurve.P) >= 0 || y.Cmp(bitCurve.P) >= 0 {
+		return false
+	}
+
 	// y² = x³ + b
 	y2 := new(big.Int).Mul(y, y) //y²
 	y2.Mod(y2, bitCurve.P)       //y²%P

--- a/crypto/secp256k1/ext.h
+++ b/crypto/secp256k1/ext.h
@@ -109,8 +109,10 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32_limit(&feX, point);
-	secp256k1_fe_set_b32_limit(&feY, point+32);
+	if (!secp256k1_fe_set_b32_limit(&feX, point) ||
+		!secp256k1_fe_set_b32_limit(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -164,6 +164,13 @@ type btCurve struct {
 	*secp256k1.KoblitzCurve
 }
 
+func (curve btCurve) IsOnCurve(x, y *big.Int) bool {
+	if x.Cmp(secp256k1.Params().P) >= 0 || y.Cmp(secp256k1.Params().P) >= 0 {
+		return false
+	}
+	return curve.KoblitzCurve.IsOnCurve(x, y)
+}
+
 // Marshal converts a point given as (x, y) into a byte slice.
 func (curve btCurve) Marshal(x, y *big.Int) []byte {
 	byteLen := (curve.Params().BitSize + 7) / 8

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -238,7 +238,6 @@ func newTestBackend(t *testing.T, config *node.Config, enableHistoricalState boo
 func generateTestChain(genesis *core.Genesis, length int) []*types.Block {
 	generate := func(i int, g *core.BlockGen) {
 		g.OffsetTime(5)
-		g.SetExtra([]byte("test"))
 		if i == 1 {
 			// Test transactions are included in block #2.
 			if genesis.Config.Optimism != nil && genesis.Config.IsBedrock(big.NewInt(1)) {

--- a/p2p/rlpx/rlpx_oracle_poc_test.go
+++ b/p2p/rlpx/rlpx_oracle_poc_test.go
@@ -1,0 +1,57 @@
+package rlpx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+)
+
+func TestHandshakeECIESInvalidCurveOracle(t *testing.T) {
+	initKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	respKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	init := handshakeState{
+		initiator: true,
+		remote:    ecies.ImportECDSAPublic(&respKey.PublicKey),
+	}
+	authMsg, err := init.makeAuthMsg(initKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet, err := init.sealEIP8(authMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recv handshakeState
+	if _, err := recv.readMsg(new(authMsgV4), respKey, bytes.NewReader(packet)); err != nil {
+		t.Fatalf("expected valid packet to decrypt: %v", err)
+	}
+
+	tampered := append([]byte(nil), packet...)
+	if len(tampered) < 2+65 {
+		t.Fatalf("unexpected packet length %d", len(tampered))
+	}
+	tampered[2] = 0x04
+	for i := 1; i < 65; i++ {
+		tampered[2+i] = 0x00
+	}
+
+	var recv2 handshakeState
+	_, err = recv2.readMsg(new(authMsgV4), respKey, bytes.NewReader(tampered))
+	if err == nil {
+		t.Fatal("expected decryption failure for invalid curve point")
+	}
+	if !errors.Is(err, ecies.ErrInvalidPublicKey) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ import (
 const (
 	Major = 1        // Major version component of the current release
 	Minor = 16       // Minor version component of the current release
-	Patch = 5        // Patch version component of the current release
+	Patch = 9        // Patch version component of the current release
 	Meta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Cherry picked security fixes from the [v1.101609.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101609.0) op-geth release.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/1344