### PR TITLE
p2p/discover: fix shutdown deadlock from nodeFeed.Send under mutex

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -378,8 +378,12 @@ loop:
 
 		case op := <-tab.addNodeCh:
 			tab.mutex.Lock()
-			ok := tab.handleAddNode(op)
+			ok, addedNode := tab.handleAddNode(op)
 			tab.mutex.Unlock()
+			// Send notification outside of mutex to avoid deadlock.
+			if addedNode != nil {
+				tab.nodeFeed.Send(addedNode)
+			}
 			tab.addNodeHandled <- ok
 
 		case op := <-tab.trackRequestCh:
@@ -454,8 +458,13 @@ func (tab *Table) loadSeedNodes() {
 			tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", addr, "age", age)
 		}
 		tab.mutex.Lock()
-		tab.handleAddNode(addNodeOp{node: seed, isInbound: false})
+		_, addedNode := tab.handleAddNode(addNodeOp{node: seed, isInbound: false})
 		tab.mutex.Unlock()
+
+		// Send notification outside of mutex to avoid deadlock.
+		if addedNode != nil {
+			tab.nodeFeed.Send(addedNode)
+		}
 	}
 }
 
@@ -506,30 +515,34 @@ func (tab *Table) removeIP(b *bucket, ip netip.Addr) {
 
 // handleAddNode adds the node in the request to the table, if there is space.
 // The caller must hold tab.mutex.
-func (tab *Table) handleAddNode(req addNodeOp) bool {
+//
+// Returns (true, addedNode) if the node was added, (false, nil) otherwise.
+// The caller should call nodeFeed.Send(addedNode) AFTER releasing the mutex
+// to notify subscribers about the new node.
+func (tab *Table) handleAddNode(req addNodeOp) (bool, *enode.Node) {
 	if req.node.ID() == tab.self().ID() {
-		return false
+		return false, nil
 	}
 	// For nodes from inbound contact, there is an additional safety measure: if the table
 	// is still initializing the node is not added.
 	if req.isInbound && !tab.isInitDone() {
-		return false
+		return false, nil
 	}
 
 	b := tab.bucket(req.node.ID())
 	n, _ := tab.bumpInBucket(b, req.node, req.isInbound)
 	if n != nil {
 		// Already in bucket.
-		return false
+		return false, nil
 	}
 	if len(b.entries) >= bucketSize {
 		// Bucket full, maybe add as replacement.
 		tab.addReplacement(b, req.node)
-		return false
+		return false, nil
 	}
 	if !tab.addIP(b, req.node.IPAddr()) {
 		// Can't add: IP limit reached.
-		return false
+		return false, nil
 	}
 
 	// Add to bucket.
@@ -540,8 +553,8 @@ func (tab *Table) handleAddNode(req addNodeOp) bool {
 	}
 	b.entries = append(b.entries, wn)
 	b.replacements = deleteNode(b.replacements, wn.ID())
-	tab.nodeAdded(b, wn)
-	return true
+	addedNode := tab.nodeAdded(b, wn)
+	return true, addedNode
 }
 
 // addReplacement adds n to the replacement cache of bucket b.
@@ -562,20 +575,28 @@ func (tab *Table) addReplacement(b *bucket, n *enode.Node) {
 	}
 }
 
-func (tab *Table) nodeAdded(b *bucket, n *tableNode) {
+// nodeAdded is called when a node is added to a bucket.
+// It returns the added node for the caller to send a notification
+// via nodeFeed.Send() AFTER releasing the mutex.
+//
+// The caller must hold tab.mutex.
+func (tab *Table) nodeAdded(b *bucket, n *tableNode) *enode.Node {
 	if n.addedToTable.IsZero() {
 		n.addedToTable = time.Now()
 	}
 	n.addedToBucket = time.Now()
 	tab.revalidation.nodeAdded(tab, n)
 
-	tab.nodeFeed.Send(n.Node)
+	// NOTE: nodeFeed.Send() is NOT called here to avoid deadlock.
+	// The caller must send the notification after releasing the mutex.
+
 	if tab.nodeAddedHook != nil {
 		tab.nodeAddedHook(b, n)
 	}
 	if metrics.Enabled() {
 		bucketsCounter[b.index].Inc(1)
 	}
+	return n.Node
 }
 
 func (tab *Table) nodeRemoved(b *bucket, n *tableNode) {
@@ -590,11 +611,18 @@ func (tab *Table) nodeRemoved(b *bucket, n *tableNode) {
 
 // deleteInBucket removes node n from the table.
 // If there are replacement nodes in the bucket, the node is replaced.
-func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
+//
+// Returns (replacementNode, nodeToNotify) where:
+//   - replacementNode is the tableNode that replaced the deleted node (or nil)
+//   - nodeToNotify is the enode.Node that should be sent via nodeFeed.Send() AFTER
+//     releasing the mutex (or nil if no notification needed)
+//
+// The caller must hold tab.mutex.
+func (tab *Table) deleteInBucket(b *bucket, id enode.ID) (*tableNode, *enode.Node) {
 	index := slices.IndexFunc(b.entries, func(e *tableNode) bool { return e.ID() == id })
 	if index == -1 {
 		// Entry has been removed already.
-		return nil
+		return nil, nil
 	}
 
 	// Remove the node.
@@ -606,15 +634,15 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *tableNode {
 	// Add replacement.
 	if len(b.replacements) == 0 {
 		tab.log.Debug("Removed dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr())
-		return nil
+		return nil, nil
 	}
 	rindex := tab.rand.Intn(len(b.replacements))
 	rep := b.replacements[rindex]
 	b.replacements = slices.Delete(b.replacements, rindex, rindex+1)
 	b.entries = append(b.entries, rep)
-	tab.nodeAdded(b, rep)
+	nodeToNotify := tab.nodeAdded(b, rep)
 	tab.log.Debug("Replaced dead node", "b", b.index, "id", n.ID(), "ip", n.IPAddr(), "r", rep.ID(), "rip", rep.IPAddr())
-	return rep
+	return rep, nodeToNotify
 }
 
 // bumpInBucket updates a node record if it exists in the bucket.
@@ -669,8 +697,10 @@ func (tab *Table) handleTrackRequest(op trackRequestOp) {
 		tab.db.UpdateFindFails(op.node.ID(), op.node.IPAddr(), fails)
 	}
 
+	// Collect nodes to notify after releasing mutex.
+	var nodesToNotify []*enode.Node
+
 	tab.mutex.Lock()
-	defer tab.mutex.Unlock()
 
 	b := tab.bucket(op.node.ID())
 	// Remove the node from the local table if it fails to return anything useful too
@@ -678,12 +708,25 @@ func (tab *Table) handleTrackRequest(op trackRequestOp) {
 	// condition specifically exists to make bootstrapping in smaller test networks more
 	// reliable.
 	if fails >= maxFindnodeFailures && len(b.entries) >= bucketSize/4 {
-		tab.deleteInBucket(b, op.node.ID())
+		_, nodeToNotify := tab.deleteInBucket(b, op.node.ID())
+		if nodeToNotify != nil {
+			nodesToNotify = append(nodesToNotify, nodeToNotify)
+		}
 	}
 
 	// Add found nodes.
 	for _, n := range op.foundNodes {
-		tab.handleAddNode(addNodeOp{n, false, false})
+		_, addedNode := tab.handleAddNode(addNodeOp{n, false, false})
+		if addedNode != nil {
+			nodesToNotify = append(nodesToNotify, addedNode)
+		}
+	}
+
+	tab.mutex.Unlock()
+
+	// Send notifications outside of mutex to avoid deadlock.
+	for _, n := range nodesToNotify {
+		tab.nodeFeed.Send(n)
 	}
 }
 
@@ -701,9 +744,14 @@ func pushNode(list []*tableNode, n *tableNode, max int) ([]*tableNode, *tableNod
 // deleteNode removes a node from the table.
 func (tab *Table) deleteNode(n *enode.Node) {
 	tab.mutex.Lock()
-	defer tab.mutex.Unlock()
 	b := tab.bucket(n.ID())
-	tab.deleteInBucket(b, n.ID())
+	_, nodeToNotify := tab.deleteInBucket(b, n.ID())
+	tab.mutex.Unlock()
+
+	// Send notification outside of mutex to avoid deadlock.
+	if nodeToNotify != nil {
+		tab.nodeFeed.Send(nodeToNotify)
+	}
 }
 
 // waitForNodes blocks until the table contains at least n nodes.

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -699,30 +699,30 @@ func (tab *Table) handleTrackRequest(op trackRequestOp) {
 
 	// Collect nodes to notify after releasing mutex.
 	var nodesToNotify []*enode.Node
+	func() {
+		tab.mutex.Lock()
+		defer tab.mutex.Unlock()
 
-	tab.mutex.Lock()
-
-	b := tab.bucket(op.node.ID())
-	// Remove the node from the local table if it fails to return anything useful too
-	// many times, but only if there are enough other nodes in the bucket. This latter
-	// condition specifically exists to make bootstrapping in smaller test networks more
-	// reliable.
-	if fails >= maxFindnodeFailures && len(b.entries) >= bucketSize/4 {
-		_, nodeToNotify := tab.deleteInBucket(b, op.node.ID())
-		if nodeToNotify != nil {
-			nodesToNotify = append(nodesToNotify, nodeToNotify)
+		b := tab.bucket(op.node.ID())
+		// Remove the node from the local table if it fails to return anything useful too
+		// many times, but only if there are enough other nodes in the bucket. This latter
+		// condition specifically exists to make bootstrapping in smaller test networks more
+		// reliable.
+		if fails >= maxFindnodeFailures && len(b.entries) >= bucketSize/4 {
+			_, nodeToNotify := tab.deleteInBucket(b, op.node.ID())
+			if nodeToNotify != nil {
+				nodesToNotify = append(nodesToNotify, nodeToNotify)
+			}
 		}
-	}
 
-	// Add found nodes.
-	for _, n := range op.foundNodes {
-		_, addedNode := tab.handleAddNode(addNodeOp{n, false, false})
-		if addedNode != nil {
-			nodesToNotify = append(nodesToNotify, addedNode)
+		// Add found nodes.
+		for _, n := range op.foundNodes {
+			_, addedNode := tab.handleAddNode(addNodeOp{n, false, false})
+			if addedNode != nil {
+				nodesToNotify = append(nodesToNotify, addedNode)
+			}
 		}
-	}
-
-	tab.mutex.Unlock()
+	}()
 
 	// Send notifications outside of mutex to avoid deadlock.
 	for _, n := range nodesToNotify {
@@ -743,10 +743,13 @@ func pushNode(list []*tableNode, n *tableNode, max int) ([]*tableNode, *tableNod
 
 // deleteNode removes a node from the table.
 func (tab *Table) deleteNode(n *enode.Node) {
-	tab.mutex.Lock()
-	b := tab.bucket(n.ID())
-	_, nodeToNotify := tab.deleteInBucket(b, n.ID())
-	tab.mutex.Unlock()
+	var nodeToNotify *enode.Node
+	func() {
+		tab.mutex.Lock()
+		defer tab.mutex.Unlock()
+		b := tab.bucket(n.ID())
+		_, nodeToNotify = tab.deleteInBucket(b, n.ID())
+	}()
 
 	// Send notification outside of mutex to avoid deadlock.
 	if nodeToNotify != nil {

--- a/p2p/discover/table_deadlock_test.go
+++ b/p2p/discover/table_deadlock_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// TestTableMutexNotHeldDuringFeedSend is a regression test for a deadlock
+// fixed by upstream PR #33665 (https://github.com/ethereum/go-ethereum/pull/33665).
+//
+// # The bug
+//
+// nodeFeed.Send was called from nodeAdded() while tab.mutex was held. If a
+// subscriber to nodeFeed was not currently reading from its channel - e.g.,
+// because it was blocked trying to re-acquire tab.mutex (the case in
+// waitForNodes' between-iterations state) - Send would block indefinitely
+// while still holding tab.mutex.
+//
+// In production this manifested as a 24-hour silent stall in peer discovery
+// on a Celo node, which became visible only on graceful shutdown:
+// FairMix.Close -> bufferIter.Close -> "for range b.buffer" could not
+// complete because the buffer producer goroutine was permanently stuck in
+// Table.waitForNodes -> tab.mutex.Lock(), which was held by Table.doRefresh
+// -> loadSeedNodes -> handleAddNode -> nodeAdded -> nodeFeed.Send.
+//
+// # What this test verifies
+//
+// Adding a node via the public API (which routes through Table.loop's
+// addNodeCh handler and triggers nodeFeed.Send) must not hold tab.mutex
+// while Send is in progress. The test sets up a subscriber whose channel
+// is never read, so Send is guaranteed to block. It then verifies that
+// tab.mutex is acquirable by an unrelated goroutine while Send is blocked.
+func TestTableMutexNotHeldDuringFeedSend(t *testing.T) {
+	transport := newPingRecorder()
+	tab, db := newTestTable(transport, Config{})
+	defer db.Close()
+	defer tab.close()
+
+	// Subscribe to nodeFeed but never read from ch. This simulates a
+	// waitForNodes goroutine that has subscribed and is currently between
+	// iterations - i.e., its channel is not being read because it's blocked
+	// trying to re-acquire tab.mutex.
+	ch := make(chan *enode.Node) // unbuffered, like waitForNodes
+	sub := tab.nodeFeed.Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	// Trigger a node addition through the public API. This routes through
+	// Table.loop's addNodeCh handler:
+	//   - Lock(); handleAddNode(...); Unlock();
+	//   - nodeFeed.Send(addedNode)   <- with the fix, OUTSIDE the lock
+	//   - addNodeHandled <- ok
+	//
+	// With the bug, Send happens inside handleAddNode under the mutex, so
+	// the mutex is held while Send blocks.
+	//
+	// addFoundNode itself blocks waiting for addNodeHandled, so we run it
+	// in a goroutine.
+	added := make(chan bool, 1)
+	go func() {
+		added <- tab.addFoundNode(nodeAtDistance(tab.self().ID(), 250, intIP(1)), false)
+	}()
+
+	// Give the loop time to pick up the addNodeCh op and reach Send.
+	// 50ms is generous; on a healthy machine the loop reaches Send in <1ms.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify tab.mutex is acquirable by another goroutine while Send is
+	// blocked. With the fix, this succeeds because Send happens after Unlock.
+	// With the bug, this would block forever because the loop holds tab.mutex
+	// while Send is blocked waiting for our subscriber to receive.
+	mutexAcquired := make(chan struct{})
+	go func() {
+		tab.mutex.Lock()
+		tab.mutex.Unlock()
+		close(mutexAcquired)
+	}()
+
+	select {
+	case <-mutexAcquired:
+		// Good - mutex is free; the fix is working.
+	case <-time.After(3 * time.Second):
+		// Drain ch in the background so cleanup (defer tab.close()) can run,
+		// then fail with a full goroutine dump to make diagnosis easy.
+		go func() {
+			for range ch {
+			}
+		}()
+		var buf [1 << 16]byte
+		n := runtime.Stack(buf[:], true)
+		t.Fatalf("DEADLOCK: tab.mutex held while nodeFeed.Send is blocked - "+
+			"PR #33665 regression.\n--- Goroutine dump:\n%s", buf[:n])
+	}
+
+	// Drain ch so the loop's pending Send can complete and tab.close() can
+	// shut down cleanly via the deferred call.
+	go func() {
+		for range ch {
+		}
+	}()
+
+	// Wait for addFoundNode to return.
+	select {
+	case <-added:
+	case <-time.After(3 * time.Second):
+		t.Fatal("addFoundNode did not return after Send was unblocked")
+	}
+}

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -155,40 +155,40 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 
 	// Remaining logic needs access to Table internals.
 	var nodeToNotify *enode.Node
+	func() {
+		tab.mutex.Lock()
+		defer tab.mutex.Unlock()
 
-	tab.mutex.Lock()
-
-	if !resp.didRespond {
-		n.livenessChecks /= 3
-		if n.livenessChecks <= 0 {
-			_, nodeToNotify = tab.deleteInBucket(b, n.ID())
-		} else {
-			tab.log.Debug("Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
-			tr.moveToList(&tr.fast, n, now, &tab.rand)
+		if !resp.didRespond {
+			n.livenessChecks /= 3
+			if n.livenessChecks <= 0 {
+				_, nodeToNotify = tab.deleteInBucket(b, n.ID())
+			} else {
+				tab.log.Debug("Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
+				tr.moveToList(&tr.fast, n, now, &tab.rand)
+			}
+			return
 		}
-		tab.mutex.Unlock()
-		// Send notification outside of mutex to avoid deadlock.
-		if nodeToNotify != nil {
-			tab.nodeFeed.Send(nodeToNotify)
+
+		// The node responded.
+		n.livenessChecks++
+		n.isValidatedLive = true
+		tab.log.Debug("Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
+		var endpointChanged bool
+		if resp.newRecord != nil {
+			_, endpointChanged = tab.bumpInBucket(b, resp.newRecord, false)
 		}
-		return
-	}
 
-	// The node responded.
-	n.livenessChecks++
-	n.isValidatedLive = true
-	tab.log.Debug("Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
-	var endpointChanged bool
-	if resp.newRecord != nil {
-		_, endpointChanged = tab.bumpInBucket(b, resp.newRecord, false)
-	}
+		// Node moves to slow list if it passed and hasn't changed.
+		if !endpointChanged {
+			tr.moveToList(&tr.slow, n, now, &tab.rand)
+		}
+	}()
 
-	// Node moves to slow list if it passed and hasn't changed.
-	if !endpointChanged {
-		tr.moveToList(&tr.slow, n, now, &tab.rand)
+	// Send notification outside of mutex to avoid deadlock.
+	if nodeToNotify != nil {
+		tab.nodeFeed.Send(nodeToNotify)
 	}
-
-	tab.mutex.Unlock()
 }
 
 // moveToList ensures n is in the 'dest' list.


### PR DESCRIPTION
## Summary

Fixes a long-standing deadlock in the discovery `Table` that manifests as a graceful-shutdown stall on long-running op-geth nodes. The root cause is that `nodeFeed.Send` is called while holding `tab.mutex`, and the only subscriber (`Table.waitForNodes`) needs that same mutex to read the next event.

This is a cherry-pick of upstream go-ethereum [PR #33665](https://github.com/ethereum/go-ethereum/pull/33665) (still open, awaiting review for ~3 months) plus a regression test and a small panic-safety improvement.

Closes celo-org/celo-blockchain-planning#1383

## Background — what we observed

A goroutine stack dump from a sequencer that failed to shut down showed two long-standing wedges (1440 minutes ≈ 24 hours) in the discovery layer:

- `Table.doRefresh → loadSeedNodes → handleAddNode → nodeAdded → nodeFeed.Send → reflect.Select` — blocked, **holding `tab.mutex`**
- `bufferIter.Next → ... → Table.waitForNodes → tab.mutex.Lock` — blocked on the mutex held by the goroutine above

Discovery had been silently degraded for 24 h before shutdown was attempted. On `SIGINT`, the shutdown path stalls here:

```
StartNode.func1.1.gowrap1
  └── Node.Close
      └── Node.stopServices
          └── Ethereum.Stop
              └── FairMix.Close
                  └── bufferIter.Close
                      └── for range b.buffer    ← BLOCKED — producer can't exit
```

`bufferIter.Close` waits for the producer goroutine (the `bufferIter.Next` one above) to exit, but the producer is permanently stuck on the table mutex. The shutdown therefore never completes. This matches the symptom in the linked issue: shutdown frozen, op-node times out, kill -9 leaves a torn database (`missing trie node` on restart).

## What's in this PR

Three commits:

### 1. `1e2b29132 p2p/discover: fix a deadlock` (cherry-pick of upstream PR #33665)

Author preserved as `cuiweixie <cuiweixie@gmail.com>` (the original PR author). Moves every `nodeFeed.Send` call out from under `tab.mutex` by changing `handleAddNode`/`nodeAdded`/`deleteInBucket` to **return** the affected node and having callers call `Send` after `Unlock`. All six call sites (`loop` addNodeCh, `loadSeedNodes`, `handleTrackRequest`, `deleteNode`, `handleResponse`, and via `addReplacement`/`deleteInBucket`) are covered.

### 2. `7d05997bd p2p/discover: add regression test for nodeFeed.Send deadlock`

Adds `TestTableMutexNotHeldDuringFeedSend`. The test deterministically subscribes a never-drained channel to `nodeFeed`, triggers an addition via `addFoundNode`, and asserts that `tab.mutex` is acquirable by an unrelated goroutine while `Send` is blocked.

Verified to **fail in <3s on the unpatched code** with a goroutine dump that exactly matches the production stall pattern (`Table.loop → handleAddNode → FeedOf.Send` blocked, plus another goroutine in `lockSlow` on the same mutex), and pass in ~50 ms on the patched code. The upstream PR description proposed a similar test, but [it was never actually committed to the PR branch](https://github.com/ethereum/go-ethereum/pull/33665/files) — adding it here closes that gap.

### 3. `eb062d993 p2p/discover: use closure pattern to keep defer Unlock() panic-safety`

The upstream fix had to remove `defer tab.mutex.Unlock()` from three functions (`deleteNode`, `handleTrackRequest`, `handleResponse`) so that `Send` could happen after `Unlock`. This left the locked sections vulnerable to panics — code under those locks reaches `revalList.remove(n)` which has a `panic` for the \"node not found in list\" case (`table_reval.go:235`).

This commit wraps each locked section in an immediately-invoked closure with its own `defer Unlock()`:

```go
// Before:                     // After:
Lock()                          func() {
... work ...                      Lock()
Unlock()                          defer Unlock()
Send(...)                         ... work ...
                                }()
                                Send(...)
```

`handleResponse` additionally benefits by collapsing two separate `Unlock()` calls (one early-return path, one late-return path) into a single deferred one.

## Test plan

- [x] `go vet ./p2p/discover/...` — clean
- [x] `go build ./p2p/discover/...` — succeeds
- [x] `go test ./p2p/discover/ -count 1` — all pass
- [x] `go test ./p2p/discover/ -race -count 1` — all pass (~12s)
- [x] Each commit independently builds and passes the relevant test subset (verified by `git checkout <sha> -- p2p/discover/`)
- [x] New test `TestTableMutexNotHeldDuringFeedSend` was confirmed to **fail with deadlock on the un-fixed code** (verified by reverting commit 1, seeing test timeout with the production-matching goroutine dump, then restoring the fix)

## Notes for the reviewer

- The fix touches only `p2p/discover/`. There is no Celo-specific change — the bug exists in the same form on upstream go-ethereum master and was introduced by upstream commit `46e4f0b5c` (PR #32518, Aug 2025) which added `waitForNodes`.
- An *earlier* shutdown deadlock in `asyncFilterIter` was patched into Celo by upstream `f0dc47aae` (PR #32572). That fix and this one address different but adjacent bugs — both manifest at `FairMix.Close → bufferIter.Close → for range b.buffer`, but the wedged producer goroutine's deeper cause is different.
- It would be worth posting the stack dump and the regression test as a comment on upstream PR #33665 to help unblock review there.