### PR TITLE
Refactor Celo hardfork overrides to use nil-guarded defaults

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -339,6 +339,33 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 		}
 	}
 
+	// Celo chain defaults — sets override values for hardfork times that may be missing
+	// from the superchain registry or genesis file. Only sets overrides that haven't
+	// already been explicitly provided, so CLI flags always win. The overrides are then
+	// applied below in the normal override flow.
+	// This is a temporary measure until the superchain registry is fully up to date.
+	// See https://github.com/celo-org/celo-blockchain-planning/issues/1346
+	if cfg.IsOptimism() && cfg.ChainID != nil && cfg.ChainID.IsUint64() {
+		switch cfg.ChainID.Uint64() {
+		case params.CeloMainnetChainID:
+			if o.OverrideOptimismHolocene == nil {
+				t := params.CeloMainnetIsthmusTimestamp
+				o.OverrideOptimismHolocene = &t
+			}
+			if o.OverrideOptimismIsthmus == nil {
+				t := params.CeloMainnetIsthmusTimestamp
+				o.OverrideOptimismIsthmus = &t
+			}
+		case params.CeloSepoliaChainID:
+			// Sepolia had isthmus active from genesis but the superchain
+			// registry genesis is missing the isthmus time.
+			if o.OverrideOptimismIsthmus == nil {
+				zero := uint64(0)
+				o.OverrideOptimismIsthmus = &zero
+			}
+		}
+	}
+
 	if o.OverrideOsaka != nil {
 		cfg.OsakaTime = o.OverrideOsaka
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -339,10 +339,12 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 		}
 	}
 
-	// Celo chain defaults — sets override values for hardfork times that may be missing
-	// from the superchain registry or genesis file. Only sets overrides that haven't
-	// already been explicitly provided, so CLI flags always win. The overrides are then
-	// applied below in the normal override flow.
+	// Celo chain defaults — fills in config values that may be missing from the
+	// superchain registry or genesis file. The superchain registry does not know
+	// about Celo-specific fields (Cel2Time, GingerbreadBlock, Celo config), and
+	// when ApplySuperchainUpgrades replaces the config above, those fields are
+	// lost. This block restores them. Hardfork overrides are set on the
+	// ChainOverrides struct so they flow through the normal override logic below.
 	// This is a temporary measure until the superchain registry is fully up to date.
 	// See https://github.com/celo-org/celo-blockchain-planning/issues/1346
 	if cfg.IsOptimism() && cfg.ChainID != nil && cfg.ChainID.IsUint64() {
@@ -356,12 +358,36 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 				t := params.CeloMainnetIsthmusTimestamp
 				o.OverrideOptimismIsthmus = &t
 			}
+			if cfg.Cel2Time == nil {
+				t := params.CeloMainnetCel2Timestamp
+				cfg.Cel2Time = &t
+			}
+			if cfg.GingerbreadBlock == nil {
+				cfg.GingerbreadBlock = new(big.Int).SetUint64(params.CeloMainnetGingerbreadBlock)
+			}
+			if cfg.Celo == nil {
+				cfg.Celo = &params.CeloConfig{
+					EIP1559BaseFeeFloor: params.CeloMainnetBaseFeeFloor,
+				}
+			}
 		case params.CeloSepoliaChainID:
 			// Sepolia had isthmus active from genesis but the superchain
-			// registry genesis is missing the isthmus time.
+			// registry is missing the isthmus time and Celo-specific fields.
 			if o.OverrideOptimismIsthmus == nil {
 				zero := uint64(0)
 				o.OverrideOptimismIsthmus = &zero
+			}
+			if cfg.Cel2Time == nil {
+				t := params.CeloSepoliaCel2Timestamp
+				cfg.Cel2Time = &t
+			}
+			if cfg.GingerbreadBlock == nil {
+				cfg.GingerbreadBlock = new(big.Int).SetUint64(params.CeloSepoliaGingerbreadBlock)
+			}
+			if cfg.Celo == nil {
+				cfg.Celo = &params.CeloConfig{
+					EIP1559BaseFeeFloor: params.CeloSepoliaBaseFeeFloor,
+				}
 			}
 		}
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -278,15 +278,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
 
-	// Add Celo-specific overrides
-	// This is a temporary workaround until Celo chains are available in the superchain registry.
-	// See https://github.com/celo-org/op-geth/issues/389
-	if networkID == params.CeloMainnetChainID {
-		activationTime := params.CeloMainnetIsthmusTimestamp
-		overrides.OverrideOptimismHolocene = &activationTime
-		overrides.OverrideOptimismIsthmus = &activationTime
-	}
-
 	if config.OverrideOsaka != nil {
 		overrides.OverrideOsaka = config.OverrideOsaka
 	}

--- a/params/celo.go
+++ b/params/celo.go
@@ -4,4 +4,10 @@ const (
 	DefaultGasLimit uint64 = 20000000 // Gas limit of the blocks before BlockchainParams contract is loaded.
 
 	CeloMainnetIsthmusTimestamp uint64 = 1752073200 // Wed Jul 09 2025 15:00:00 GMT+0000
+	CeloMainnetCel2Timestamp    uint64 = 1742957258 // Wed Mar 26 2025 02:27:38 GMT+0000
+	CeloMainnetGingerbreadBlock uint64 = 21616000
+	CeloMainnetBaseFeeFloor     uint64 = 25000000000 // 25 gwei
+	CeloSepoliaCel2Timestamp    uint64 = 0
+	CeloSepoliaGingerbreadBlock uint64 = 0
+	CeloSepoliaBaseFeeFloor     uint64 = 25000000000 // 25 gwei
 )


### PR DESCRIPTION
Move Celo-specific hardfork overrides from eth/backend.go into ChainOverrides.apply() so they participate in the standard override pipeline. Use nil-guards so that superchain registry values and CLI flags always take precedence. Add Celo Sepolia isthmus override.

This approach removes our reliance on the superchain registry, since we cannot safely rely on our updates to the superchain registry being merged in a timely manner.

For this approach to work correctly we need to make similar changes in the optimism repo, see - https://github.com/celo-org/optimism/pull/423 

See https://github.com/celo-org/celo-blockchain-planning/issues/1346