### PR TITLE
consensus/beacon: exempt Celo L2 migration block from extraData validation

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -244,7 +244,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 			chain.Config().BedrockBlock != nil &&
 			chain.Config().BedrockBlock.Cmp(header.Number) == 0
 		if isCeloMigrationBlock {
-			return
+			return nil
 		}
 		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
 			return fmt.Errorf("invalid optimism extraData: %w", err)

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -244,7 +244,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 			chain.Config().BedrockBlock != nil &&
 			chain.Config().BedrockBlock.Cmp(header.Number) == 0
 		if isCeloMigrationBlock {
-			return nil
+			return
 		}
 		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
 			return fmt.Errorf("invalid optimism extraData: %w", err)

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -243,10 +243,11 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		isCeloMigrationBlock := chain.Config().IsMigratedChain() &&
 			chain.Config().BedrockBlock != nil &&
 			chain.Config().BedrockBlock.Cmp(header.Number) == 0
-		if !isCeloMigrationBlock {
-			if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
-				return fmt.Errorf("invalid optimism extraData: %w", err)
-			}
+		if isCeloMigrationBlock {
+			return
+		}
+		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
+			return fmt.Errorf("invalid optimism extraData: %w", err)
 		}
 	}
 	// Verify the seal parts. Ensure the nonce and uncle hash are the expected value.

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -243,11 +243,10 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		isCeloMigrationBlock := chain.Config().IsMigratedChain() &&
 			chain.Config().BedrockBlock != nil &&
 			chain.Config().BedrockBlock.Cmp(header.Number) == 0
-		if isCeloMigrationBlock {
-			return
-		}
-		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
-			return fmt.Errorf("invalid optimism extraData: %w", err)
+		if !isCeloMigrationBlock {
+			if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
+				return fmt.Errorf("invalid optimism extraData: %w", err)
+			}
 		}
 	}
 	// Verify the seal parts. Ensure the nonce and uncle hash are the expected value.

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -237,8 +237,16 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	}
 	// Validate Optimism extraData format
 	if chain.Config().IsOptimism() {
-		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
-			return fmt.Errorf("invalid optimism extraData: %w", err)
+		// The Celo L2 migration block has non-empty extraData ("Celo L2 migration"
+		// marker), exempt it from the standard OP Stack extraData validation which
+		// requires empty extraData before Holocene.
+		isCeloMigrationBlock := chain.Config().IsMigratedChain() &&
+			chain.Config().BedrockBlock != nil &&
+			chain.Config().BedrockBlock.Cmp(header.Number) == 0
+		if !isCeloMigrationBlock {
+			if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
+				return fmt.Errorf("invalid optimism extraData: %w", err)
+			}
 		}
 	}
 	// Verify the seal parts. Ensure the nonce and uncle hash are the expected value.


### PR DESCRIPTION
## Summary

This fixes a problem witnessed in the latest mainnet snap sync test.

- Exempt the Celo bedrock transition block (31056500) from `ValidateOptimismExtraData` during beacon header verification
- This block carries `extraData = "Celo L2 migration"` (17 bytes) as a migration marker — the only post-bedrock block with non-empty extraData before Holocene
- The upstream security fix (`12b7ef807`) added validation that rejects non-empty extraData in pre-Holocene blocks, causing snap sync beacon backfill to fail at this block

## Approach

Uses `IsMigratedChain()` to identify Celo-migrated chains and checks exact equality with `BedrockBlock` to only exempt that single block. The catalyst API call site (`eth/catalyst/api_optimism.go`) is unaffected — it only validates new payloads from the consensus layer, not historical headers during backfill.

## Test plan

- [x] `go test ./consensus/beacon/... ./eth/catalyst/... ./consensus/misc/eip1559/...` — all pass
- [x] Rebuild Docker image and redeploy snap sync node to confirm backfilling passes block 31056500