### PR TITLE
Align default logs history with celo block time

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -55,7 +55,7 @@ var Defaults = Config{
 	NetworkId:            0,            // enable auto configuration of networkID == chainID
 	TxLookupLimit:        2350000 * 12, // Increase by factor 12 to adapt to Celo 1s block time
 	TransactionHistory:   2350000 * 12,
-	LogHistory:           2350000, // Increase by factor 12 to adapt to Celo 1s block time
+	LogHistory:           2350000 * 12, // Increase by factor 12 to adapt to Celo 1s block time
 	StateHistory:         params.FullImmutabilityThreshold,
 	DatabaseCache:        512,
 	TrieCleanCache:       154,


### PR DESCRIPTION
This updates the log history default to be consistent with our other history defaults multiplying by 12 because celo's block time is 1/12 of ehtereum's.

Somehow we had previously added the comment but forgotten to multiply by 12.